### PR TITLE
Make sure that extended/implemented classes are initialized first

### DIFF
--- a/Library/ClassDefinition.php
+++ b/Library/ClassDefinition.php
@@ -375,22 +375,24 @@ class ClassDefinition
      * Calculate the dependency rank of the class based on its dependencies
      *
      */
-    public function calculateDependencyRank()
+    public function getDependencies()
     {
+        $dependencies = array();
         if ($this->extendsClassDefinition) {
             $classDefinition = $this->extendsClassDefinition;
             if (method_exists($classDefinition, 'increaseDependencyRank')) {
-                $classDefinition->increaseDependencyRank($this->dependencyRank * 2);
+                $dependencies[] = $classDefinition;
             }
         }
 
         if ($this->implementedInterfaceDefinitions) {
             foreach ($this->implementedInterfaceDefinitions as $interfaceDefinition) {
                 if (method_exists($interfaceDefinition, 'increaseDependencyRank')) {
-                    $interfaceDefinition->increaseDependencyRank($this->dependencyRank * 2);
+                    $dependencies[] = $interfaceDefinition;
                 }
             }
         }
+        return $dependencies;
     }
 
     /**

--- a/test/oo/extend/Exception.zep
+++ b/test/oo/extend/Exception.zep
@@ -1,0 +1,7 @@
+use \Exception as PHPException;
+
+namespace Test\Oo\Extend;
+
+class Exception extends PHPException
+{
+}

--- a/test/oo/extend/db/Exception.zep
+++ b/test/oo/extend/db/Exception.zep
@@ -1,0 +1,7 @@
+use Test\Oo\Extend\Exception as ItException;
+
+namespace Test\Oo\Extend\Db;
+
+class Exception extends ItException
+{
+}

--- a/test/oo/extend/db/query/Exception.zep
+++ b/test/oo/extend/db/query/Exception.zep
@@ -1,0 +1,7 @@
+use Test\Oo\Extend\Db\Exception as ItDbException;
+
+namespace Test\Oo\Extend\Db\Query;
+
+class Exception extends ItDbException
+{
+}

--- a/test/oo/extend/db/query/placeholder/Exception.zep
+++ b/test/oo/extend/db/query/placeholder/Exception.zep
@@ -1,0 +1,5 @@
+namespace Test\Oo\Extend\Db\Query\Placeholder;
+
+class Exception extends \Test\Oo\Extend\Db\Query\Exception
+{
+}


### PR DESCRIPTION
This should ensure that dependencies are loaded in the correct order
by recursively setting the rank accordingly

Followup of #742 addressing #702

This seems to work so far, needs some testing
