### PR TITLE
Better method cache analysis

### DIFF
--- a/Library/ClassMethod.php
+++ b/Library/ClassMethod.php
@@ -1316,6 +1316,8 @@ class ClassMethod
         $callGathererPass = null;
 
         if (is_object($this->statements)) {
+            $compilationContext->currentMethod = $this;
+
             /**
              * This pass checks for zval variables than can be potentially
              * used without allocating memory and track it

--- a/Library/Compiler.php
+++ b/Library/Compiler.php
@@ -629,7 +629,7 @@ class Compiler
                         if (!file_exists($path . '.gch')) {
                             $this->fileSystem->system('cd ext && gcc -c kernel/' . $file->getBaseName() . ' -I. ' . $phpIncludes . ' -o kernel/' . $file->getBaseName() . '.gch', 'stdout', self::VERSION . '/compile-header');
                         } else {
-                            if (filemtime($path . '.h') > filemtime($path . '.gch')) {
+                            if (filemtime($path) > filemtime($path . '.gch')) {
                                 $this->fileSystem->system('cd ext && gcc -c kernel/' . $file->getBaseName() . ' -I. ' . $phpIncludes . ' -o kernel/' . $file->getBaseName() . '.gch', 'stdout', self::VERSION . '/compile-header');
                             }
                         }

--- a/Library/Passes/CallGathererPass.php
+++ b/Library/Passes/CallGathererPass.php
@@ -81,6 +81,16 @@ class CallGathererPass
     }
 
     /**
+     * Returns all the method calls
+     *
+     * @return int
+     */
+    public function getAllMethodCalls()
+    {
+        return $this->methodCalls;
+    }
+
+    /**
      * Do the compilation pass
      *
      * @param StatementsBlock $block
@@ -205,6 +215,20 @@ class CallGathererPass
                 break;
 
             case 'mcall':
+                if (isset($expression['variable']['value'])) {
+                    if ($expression['variable']['value'] == 'this') {
+                        $methodName = $expression['name'];
+                        $className = $this->compilationContext->classDefinition->getCompleteName();
+                        if (!isset($this->methodCalls[$className][$methodName])) {
+                            $this->methodCalls[$className][$methodName] = 1;
+                        } else {
+                            $this->methodCalls[$className][$methodName]++;
+                        }
+                    }
+                }
+                $this->passCall($expression);
+                break;
+
             case 'scall':
                 $this->passCall($expression);
                 break;
@@ -378,7 +402,7 @@ class CallGathererPass
 
                 case 'mcall':
                 case 'scall':
-                    $this->passCall($statement['expr']);
+                    $this->passExpression($statement['expr']);
                     break;
 
                 case 'fcall':


### PR DESCRIPTION
- Analyses how many times a method is called in a specific scope and adds an inline cache
- Checks if the caller belongs to a class of the same extension or internal class and adds an inline cache
- Checks if the method is called within a loop without any mutation and adds an inline cache
- Checks if the method is final or private and adds an inline cache
- Checks if the class is final and adds an inline cache
