### PR TITLE
[NFR] Added prototypes disabled option

### DIFF
--- a/Library/Compiler.php
+++ b/Library/Compiler.php
@@ -768,7 +768,17 @@ class Compiler
                 }
             }
 
-            if (is_dir(ZEPHIRPATH . 'prototypes') && is_readable(ZEPHIRPATH . 'prototypes')) {
+            $prototypes = $this->config->get('prototypes', 'extra');
+            if ($prototypes !== null
+                && (empty($prototypes)
+                    || strcasecmp($prototypes, 'no') == 0
+                    || strncasecmp($prototypes, 'disable', 7) == 0)) {
+                $prototypes = false;
+            } else {
+                $prototypes = true;
+            }
+
+            if ($prototypes == true && is_dir(ZEPHIRPATH . 'prototypes') && is_readable(ZEPHIRPATH . 'prototypes')) {
                 /**
                  * Load additional extension prototypes
                  * @var $file \DirectoryIterator


### PR DESCRIPTION
Because there could be an unexpected error such as #900,
'prototypes' or not be better there was an option to disable.

```
zephir generate --prototypes=disabled  # prototypes unloaded
```
