### PR TITLE
Global static cache

### DIFF
--- a/Library/Cache/MethodCache.php
+++ b/Library/Cache/MethodCache.php
@@ -119,7 +119,6 @@ class MethodCache
         }
 
         if (!($method instanceof \ReflectionMethod)) {
-
             /**
              * Avoid generate caches for external classes
              */
@@ -174,7 +173,7 @@ class MethodCache
         if (!($method instanceof \ReflectionMethod) && $staticCacheable) {
             $cacheSlot = SlotsCache::getMethodSlot($method);
         } else {
-            $cacheSlot = 0;
+            $cacheSlot = '0';
         }
 
         $functionCache->setMustInitNull(true);

--- a/Library/Cache/MethodCache.php
+++ b/Library/Cache/MethodCache.php
@@ -50,11 +50,7 @@ class MethodCache
 {
     protected $cache = array();
 
-    protected $cacheSlots = array();
-
     protected $gatherer;
-
-    private static $slot = 0;
 
     /**
      * MethodCache
@@ -133,7 +129,7 @@ class MethodCache
 
             $completeName = $method->getClassDefinition()->getCompleteName();
             if (isset($this->cache[$completeName][$method->getName()])) {
-                return '&' . $this->cache[$completeName][$method->getName()]->getName() . ', ' . $this->cacheSlots[$completeName][$method->getName()];
+                return '&' . $this->cache[$completeName][$method->getName()]->getName() . ', ' . SlotsCache::getExistingMethodSlot($method);
             }
 
             $gatherer = $this->gatherer;
@@ -186,7 +182,6 @@ class MethodCache
 
         if (!($method instanceof \ReflectionMethod)) {
             $this->cache[$completeName][$method->getName()] = $functionCache;
-            $this->cacheSlots[$completeName][$method->getName()] = $cacheSlot;
         }
 
         return '&' . $functionCache->getName() . ', ' . $cacheSlot;

--- a/Library/Cache/MethodCache.php
+++ b/Library/Cache/MethodCache.php
@@ -173,11 +173,11 @@ class MethodCache
             return 'NULL, 0';
         }
 
+        $functionCache = $compilationContext->symbolTable->getTempVariableForWrite('zephir_fcall_cache_entry', $compilationContext);
+
         if (!($method instanceof \ReflectionMethod) && $staticCacheable) {
-            $functionCache = $compilationContext->symbolTable->getTempVariableForWrite('zephir_fcall_cache_entry', $compilationContext);
-            $cacheSlot = self::$slot++;
+            $cacheSlot = SlotsCache::getMethodSlot($method);
         } else {
-            $functionCache = $compilationContext->symbolTable->getTempVariableForWrite('zephir_fcall_cache_entry', $compilationContext);
             $cacheSlot = 0;
         }
 

--- a/Library/Cache/SlotsCache.php
+++ b/Library/Cache/SlotsCache.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------------+
+ | Zephir Language                                                          |
+ +--------------------------------------------------------------------------+
+ | Copyright (c) 2013-2015 Zephir Team and contributors                     |
+ +--------------------------------------------------------------------------+
+ | This source file is subject the MIT license, that is bundled with        |
+ | this package in the file LICENSE, and is available through the           |
+ | world-wide-web at the following url:                                     |
+ | http://zephir-lang.com/license.html                                      |
+ |                                                                          |
+ | If you did not receive a copy of the MIT license and are unable          |
+ | to obtain it through the world-wide-web, please send a note to           |
+ | license@zephir-lang.com so we can mail you a copy immediately.           |
+ +--------------------------------------------------------------------------+
+*/
+
+namespace Zephir\Cache;
+
+use Zephir\Call;
+use Zephir\CompilationContext;
+use Zephir\Passes\CallGathererPass;
+
+/**
+ * SlotsCache
+ *
+ * In order to reduce memory allocation when calling functions and method_exists
+ * Zephir provides a global cache that store pointers to resolved functions
+ * that aren't dynamical reducing the time to lookup functions and methods
+ */
+class SlotsCache
+{
+    private static $slot = 1;
+
+    private static $cacheSlots = array();
+
+    public static function getMethodSlot($method)
+    {
+        $className = $method->getClassDefinition()->getCompleteName();
+        $methodName = $method->getName();
+
+        if (isset(self::$cacheSlots[$className][$methodName])) {
+            return self::$cacheSlots[$className][$methodName];
+        }
+
+        $slot = self::$slot++;
+        self::$cacheSlots[$className][$methodName] = $slot;        
+        return $slot;
+    }
+}

--- a/Library/Cache/SlotsCache.php
+++ b/Library/Cache/SlotsCache.php
@@ -34,30 +34,85 @@ class SlotsCache
 {
     private static $slot = 1;
 
-    private static $cacheSlots = array();
+    private static $cacheMethodSlots = array();
 
+    private static $cacheFunctionSlots = array();
+
+    const MAX_SLOTS_NUMBER = 512;
+
+    /**
+     * Returns or creates a cache slot for a function
+     *
+     * @param string $functionName
+     * @return int
+     */
+    public static function getFunctionSlot($functionName)
+    {
+        if (isset(self::$cacheFunctionSlots[$functionName])) {
+            return self::$cacheFunctionSlots[$functionName];
+        }
+
+        $slot = self::$slot++;
+        if ($slot >= self::MAX_SLOTS_NUMBER) {
+            return 0;
+        }
+
+        self::$cacheFunctionSlots[$functionName] = $slot;
+        return $slot;
+    }
+
+    /**
+     * Returns or creates a cache slot for a function
+     *
+     * @param string $functionName
+     * @return int
+     */
+    public static function getExistingFunctionSlot($functionName)
+    {
+        if (isset(self::$cacheFunctionSlots[$functionName])) {
+            return self::$cacheFunctionSlots[$functionName];
+        }
+
+        return 0;
+    }
+
+    /**
+     * Returns or creates a cache slot for a method
+     *
+     * @param string $functionName
+     * @return int
+     */
     public static function getMethodSlot($method)
     {
         $className = $method->getClassDefinition()->getCompleteName();
         $methodName = $method->getName();
 
-        if (isset(self::$cacheSlots[$className][$methodName])) {
-            return self::$cacheSlots[$className][$methodName];
+        if (isset(self::$cacheMethodSlots[$className][$methodName])) {
+            return self::$cacheMethodSlots[$className][$methodName];
         }
 
         $slot = self::$slot++;
-        self::$cacheSlots[$className][$methodName] = $slot;
-        echo $slot, PHP_EOL;
+        if ($slot >= self::MAX_SLOTS_NUMBER) {
+            return 0;
+        }
+
+        self::$cacheMethodSlots[$className][$methodName] = $slot;
         return $slot;
     }
 
+    /**
+     * Returns a cache slot for a method
+     *
+     * @param string $functionName
+     * @return int
+     */
     public static function getExistingMethodSlot($method)
     {
         $className = $method->getClassDefinition()->getCompleteName();
         $methodName = $method->getName();
 
-        if (isset(self::$cacheSlots[$className][$methodName])) {
-            return self::$cacheSlots[$className][$methodName];
+        if (isset(self::$cacheMethodSlots[$className][$methodName])) {
+            return self::$cacheMethodSlots[$className][$methodName];
         }
 
         return 0;

--- a/Library/Cache/SlotsCache.php
+++ b/Library/Cache/SlotsCache.php
@@ -46,7 +46,20 @@ class SlotsCache
         }
 
         $slot = self::$slot++;
-        self::$cacheSlots[$className][$methodName] = $slot;        
+        self::$cacheSlots[$className][$methodName] = $slot;
+        echo $slot, PHP_EOL;
         return $slot;
+    }
+
+    public static function getExistingMethodSlot($method)
+    {
+        $className = $method->getClassDefinition()->getCompleteName();
+        $methodName = $method->getName();
+
+        if (isset(self::$cacheSlots[$className][$methodName])) {
+            return self::$cacheSlots[$className][$methodName];
+        }
+
+        return 0;
     }
 }

--- a/Library/Cache/StaticMethodCache.php
+++ b/Library/Cache/StaticMethodCache.php
@@ -56,7 +56,7 @@ class StaticMethodCache
     public function get(CompilationContext $compilationContext, $method, $allowNtsCache = true)
     {
         if (!is_object($method)) {
-            return 'NULL';
+            return 'NULL, 0';
         }
 
         if (!($method instanceof \ReflectionMethod)) {
@@ -66,15 +66,15 @@ class StaticMethodCache
              * Avoid generate caches for external classes
              */
             if ($method->getClassDefinition()->isExternal()) {
-                return 'NULL';
+                return 'NULL, 0';
             }
 
             if (isset($this->cache[$completeName][$method->getName()])) {
-                return '&' . $this->cache[$completeName][$method->getName()]->getName();
+                return '&' . $this->cache[$completeName][$method->getName()]->getName() . ', 0';
             }
 
             if ($method->getClassDefinition()->isInterface()) {
-                return 'NULL';
+                return 'NULL, 0';
             }
         }
 
@@ -86,12 +86,12 @@ class StaticMethodCache
                     $mustBeCached = true;
                 } else {
                     if (!$method->isPrivate() && !$method->isFinal()) {
-                        return 'NULL';
+                        return 'NULL, 0';
                     }
                 }
             } else {
                 if (!$method->isPrivate() && !$method->isFinal()) {
-                    return 'NULL';
+                    return 'NULL, 0';
                 }
             }
         }
@@ -109,6 +109,6 @@ class StaticMethodCache
             $this->cache[$completeName][$method->getName()] = $functionCache;
         }
 
-        return '&' . $functionCache->getName();
+        return '&' . $functionCache->getName() . ', 0';
     }
 }

--- a/Library/Cache/StaticMethodCache.php
+++ b/Library/Cache/StaticMethodCache.php
@@ -70,7 +70,7 @@ class StaticMethodCache
             }
 
             if (isset($this->cache[$completeName][$method->getName()])) {
-                return '&' . $this->cache[$completeName][$method->getName()]->getName() . ', 0';
+                return '&' . $this->cache[$completeName][$method->getName()]->getName() . ', ' . SlotsCache::getExistingMethodSlot($method);
             }
 
             if ($method->getClassDefinition()->isInterface()) {
@@ -96,10 +96,12 @@ class StaticMethodCache
             }
         }
 
+        $functionCache = $compilationContext->symbolTable->getTempVariableForWrite('zephir_fcall_cache_entry', $compilationContext);
+
         if ($method->isPrivate() || $method->isFinal() || $mustBeCached) {
-            $functionCache = $compilationContext->symbolTable->getTempVariableForWrite('static_zephir_fcall_cache_entry', $compilationContext);
+            $cacheSlot = SlotsCache::getMethodSlot($method);
         } else {
-            $functionCache = $compilationContext->symbolTable->getTempVariableForWrite('zephir_fcall_cache_entry', $compilationContext);
+            $cacheSlot = 0;
         }
 
         $functionCache->setMustInitNull(true);
@@ -109,6 +111,6 @@ class StaticMethodCache
             $this->cache[$completeName][$method->getName()] = $functionCache;
         }
 
-        return '&' . $functionCache->getName() . ', 0';
+        return '&' . $functionCache->getName() . ', ' . $cacheSlot;
     }
 }

--- a/Library/Cache/StaticMethodCache.php
+++ b/Library/Cache/StaticMethodCache.php
@@ -101,7 +101,7 @@ class StaticMethodCache
         if ($method->isPrivate() || $method->isFinal() || $mustBeCached) {
             $cacheSlot = SlotsCache::getMethodSlot($method);
         } else {
-            $cacheSlot = 0;
+            $cacheSlot = '0';
         }
 
         $functionCache->setMustInitNull(true);

--- a/Library/Compiler.php
+++ b/Library/Compiler.php
@@ -30,7 +30,7 @@ use Zephir\FileSystem\HardDisk as FileSystem;
  */
 class Compiler
 {
-    const VERSION = '0.6.2a';
+    const VERSION = '0.6.3a';
 
     /**
      * @var CompilerFile[]

--- a/Library/FunctionCall.php
+++ b/Library/FunctionCall.php
@@ -505,45 +505,45 @@ class FunctionCall extends Call
         if (!isset($expression['parameters'])) {
             if ($this->isExpectingReturn()) {
                 if ($symbolVariable->getName() == 'return_value') {
-                    $codePrinter->output('ZEPHIR_RETURN_CALL_ZVAL_FUNCTION(' . $variable->getName() . ', NULL);');
+                    $codePrinter->output('ZEPHIR_RETURN_CALL_ZVAL_FUNCTION(' . $variable->getName() . ', NULL, 0);');
                 } else {
                     if ($this->mustInitSymbolVariable()) {
                         $symbolVariable->setMustInitNull(true);
                         $symbolVariable->trackVariant($compilationContext);
                     }
-                    $codePrinter->output('ZEPHIR_CALL_ZVAL_FUNCTION(&' . $symbolVariable->getName() . ', ' . $variable->getName() . ', NULL);');
+                    $codePrinter->output('ZEPHIR_CALL_ZVAL_FUNCTION(&' . $symbolVariable->getName() . ', ' . $variable->getName() . ', NULL, 0);');
                 }
             } else {
-                $codePrinter->output('ZEPHIR_CALL_ZVAL_FUNCTION(NULL, ' . $variable->getName() . ', NULL);');
+                $codePrinter->output('ZEPHIR_CALL_ZVAL_FUNCTION(NULL, ' . $variable->getName() . ', NULL, 0);');
             }
         } else {
             if (count($params)) {
                 if ($this->isExpectingReturn()) {
                     if ($symbolVariable->getName() == 'return_value') {
-                        $codePrinter->output('ZEPHIR_RETURN_CALL_ZVAL_FUNCTION(' . $variable->getName() . ', NULL, ' . join(', ', $params) . ');');
+                        $codePrinter->output('ZEPHIR_RETURN_CALL_ZVAL_FUNCTION(' . $variable->getName() . ', NULL, 0, ' . join(', ', $params) . ');');
                     } else {
                         if ($this->mustInitSymbolVariable()) {
                             $symbolVariable->setMustInitNull(true);
                             $symbolVariable->trackVariant($compilationContext);
                         }
-                        $codePrinter->output('ZEPHIR_CALL_ZVAL_FUNCTION(&' . $symbolVariable->getName() . ', ' . $variable->getName() . ', NULL, ' . join(', ', $params) . ');');
+                        $codePrinter->output('ZEPHIR_CALL_ZVAL_FUNCTION(&' . $symbolVariable->getName() . ', ' . $variable->getName() . ', NULL, 0, ' . join(', ', $params) . ');');
                     }
                 } else {
-                    $codePrinter->output('ZEPHIR_CALL_ZVAL_FUNCTION(NULL, ' . $variable->getName() . ', NULL, ' . join(', ', $params) . ');');
+                    $codePrinter->output('ZEPHIR_CALL_ZVAL_FUNCTION(NULL, ' . $variable->getName() . ', NULL, 0, ' . join(', ', $params) . ');');
                 }
             } else {
                 if ($this->isExpectingReturn()) {
                     if ($symbolVariable->getName() == 'return_value') {
-                        $codePrinter->output('ZEPHIR_RETURN_CALL_ZVAL_FUNCTION(' . $variable->getName() . ', NULL);');
+                        $codePrinter->output('ZEPHIR_RETURN_CALL_ZVAL_FUNCTION(' . $variable->getName() . ', NULL, 0);');
                     } else {
                         if ($this->mustInitSymbolVariable()) {
                             $symbolVariable->setMustInitNull(true);
                             $symbolVariable->trackVariant($compilationContext);
                         }
-                        $codePrinter->output('ZEPHIR_CALL_ZVAL_FUNCTION(&' . $symbolVariable->getName() . ', ' . $variable->getName() . ', NULL);');
+                        $codePrinter->output('ZEPHIR_CALL_ZVAL_FUNCTION(&' . $symbolVariable->getName() . ', ' . $variable->getName() . ', NULL, 0);');
                     }
                 } else {
-                    $codePrinter->output('ZEPHIR_CALL_ZVAL_FUNCTION(NULL, ' . $variable->getName() . ', NULL);');
+                    $codePrinter->output('ZEPHIR_CALL_ZVAL_FUNCTION(NULL, ' . $variable->getName() . ', NULL, 0);');
                 }
             }
         }

--- a/Library/MethodCall.php
+++ b/Library/MethodCall.php
@@ -586,7 +586,7 @@ class MethodCall extends Call
                 if ($variableMethod->getType() == 'variable') {
                 }
 
-                $cachePointer = 'NULL';
+                $cachePointer = 'NULL, 0';
 
                 if (!count($params)) {
                     if ($isExpecting) {

--- a/Library/StaticCall.php
+++ b/Library/StaticCall.php
@@ -281,7 +281,7 @@ class StaticCall extends Call
             $symbolVariable->trackVariant($compilationContext);
         }
 
-        $cachePointer = 'NULL';
+        $cachePointer = 'NULL, 0';
 
         if (isset($expression['parameters']) && count($expression['parameters'])) {
             $params = $this->getResolvedParams($expression['parameters'], $compilationContext, $expression);
@@ -358,7 +358,7 @@ class StaticCall extends Call
             $symbolVariable->trackVariant($compilationContext);
         }
 
-        $cachePointer = 'NULL';
+        $cachePointer = 'NULL, 0';
 
         if (isset($expression['parameters']) && count($expression['parameters'])) {
             $params = $this->getResolvedParams($expression['parameters'], $compilationContext, $expression);

--- a/ext/kernel/exception.c
+++ b/ext/kernel/exception.c
@@ -57,14 +57,14 @@ void zephir_throw_exception_debug(zval *object, const char *file, zend_uint line
 		object_copy = object;
 		ALLOC_INIT_ZVAL(object);
 		object_init_ex(object, zend_exception_get_default(TSRMLS_C));
-		ZEPHIR_CALL_METHOD(NULL, object, "__construct", NULL, object_copy);
+		ZEPHIR_CALL_METHOD(NULL, object, "__construct", NULL, 0, object_copy);
 	}
 
 	Z_ADDREF_P(object);
 
 	if (line > 0) {
 		curline = 0;
-		ZEPHIR_CALL_METHOD(&curline, object, "getline", NULL);
+		ZEPHIR_CALL_METHOD(&curline, object, "getline", NULL, 0);
 		zephir_check_call_status();
 		if (ZEPHIR_IS_LONG(curline, 0)) {
 			default_exception_ce = zend_exception_get_default(TSRMLS_C);
@@ -92,7 +92,7 @@ void zephir_throw_exception_string_debug(zend_class_entry *ce, const char *messa
 	ALLOC_INIT_ZVAL(msg);
 	ZVAL_STRINGL(msg, message, message_len, 1);
 
-	ZEPHIR_CALL_METHOD(NULL, object, "__construct", NULL, msg);
+	ZEPHIR_CALL_METHOD(NULL, object, "__construct", NULL, 0, msg);
 	zephir_check_call_status();
 
 	if (line > 0) {
@@ -120,7 +120,7 @@ void zephir_throw_exception_string(zend_class_entry *ce, const char *message, ze
 	ALLOC_INIT_ZVAL(msg);
 	ZVAL_STRINGL(msg, message, message_len, 1);
 
-	ZEPHIR_CALL_METHOD(NULL, object, "__construct", NULL, msg);
+	ZEPHIR_CALL_METHOD(NULL, object, "__construct", NULL, 0, msg);
 	zephir_check_call_status();
 
 	zend_throw_exception_object(object TSRMLS_CC);
@@ -148,7 +148,7 @@ void zephir_throw_exception_format(zend_class_entry *ce TSRMLS_DC, const char *f
 	ALLOC_INIT_ZVAL(msg);
 	ZVAL_STRINGL(msg, buffer, len, 0);
 
-	ZEPHIR_CALL_METHOD(NULL, object, "__construct", NULL, msg);
+	ZEPHIR_CALL_METHOD(NULL, object, "__construct", NULL, 0, msg);
 	zephir_check_call_status();
 
 	zend_throw_exception_object(object TSRMLS_CC);
@@ -168,7 +168,7 @@ void zephir_throw_exception_zval_debug(zend_class_entry *ce, zval *message, cons
 	ALLOC_INIT_ZVAL(object);
 	object_init_ex(object, ce);
 
-	ZEPHIR_CALL_METHOD(NULL, object, "__construct", NULL, message);
+	ZEPHIR_CALL_METHOD(NULL, object, "__construct", NULL, 0, message);
 	zephir_check_call_status();
 
 	if (line > 0) {
@@ -191,7 +191,7 @@ void zephir_throw_exception_zval(zend_class_entry *ce, zval *message TSRMLS_DC){
 	ALLOC_INIT_ZVAL(object);
 	object_init_ex(object, ce);
 
-	ZEPHIR_CALL_METHOD(NULL, object, "__construct", NULL, message);
+	ZEPHIR_CALL_METHOD(NULL, object, "__construct", NULL, 0, message);
 	zephir_check_call_status();
 
 	zend_throw_exception_object(object TSRMLS_CC);

--- a/ext/kernel/fcall.c
+++ b/ext/kernel/fcall.c
@@ -514,7 +514,7 @@ int zephir_call_user_function(zval **object_pp, zend_class_entry *obj_ce, zephir
 				if (!zephir_globals_ptr->scache[cache_slot]) {
 					reload_cache = 1;
 				} else {
-					*temp_cache_entry = zephir_globals_ptr->scache[cache_slot];
+					temp_cache_entry = &zephir_globals_ptr->scache[cache_slot];
 				}
 			}
 

--- a/ext/kernel/fcall.c
+++ b/ext/kernel/fcall.c
@@ -119,7 +119,7 @@ static char *zephir_fcall_possible_method(zend_class_entry *ce, const char *wron
 		ZVAL_STRING(&method_name, wrong_name, 0);
 
 		params[0] = &method_name;
-		zephir_call_func_aparams(&right, SL("metaphone"), NULL, 1, params TSRMLS_CC);
+		zephir_call_func_aparams(&right, SL("metaphone"), NULL, 0, 1, params TSRMLS_CC);
 
 		methods = &ce->function_table;
 		zend_hash_internal_pointer_reset_ex(methods, &pos);
@@ -135,7 +135,7 @@ static char *zephir_fcall_possible_method(zend_class_entry *ce, const char *wron
 			left = NULL;
 
 			params[0] = &method_name;
-			zephir_call_func_aparams(&left, SL("metaphone"), NULL, 1, params TSRMLS_CC);
+			zephir_call_func_aparams(&left, SL("metaphone"), NULL, 0, 1, params TSRMLS_CC);
 
 			if (zephir_is_equal(left, right TSRMLS_CC)) {
 				possible_method = (char *) method->common.function_name;
@@ -650,7 +650,7 @@ int zephir_call_user_function(zval **object_pp, zend_class_entry *obj_ce, zephir
 }
 
 int zephir_call_func_aparams(zval **return_value_ptr, const char *func_name, uint func_length,
-	zephir_fcall_cache_entry **cache_entry,
+	zephir_fcall_cache_entry **cache_entry, int cache_slot,
 	uint param_count, zval **params TSRMLS_DC)
 {
 	int status;
@@ -675,7 +675,7 @@ int zephir_call_func_aparams(zval **return_value_ptr, const char *func_name, uin
 	info.func_name = func_name;
 	info.func_length = func_length;
 
-	status = zephir_call_user_function(NULL, NULL, zephir_fcall_function, func, rvp, cache_entry, 0, param_count, params, &info TSRMLS_CC);
+	status = zephir_call_user_function(NULL, NULL, zephir_fcall_function, func, rvp, cache_entry, cache_slot, param_count, params, &info TSRMLS_CC);
 
 #else
 
@@ -717,7 +717,7 @@ int zephir_call_func_aparams(zval **return_value_ptr, const char *func_name, uin
 }
 
 int zephir_call_zval_func_aparams(zval **return_value_ptr, zval *func_name,
-	zephir_fcall_cache_entry **cache_entry,
+	zephir_fcall_cache_entry **cache_entry, int cache_slot,
 	uint param_count, zval **params TSRMLS_DC)
 {
 	int status;
@@ -731,7 +731,7 @@ int zephir_call_zval_func_aparams(zval **return_value_ptr, zval *func_name,
 	}
 #endif
 
-	status = zephir_call_user_function(NULL, NULL, zephir_fcall_function, func_name, rvp, cache_entry, 0, param_count, params, NULL TSRMLS_CC);
+	status = zephir_call_user_function(NULL, NULL, zephir_fcall_function, func_name, rvp, cache_entry, cache_slot, param_count, params, NULL TSRMLS_CC);
 
 	if (status == FAILURE && !EG(exception)) {
 		zephir_throw_exception_format(spl_ce_RuntimeException TSRMLS_CC, "Call to undefined function %s()", Z_TYPE_P(func_name) ? Z_STRVAL_P(func_name) : "undefined");

--- a/ext/kernel/fcall.c
+++ b/ext/kernel/fcall.c
@@ -444,8 +444,8 @@ ZEPHIR_ATTR_NONNULL static void zephir_fcall_populate_fci_cache(zend_fcall_info_
 /**
  * Calls a function/method in the PHP userland
  */
-int ZEPHIR_NO_OPT zephir_call_user_function(zval **object_pp, zend_class_entry *obj_ce, zephir_call_type type,
-	zval *function_name, zval **retval_ptr_ptr, zephir_fcall_cache_entry **cache_entry, zend_uint param_count,
+int zephir_call_user_function(zval **object_pp, zend_class_entry *obj_ce, zephir_call_type type,
+	zval *function_name, zval **retval_ptr_ptr, zephir_fcall_cache_entry **cache_entry, int cache_slot, zend_uint param_count,
 	zval *params[], zephir_fcall_info *info TSRMLS_DC)
 {
 	zval ***params_ptr, ***params_array = NULL;
@@ -460,6 +460,7 @@ int ZEPHIR_NO_OPT zephir_call_user_function(zval **object_pp, zend_class_entry *
 	ulong fcall_key_hash;
 	zephir_fcall_cache_entry **temp_cache_entry = NULL;
 	zend_class_entry *old_scope = EG(scope);
+	int reload_cache = 1;
 
 	assert(obj_ce || !object_pp);
 
@@ -508,10 +509,21 @@ int ZEPHIR_NO_OPT zephir_call_user_function(zval **object_pp, zend_class_entry *
 
 	if (!cache_entry || !*cache_entry) {
 		if (zephir_globals_ptr->cache_enabled) {
-			if (info) {
-				fcall_key_hash = zephir_make_fcall_info_key(&fcall_key, &fcall_key_len, (object_pp && type != zephir_fcall_ce ? Z_OBJCE_PP(object_pp) : obj_ce), type, info TSRMLS_CC);
-			} else {
-				fcall_key_hash = zephir_make_fcall_key(&fcall_key, &fcall_key_len, (object_pp && type != zephir_fcall_ce ? Z_OBJCE_PP(object_pp) : obj_ce), type, function_name TSRMLS_CC);
+
+			if (cache_slot > 0) {
+				if (!zephir_globals_ptr->scache[cache_slot]) {
+					reload_cache = 1;
+				} else {
+					*temp_cache_entry = zephir_globals_ptr->scache[cache_slot];
+				}
+			}
+
+			if (reload_cache) {
+				if (info) {
+					fcall_key_hash = zephir_make_fcall_info_key(&fcall_key, &fcall_key_len, (object_pp && type != zephir_fcall_ce ? Z_OBJCE_PP(object_pp) : obj_ce), type, info TSRMLS_CC);
+				} else {
+					fcall_key_hash = zephir_make_fcall_key(&fcall_key, &fcall_key_len, (object_pp && type != zephir_fcall_ce ? Z_OBJCE_PP(object_pp) : obj_ce), type, function_name TSRMLS_CC);
+				}
 			}
 		}
 	}
@@ -610,9 +622,10 @@ int ZEPHIR_NO_OPT zephir_call_user_function(zval **object_pp, zend_class_entry *
 #endif
 			} else {
 				if (cache_entry) {
-					//if (fcic.function_handler->type == ZEND_INTERNAL_FUNCTION) {
-						*cache_entry = temp_cache_entry;
-					//}
+					*cache_entry = temp_cache_entry;
+					if (cache_slot > 0) {
+						zephir_globals_ptr->scache[cache_slot] = *cache_entry;
+					}
 				}
 			}
 		}
@@ -662,14 +675,14 @@ int zephir_call_func_aparams(zval **return_value_ptr, const char *func_name, uin
 	info.func_name = func_name;
 	info.func_length = func_length;
 
-	status = zephir_call_user_function(NULL, NULL, zephir_fcall_function, func, rvp, cache_entry, param_count, params, &info TSRMLS_CC);
+	status = zephir_call_user_function(NULL, NULL, zephir_fcall_function, func, rvp, cache_entry, 0, param_count, params, &info TSRMLS_CC);
 
 #else
 
 	ALLOC_INIT_ZVAL(func);
 	ZVAL_STRINGL(func, func_name, func_length, 0);
 
-	status = zephir_call_user_function(NULL, NULL, zephir_fcall_function, func, rvp, cache_entry, param_count, params, NULL TSRMLS_CC);
+	status = zephir_call_user_function(NULL, NULL, zephir_fcall_function, func, rvp, cache_entry, 0, param_count, params, NULL TSRMLS_CC);
 
 #endif
 
@@ -718,7 +731,7 @@ int zephir_call_zval_func_aparams(zval **return_value_ptr, zval *func_name,
 	}
 #endif
 
-	status = zephir_call_user_function(NULL, NULL, zephir_fcall_function, func_name, rvp, cache_entry, param_count, params, NULL TSRMLS_CC);
+	status = zephir_call_user_function(NULL, NULL, zephir_fcall_function, func_name, rvp, cache_entry, 0, param_count, params, NULL TSRMLS_CC);
 
 	if (status == FAILURE && !EG(exception)) {
 		zephir_throw_exception_format(spl_ce_RuntimeException TSRMLS_CC, "Call to undefined function %s()", Z_TYPE_P(func_name) ? Z_STRVAL_P(func_name) : "undefined");
@@ -743,7 +756,7 @@ int zephir_call_zval_func_aparams(zval **return_value_ptr, zval *func_name,
 
 int zephir_call_class_method_aparams(zval **return_value_ptr, zend_class_entry *ce, zephir_call_type type, zval *object,
 	const char *method_name, uint method_len,
-	zephir_fcall_cache_entry **cache_entry,
+	zephir_fcall_cache_entry **cache_entry, int cache_slot,
 	uint param_count, zval **params TSRMLS_DC)
 {
 	char *possible_method;
@@ -814,7 +827,7 @@ int zephir_call_class_method_aparams(zval **return_value_ptr, zend_class_entry *
 		info.func_length = method_len;
 	}
 
-	status = zephir_call_user_function(object ? &object : NULL, ce, type, fn, rvp, cache_entry, param_count, params, &info TSRMLS_CC);
+	status = zephir_call_user_function(object ? &object : NULL, ce, type, fn, rvp, cache_entry, cache_slot, param_count, params, &info TSRMLS_CC);
 
 #else
 
@@ -848,7 +861,7 @@ int zephir_call_class_method_aparams(zval **return_value_ptr, zend_class_entry *
 		ZVAL_STRINGL(fn, "undefined", sizeof("undefined")-1, 1);
 	}
 
-	status = zephir_call_user_function(object ? &object : NULL, ce, type, fn, rvp, cache_entry, param_count, params, NULL TSRMLS_CC);
+	status = zephir_call_user_function(object ? &object : NULL, ce, type, fn, rvp, cache_entry, cache_slot, param_count, params, NULL TSRMLS_CC);
 
 #endif
 

--- a/ext/kernel/fcall.h
+++ b/ext/kernel/fcall.h
@@ -37,19 +37,6 @@ typedef enum _zephir_call_type {
 	zephir_fcall_function
 } zephir_call_type;
 
-#ifndef ZEPHIR_RELEASE
-
-typedef struct _zephir_fcall_cache_entry {
-	zend_function *f;
-	zend_uint times;
-} zephir_fcall_cache_entry;
-
-#else
-
-typedef zend_function zephir_fcall_cache_entry;
-
-#endif
-
 /**
  * @addtogroup callfuncs Calling Functions
  * @{
@@ -187,52 +174,52 @@ typedef zend_function zephir_fcall_cache_entry;
  * @}
  */
 
-#define ZEPHIR_CALL_METHODW(return_value_ptr, object, method, cache, ...) \
+#define ZEPHIR_CALL_METHODW(return_value_ptr, object, method, cache, cache_slot, ...) \
 	do { \
 		zval *params_[] = {ZEPHIR_FETCH_VA_ARGS __VA_ARGS__}; \
 		if (__builtin_constant_p(method)) { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, Z_TYPE_P(object) == IS_OBJECT ? Z_OBJCE_P(object) : NULL, zephir_fcall_method, object, method, sizeof(method)-1, cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, Z_TYPE_P(object) == IS_OBJECT ? Z_OBJCE_P(object) : NULL, zephir_fcall_method, object, method, sizeof(method)-1, cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 		else { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, Z_TYPE_P(object) == IS_OBJECT ? Z_OBJCE_P(object) : NULL, zephir_fcall_method, object, method, strlen(method), cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, Z_TYPE_P(object) == IS_OBJECT ? Z_OBJCE_P(object) : NULL, zephir_fcall_method, object, method, strlen(method), cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 	} while (0)
 
-#define ZEPHIR_CALL_METHOD(return_value_ptr, object, method, cache, ...) \
+#define ZEPHIR_CALL_METHOD(return_value_ptr, object, method, cache, cache_slot, ...) \
 	do { \
 		zval *params_[] = {ZEPHIR_FETCH_VA_ARGS __VA_ARGS__}; \
 		ZEPHIR_OBSERVE_OR_NULLIFY_PPZV(return_value_ptr); \
 		if (__builtin_constant_p(method)) { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, Z_TYPE_P(object) == IS_OBJECT ? Z_OBJCE_P(object) : NULL, zephir_fcall_method, object, method, sizeof(method)-1, cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, Z_TYPE_P(object) == IS_OBJECT ? Z_OBJCE_P(object) : NULL, zephir_fcall_method, object, method, sizeof(method)-1, cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 		else { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, Z_TYPE_P(object) == IS_OBJECT ? Z_OBJCE_P(object) : NULL, zephir_fcall_method, object, method, strlen(method), cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, Z_TYPE_P(object) == IS_OBJECT ? Z_OBJCE_P(object) : NULL, zephir_fcall_method, object, method, strlen(method), cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 	} while (0)
 
-#define ZEPHIR_RETURN_CALL_METHODW(object, method, cache, ...) \
+#define ZEPHIR_RETURN_CALL_METHODW(object, method, cache, cache_slot, ...) \
 	do { \
 		zval *params_[] = {ZEPHIR_FETCH_VA_ARGS __VA_ARGS__}; \
 		if (__builtin_constant_p(method)) { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_class_method(return_value, return_value_ptr, Z_TYPE_P(object) == IS_OBJECT ? Z_OBJCE_P(object) : NULL, zephir_fcall_method, object, method, sizeof(method)-1, cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_class_method(return_value, return_value_ptr, Z_TYPE_P(object) == IS_OBJECT ? Z_OBJCE_P(object) : NULL, zephir_fcall_method, object, method, sizeof(method)-1, cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 		else { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_class_method(return_value, return_value_ptr, Z_TYPE_P(object) == IS_OBJECT ? Z_OBJCE_P(object) : NULL, zephir_fcall_method, object, method, strlen(method), cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_class_method(return_value, return_value_ptr, Z_TYPE_P(object) == IS_OBJECT ? Z_OBJCE_P(object) : NULL, zephir_fcall_method, object, method, strlen(method), cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 	} while (0)
 
-#define ZEPHIR_RETURN_CALL_METHOD(object, method, cache, ...) \
+#define ZEPHIR_RETURN_CALL_METHOD(object, method, cache, cache_slot, ...) \
 	do { \
 		zval *params_[] = {ZEPHIR_FETCH_VA_ARGS __VA_ARGS__}; \
 		if (__builtin_constant_p(method)) { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_class_method(return_value, return_value_ptr, Z_TYPE_P(object) == IS_OBJECT ? Z_OBJCE_P(object) : NULL, zephir_fcall_method, object, method, sizeof(method)-1, cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_class_method(return_value, return_value_ptr, Z_TYPE_P(object) == IS_OBJECT ? Z_OBJCE_P(object) : NULL, zephir_fcall_method, object, method, sizeof(method)-1, cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 		else { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_class_method(return_value, return_value_ptr, Z_TYPE_P(object) == IS_OBJECT ? Z_OBJCE_P(object) : NULL, zephir_fcall_method, object, method, strlen(method), cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_class_method(return_value, return_value_ptr, Z_TYPE_P(object) == IS_OBJECT ? Z_OBJCE_P(object) : NULL, zephir_fcall_method, object, method, strlen(method), cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 	} while (0)
 
-#define ZEPHIR_CALL_METHOD_ZVAL(return_value_ptr, object, method, cache, ...) \
+#define ZEPHIR_CALL_METHOD_ZVAL(return_value_ptr, object, method, cache, cache_slot, ...) \
 	do { \
 		char *method_name; \
 		int method_len; \
@@ -245,11 +232,11 @@ typedef zend_function zephir_fcall_cache_entry;
 			method_name = zend_str_tolower_dup("", 0); \
 		} \
 		ZEPHIR_OBSERVE_OR_NULLIFY_PPZV(return_value_ptr); \
-		ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, Z_TYPE_P(object) == IS_OBJECT ? Z_OBJCE_P(object) : NULL, zephir_fcall_method, object, method_name, method_len, cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+		ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, Z_TYPE_P(object) == IS_OBJECT ? Z_OBJCE_P(object) : NULL, zephir_fcall_method, object, method_name, method_len, cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		efree(method_name); \
 	} while (0)
 
-#define ZEPHIR_RETURN_CALL_METHODW_ZVAL(object, method, cache, ...) \
+#define ZEPHIR_RETURN_CALL_METHODW_ZVAL(object, method, cache, cache_slot, ...) \
 	do { \
 		char *method_name; \
 		int method_len; \
@@ -261,11 +248,11 @@ typedef zend_function zephir_fcall_cache_entry;
 			method_len = 0; \
 			method_name = zend_str_tolower_dup("", 0); \
 		} \
-		ZEPHIR_LAST_CALL_STATUS = zephir_return_call_class_method(return_value, return_value_ptr, Z_TYPE_P(object) == IS_OBJECT ? Z_OBJCE_P(object) : NULL, zephir_fcall_method, object, method_name, method_len, cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+		ZEPHIR_LAST_CALL_STATUS = zephir_return_call_class_method(return_value, return_value_ptr, Z_TYPE_P(object) == IS_OBJECT ? Z_OBJCE_P(object) : NULL, zephir_fcall_method, object, method_name, method_len, cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		efree(method_name); \
 	} while (0)
 
-#define ZEPHIR_RETURN_CALL_METHOD_ZVAL(object, method, cache, ...) \
+#define ZEPHIR_RETURN_CALL_METHOD_ZVAL(object, method, cache, cache_slot, ...) \
 	do { \
 		char *method_name; \
 		int method_len; \
@@ -277,42 +264,42 @@ typedef zend_function zephir_fcall_cache_entry;
 			method_len = 0; \
 			method_name = zend_str_tolower_dup("", 0); \
 		} \
-		ZEPHIR_LAST_CALL_STATUS = zephir_return_call_class_method(return_value, return_value_ptr, Z_TYPE_P(object) == IS_OBJECT ? Z_OBJCE_P(object) : NULL, zephir_fcall_method, object, method_name, method_len, cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+		ZEPHIR_LAST_CALL_STATUS = zephir_return_call_class_method(return_value, return_value_ptr, Z_TYPE_P(object) == IS_OBJECT ? Z_OBJCE_P(object) : NULL, zephir_fcall_method, object, method_name, method_len, cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		efree(method_name); \
 	} while (0)
 
-#define ZEPHIR_CALL_METHOD_THIS(return_value_ptr, method, cache, ...) \
+#define ZEPHIR_CALL_METHOD_THIS(return_value_ptr, method, cache, cache_slot, ...) \
 	do { \
 		zval *params_[] = {ZEPHIR_FETCH_VA_ARGS __VA_ARGS__}; \
 		ZEPHIR_OBSERVE_OR_NULLIFY_PPZV(return_value_ptr); \
 		if (__builtin_constant_p(method)) { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, THIS_CE, zephir_fcall_method, this_ptr, method, sizeof(method)-1, cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, THIS_CE, zephir_fcall_method, this_ptr, method, sizeof(method)-1, cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 		else { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, THIS_CE, zephir_fcall_method, this_ptr, method, strlen(method), cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, THIS_CE, zephir_fcall_method, this_ptr, method, strlen(method), cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 	} while (0)
 
-#define ZEPHIR_CALL_PARENTW(return_value_ptr, class_entry, this_ptr, method, cache, ...) \
+#define ZEPHIR_CALL_PARENTW(return_value_ptr, class_entry, this_ptr, method, cache, cache_slot, ...) \
 	do { \
 		zval *params_[] = {ZEPHIR_FETCH_VA_ARGS __VA_ARGS__}; \
 		if (__builtin_constant_p(method)) { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, class_entry, zephir_fcall_parent, this_ptr, method, sizeof(method)-1, cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, class_entry, zephir_fcall_parent, this_ptr, method, sizeof(method)-1, cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 		else { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, class_entry, zephir_fcall_parent, this_ptr, method, strlen(method), cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, class_entry, zephir_fcall_parent, this_ptr, method, strlen(method), cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 	} while (0)
 
-#define ZEPHIR_CALL_PARENT(return_value_ptr, class_entry, this_ptr, method, cache, ...) \
+#define ZEPHIR_CALL_PARENT(return_value_ptr, class_entry, this_ptr, method, cache, cache_slot, ...) \
 	do { \
 		zval *params_[] = {ZEPHIR_FETCH_VA_ARGS __VA_ARGS__}; \
 		ZEPHIR_OBSERVE_OR_NULLIFY_PPZV(return_value_ptr); \
 		if (__builtin_constant_p(method)) { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, class_entry, zephir_fcall_parent, this_ptr, method, sizeof(method)-1, cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, class_entry, zephir_fcall_parent, this_ptr, method, sizeof(method)-1, cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 		else { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, class_entry, zephir_fcall_parent, this_ptr, method, strlen(method), cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, class_entry, zephir_fcall_parent, this_ptr, method, strlen(method), cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 	} while (0)
 
@@ -327,37 +314,37 @@ typedef zend_function zephir_fcall_cache_entry;
 		} \
 	} while (0)
 
-#define ZEPHIR_RETURN_CALL_PARENT(class_entry, this_ptr, method, cache, ...) \
+#define ZEPHIR_RETURN_CALL_PARENT(class_entry, this_ptr, method, cache, cache_slot, ...) \
 	do { \
 		zval *params_[] = {ZEPHIR_FETCH_VA_ARGS __VA_ARGS__}; \
 		if (__builtin_constant_p(method)) { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_class_method(return_value, return_value_ptr, class_entry, zephir_fcall_parent, this_ptr, method, sizeof(method)-1, cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_class_method(return_value, return_value_ptr, class_entry, zephir_fcall_parent, this_ptr, method, sizeof(method)-1, cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 		else { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_class_method(return_value, return_value_ptr, class_entry, zephir_fcall_parent, this_ptr, method, strlen(method), cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_class_method(return_value, return_value_ptr, class_entry, zephir_fcall_parent, this_ptr, method, strlen(method), cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 	} while (0)
 
-#define ZEPHIR_CALL_SELFW(return_value_ptr, method, cache, ...) \
+#define ZEPHIR_CALL_SELFW(return_value_ptr, method, cache, cache_slot, ...) \
 	do { \
 		zval *params_[] = {ZEPHIR_FETCH_VA_ARGS __VA_ARGS__}; \
 		if (__builtin_constant_p(method)) { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, NULL, zephir_fcall_self, NULL, method, cache, sizeof(method)-1, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, NULL, zephir_fcall_self, NULL, method, cache, cache_slot, sizeof(method)-1, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 		else { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, NULL, zephir_fcall_self, NULL, method, cache, strlen(method), ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, NULL, zephir_fcall_self, NULL, method, cache, cache_slot, strlen(method), ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 	} while (0)
 
-#define ZEPHIR_CALL_SELF(return_value_ptr, method, cache, ...) \
+#define ZEPHIR_CALL_SELF(return_value_ptr, method, cache, cache_slot, ...) \
 	do { \
 		zval *params_[] = {ZEPHIR_FETCH_VA_ARGS __VA_ARGS__}; \
 		ZEPHIR_OBSERVE_OR_NULLIFY_PPZV(return_value_ptr); \
 		if (__builtin_constant_p(method)) { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, NULL, zephir_fcall_self, NULL, method, sizeof(method)-1, cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, NULL, zephir_fcall_self, NULL, method, sizeof(method)-1, cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 		else { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, NULL, zephir_fcall_self, NULL, method, strlen(method), cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, NULL, zephir_fcall_self, NULL, method, strlen(method), cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 	} while (0)
 
@@ -372,14 +359,14 @@ typedef zend_function zephir_fcall_cache_entry;
 		} \
 	} while (0)
 
-#define ZEPHIR_RETURN_CALL_SELF(method, cache, ...) \
+#define ZEPHIR_RETURN_CALL_SELF(method, cache, cache_slot, ...) \
 	do { \
 		zval *params_[] = {ZEPHIR_FETCH_VA_ARGS __VA_ARGS__}; \
 		if (__builtin_constant_p(method)) { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_class_method(return_value, return_value_ptr, NULL, zephir_fcall_self, NULL, method, sizeof(method)-1, cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_class_method(return_value, return_value_ptr, NULL, zephir_fcall_self, NULL, method, sizeof(method)-1, cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 		else { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_class_method(return_value, return_value_ptr, NULL, zephir_fcall_self, NULL, method, strlen(method), cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_class_method(return_value, return_value_ptr, NULL, zephir_fcall_self, NULL, method, strlen(method), cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 	} while (0)
 
@@ -394,64 +381,64 @@ typedef zend_function zephir_fcall_cache_entry;
 		} \
 	} while (0)
 
-#define ZEPHIR_CALL_STATIC(return_value_ptr, method, cache, ...) \
+#define ZEPHIR_CALL_STATIC(return_value_ptr, method, cache, cache_slot, ...) \
 	do { \
 		zval *params_[] = {ZEPHIR_FETCH_VA_ARGS __VA_ARGS__}; \
 		ZEPHIR_OBSERVE_OR_NULLIFY_PPZV(return_value_ptr); \
 		if (__builtin_constant_p(method)) { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, NULL, zephir_fcall_static, NULL, method, sizeof(method)-1, cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, NULL, zephir_fcall_static, NULL, method, sizeof(method)-1, cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 		else { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, NULL, zephir_fcall_static, NULL, method, strlen(method), cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, NULL, zephir_fcall_static, NULL, method, strlen(method), cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 	} while (0)
 
-#define ZEPHIR_RETURN_CALL_STATICW(method, cache, ...) \
+#define ZEPHIR_RETURN_CALL_STATICW(method, cache, cache_slot, ...) \
 	do { \
 		zval *params_[] = {ZEPHIR_FETCH_VA_ARGS __VA_ARGS__}; \
 		if (__builtin_constant_p(method)) { \
-			RETURN_ON_FAILURE(zephir_return_call_class_method(return_value, return_value_ptr, NULL, zephir_fcall_static, NULL, method, sizeof(method)-1, cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC)); \
+			RETURN_ON_FAILURE(zephir_return_call_class_method(return_value, return_value_ptr, NULL, zephir_fcall_static, NULL, method, sizeof(method)-1, cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC)); \
 		} \
 		else { \
-			RETURN_ON_FAILURE(zephir_return_call_class_method(return_value, return_value_ptr, NULL, zephir_fcall_static, NULL, method, strlen(method), cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC)); \
+			RETURN_ON_FAILURE(zephir_return_call_class_method(return_value, return_value_ptr, NULL, zephir_fcall_static, NULL, method, strlen(method), cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC)); \
 		} \
 	} while (0)
 
-#define ZEPHIR_RETURN_CALL_STATIC(method, cache, ...) \
+#define ZEPHIR_RETURN_CALL_STATIC(method, cache, cache_slot, ...) \
 	do { \
 		zval *params_[] = {ZEPHIR_FETCH_VA_ARGS __VA_ARGS__}; \
 		if (__builtin_constant_p(method)) { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_class_method(return_value, return_value_ptr, NULL, zephir_fcall_static, NULL, method, sizeof(method)-1, cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_class_method(return_value, return_value_ptr, NULL, zephir_fcall_static, NULL, method, sizeof(method)-1, cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 		else { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_class_method(return_value, return_value_ptr, NULL, zephir_fcall_static, NULL, method, strlen(method), cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_class_method(return_value, return_value_ptr, NULL, zephir_fcall_static, NULL, method, strlen(method), cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 	} while (0)
 
-#define ZEPHIR_CALL_CE_STATICW(return_value_ptr, class_entry, method, cache, ...) \
+#define ZEPHIR_CALL_CE_STATICW(return_value_ptr, class_entry, method, cache, cache_slot, ...) \
 	do { \
 		zval *params[] = {__VA_ARGS__}; \
 		if (__builtin_constant_p(method)) { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, class_entry, zephir_fcall_ce, NULL, method, sizeof(method)-1, cache, sizeof(params)/sizeof(zval*), params TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, class_entry, zephir_fcall_ce, NULL, method, sizeof(method)-1, cache, cache_slot, sizeof(params)/sizeof(zval*), params TSRMLS_CC); \
 		} \
 		else { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, class_entry, zephir_fcall_ce, NULL, method, strlen(method), cache, sizeof(params)/sizeof(zval*), params TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, class_entry, zephir_fcall_ce, NULL, method, strlen(method), cache, cache_slot, sizeof(params)/sizeof(zval*), params TSRMLS_CC); \
 		} \
 	} while (0)
 
-#define ZEPHIR_CALL_CE_STATIC(return_value_ptr, class_entry, method, cache, ...) \
+#define ZEPHIR_CALL_CE_STATIC(return_value_ptr, class_entry, method, cache, cache_slot, ...) \
 	do { \
 		zval *params_[] = {ZEPHIR_FETCH_VA_ARGS __VA_ARGS__}; \
 		ZEPHIR_OBSERVE_OR_NULLIFY_PPZV(return_value_ptr); \
 		if (__builtin_constant_p(method)) { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, class_entry, zephir_fcall_ce, NULL, method, sizeof(method)-1, cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, class_entry, zephir_fcall_ce, NULL, method, sizeof(method)-1, cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 		else { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, class_entry, zephir_fcall_ce, NULL, method, strlen(method), cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, class_entry, zephir_fcall_ce, NULL, method, strlen(method), cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 	} while (0)
 
-#define ZEPHIR_RETURN_CALL_CE_STATICW(class_entry, method, cache, ...) \
+#define ZEPHIR_RETURN_CALL_CE_STATICW(class_entry, method, cache, cache_slot, ...) \
 	do { \
 		zval *params_[] = {ZEPHIR_FETCH_VA_ARGS __VA_ARGS__}; \
 		if (__builtin_constant_p(method)) { \
@@ -462,18 +449,18 @@ typedef zend_function zephir_fcall_cache_entry;
 		} \
 	} while (0)
 
-#define ZEPHIR_RETURN_CALL_CE_STATIC(class_entry, method, cache, ...) \
+#define ZEPHIR_RETURN_CALL_CE_STATIC(class_entry, method, cache, cache_slot, ...) \
 	do { \
 		zval *params_[] = {ZEPHIR_FETCH_VA_ARGS __VA_ARGS__}; \
 		if (__builtin_constant_p(method)) { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_class_method(return_value, return_value_ptr, class_entry, zephir_fcall_ce, NULL, method, sizeof(method)-1, cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_class_method(return_value, return_value_ptr, class_entry, zephir_fcall_ce, NULL, method, sizeof(method)-1, cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 		else { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_class_method(return_value, return_value_ptr, class_entry, zephir_fcall_ce, NULL, method, strlen(method), cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_class_method(return_value, return_value_ptr, class_entry, zephir_fcall_ce, NULL, method, strlen(method), cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 	} while (0)
 
-#define ZEPHIR_CALL_CE_STATIC_ZVAL(return_value_ptr, class_entry, method, cache, ...) \
+#define ZEPHIR_CALL_CE_STATIC_ZVAL(return_value_ptr, class_entry, method, cache, cache_slot, ...) \
 	do { \
 		char *method_name; \
 		int method_len; \
@@ -486,11 +473,11 @@ typedef zend_function zephir_fcall_cache_entry;
 			method_name = zend_str_tolower_dup("", 0); \
 		} \
 		ZEPHIR_OBSERVE_OR_NULLIFY_PPZV(return_value_ptr); \
-		ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, class_entry, zephir_fcall_ce, NULL, method_name, method_len, cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+		ZEPHIR_LAST_CALL_STATUS = zephir_call_class_method_aparams(return_value_ptr, class_entry, zephir_fcall_ce, NULL, method_name, method_len, cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		efree(method_name); \
 	} while (0)
 
-#define ZEPHIR_RETURN_CALL_CE_STATICW_ZVAL(class_entry, method, cache, ...) \
+#define ZEPHIR_RETURN_CALL_CE_STATICW_ZVAL(class_entry, method, cache, cache_slot, ...) \
 	do { \
 		char *method_name; \
 		int method_len; \
@@ -506,7 +493,7 @@ typedef zend_function zephir_fcall_cache_entry;
 		efree(method_name); \
 	} while (0)
 
-#define ZEPHIR_RETURN_CALL_CE_STATIC_ZVAL(class_entry, method, cache, ...) \
+#define ZEPHIR_RETURN_CALL_CE_STATIC_ZVAL(class_entry, method, cache, cache_slot, ...) \
 	do { \
 		char *method_name; \
 		int method_len; \
@@ -518,7 +505,7 @@ typedef zend_function zephir_fcall_cache_entry;
 			method_len = 0; \
 			method_name = zend_str_tolower_dup("", 0); \
 		} \
-		ZEPHIR_LAST_CALL_STATUS = zephir_return_call_class_method(return_value, return_value_ptr, class_entry, zephir_fcall_ce, NULL, method_name, method_len, cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+		ZEPHIR_LAST_CALL_STATUS = zephir_return_call_class_method(return_value, return_value_ptr, class_entry, zephir_fcall_ce, NULL, method_name, method_len, cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		efree(method_name); \
 	} while (0)
 
@@ -616,15 +603,20 @@ ZEPHIR_ATTR_WARN_UNUSED_RESULT static inline int zephir_return_call_zval_functio
 	return SUCCESS;
 }
 
-int zephir_call_class_method_aparams(zval **return_value_ptr, zend_class_entry *ce, zephir_call_type type, zval *object,
+int zephir_call_class_method_aparams(zval **return_value_ptr,
+	zend_class_entry *ce,
+	zephir_call_type type,
+	zval *object,
 	const char *method_name, uint method_len,
 	zephir_fcall_cache_entry **cache_entry,
-	uint param_count, zval **params TSRMLS_DC) ZEPHIR_ATTR_WARN_UNUSED_RESULT;
+	int cache_slot,
+	uint param_count,
+	zval **params TSRMLS_DC) ZEPHIR_ATTR_WARN_UNUSED_RESULT;
 
 ZEPHIR_ATTR_WARN_UNUSED_RESULT static inline int zephir_return_call_class_method(zval *return_value,
 	zval **return_value_ptr, zend_class_entry *ce, zephir_call_type type, zval *object,
 	const char *method_name, uint method_len,
-	zephir_fcall_cache_entry **cache_entry,
+	zephir_fcall_cache_entry **cache_entry, int cache_slot,
 	uint param_count, zval **params TSRMLS_DC)
 {
 	zval *rv = NULL, **rvp = return_value_ptr ? return_value_ptr : &rv;
@@ -635,7 +627,7 @@ ZEPHIR_ATTR_WARN_UNUSED_RESULT static inline int zephir_return_call_class_method
 		*return_value_ptr = NULL;
 	}
 
-	status = zephir_call_class_method_aparams(rvp, ce, type, object, method_name, method_len, cache_entry, param_count, params TSRMLS_CC);
+	status = zephir_call_class_method_aparams(rvp, ce, type, object, method_name, method_len, cache_entry, cache_slot, param_count, params TSRMLS_CC);
 
 	if (status == FAILURE) {
 		if (return_value_ptr && EG(exception)) {

--- a/ext/kernel/fcall.h
+++ b/ext/kernel/fcall.h
@@ -78,15 +78,15 @@ typedef enum _zephir_call_type {
  * @note If the call fails or an exception occurs, the memory frame is restored.
  * In this case if @c return_value_ptr is not @c NULL, <tt>*return_value_ptr</tt> is set to @c NULL
  */
-#define ZEPHIR_CALL_FUNCTION(return_value_ptr, func_name, cache, ...) \
+#define ZEPHIR_CALL_FUNCTION(return_value_ptr, func_name, cache, cache_slot, ...) \
 	do { \
 		zval *params_[] = {ZEPHIR_FETCH_VA_ARGS __VA_ARGS__}; \
 		ZEPHIR_OBSERVE_OR_NULLIFY_PPZV(return_value_ptr); \
 		if (__builtin_constant_p(func_name)) { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_call_func_aparams(return_value_ptr, func_name, sizeof(func_name)-1, cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_call_func_aparams(return_value_ptr, func_name, sizeof(func_name)-1, cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 		else { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_call_func_aparams(return_value_ptr, func_name, strlen(func_name), cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_call_func_aparams(return_value_ptr, func_name, strlen(func_name), cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 	} while (0)
 
@@ -99,14 +99,14 @@ typedef enum _zephir_call_type {
  * @li if @c return_value_ptr is not @c NULL, @c *return_value_ptr is initialized with @c ALLOC_INIT_ZVAL
  * @li otherwise, if @c return_value is not @c NULL, @c return_value and @c *return_value are not changed
  */
-#define ZEPHIR_RETURN_CALL_FUNCTIONW(func_name, cache, ...) \
+#define ZEPHIR_RETURN_CALL_FUNCTIONW(func_name, cache, cache_slot, ...) \
 	do { \
 		zval *params_[] = {ZEPHIR_FETCH_VA_ARGS __VA_ARGS__}; \
 		if (__builtin_constant_p(func_name)) { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_function(return_value, return_value_ptr, func_name, sizeof(func_name)-1, cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_function(return_value, return_value_ptr, func_name, sizeof(func_name)-1, cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 		else { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_function(return_value, return_value_ptr, func_name, strlen(func_name), cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_function(return_value, return_value_ptr, func_name, strlen(func_name), cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 	} while (0)
 
@@ -119,14 +119,14 @@ typedef enum _zephir_call_type {
  * @li if @c return_value_ptr is not @c NULL, @c *return_value_ptr is initialized with @c ALLOC_INIT_ZVAL
  * @li otherwise, if @c return_value is not @c NULL, @c return_value and @c *return_value are not changed
  */
-#define ZEPHIR_RETURN_CALL_FUNCTION(func_name, cache, ...) \
+#define ZEPHIR_RETURN_CALL_FUNCTION(func_name, cache, cache_slot, ...) \
 	do { \
 		zval *params_[] = {ZEPHIR_FETCH_VA_ARGS __VA_ARGS__}; \
 		if (__builtin_constant_p(func_name)) { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_function(return_value, return_value_ptr, func_name, sizeof(func_name)-1, cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_function(return_value, return_value_ptr, func_name, sizeof(func_name)-1, cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 		else { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_function(return_value, return_value_ptr, func_name, strlen(func_name), cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_function(return_value, return_value_ptr, func_name, strlen(func_name), cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 	} while (0)
 
@@ -138,15 +138,15 @@ typedef enum _zephir_call_type {
  * @note If the call fails or an exception occurs, the memory frame is restored.
  * In this case if @c return_value_ptr is not @c NULL, <tt>*return_value_ptr</tt> is set to @c NULL
  */
-#define ZEPHIR_CALL_ZVAL_FUNCTION(return_value_ptr, func_name, cache, ...) \
+#define ZEPHIR_CALL_ZVAL_FUNCTION(return_value_ptr, func_name, cache, cache_slot, ...) \
 	do { \
 		zval *params_[] = {ZEPHIR_FETCH_VA_ARGS __VA_ARGS__}; \
 		ZEPHIR_OBSERVE_OR_NULLIFY_PPZV(return_value_ptr); \
 		if (__builtin_constant_p(func_name)) { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_call_zval_func_aparams(return_value_ptr, func_name, cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_call_zval_func_aparams(return_value_ptr, func_name, cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 		else { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_call_zval_func_aparams(return_value_ptr, func_name, cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_call_zval_func_aparams(return_value_ptr, func_name, cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 	} while (0)
 
@@ -159,14 +159,14 @@ typedef enum _zephir_call_type {
  * @li if @c return_value_ptr is not @c NULL, @c *return_value_ptr is initialized with @c ALLOC_INIT_ZVAL
  * @li otherwise, if @c return_value is not @c NULL, @c return_value and @c *return_value are not changed
  */
-#define ZEPHIR_RETURN_CALL_ZVAL_FUNCTION(func_name, cache, ...) \
+#define ZEPHIR_RETURN_CALL_ZVAL_FUNCTION(func_name, cache, cache_slot, ...) \
 	do { \
 		zval *params_[] = {ZEPHIR_FETCH_VA_ARGS __VA_ARGS__}; \
 		if (__builtin_constant_p(func_name)) { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_zval_function(return_value, return_value_ptr, func_name, cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_zval_function(return_value, return_value_ptr, func_name, cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 		else { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_zval_function(return_value, return_value_ptr, func_name, cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			ZEPHIR_LAST_CALL_STATUS = zephir_return_call_zval_function(return_value, return_value_ptr, func_name, cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 	} while (0)
 
@@ -522,11 +522,11 @@ typedef enum _zephir_call_type {
 	} while (0)
 
 int zephir_call_func_aparams(zval **return_value_ptr, const char *func_name, uint func_length,
-	zephir_fcall_cache_entry **cache_entry,
+	zephir_fcall_cache_entry **cache_entry, int cache_slot,
 	uint param_count, zval **params TSRMLS_DC);
 
 int zephir_call_zval_func_aparams(zval **return_value_ptr, zval *func_name,
-	zephir_fcall_cache_entry **cache_entry,
+	zephir_fcall_cache_entry **cache_entry, int cache_slot,
 	uint param_count, zval **params TSRMLS_DC) ZEPHIR_ATTR_WARN_UNUSED_RESULT;
 
 /**
@@ -539,7 +539,7 @@ int zephir_call_zval_func_aparams(zval **return_value_ptr, zval *func_name,
  * @param param_count Number of parameters
  */
 ZEPHIR_ATTR_WARN_UNUSED_RESULT static inline int zephir_return_call_function(zval *return_value, zval **return_value_ptr,
-	const char *func, uint func_len, zephir_fcall_cache_entry **cache_entry, uint param_count, zval **params TSRMLS_DC)
+	const char *func, uint func_len, zephir_fcall_cache_entry **cache_entry, int cache_slot, uint param_count, zval **params TSRMLS_DC)
 {
 	zval *rv = NULL, **rvp = return_value_ptr ? return_value_ptr : &rv;
 	int status;
@@ -549,7 +549,7 @@ ZEPHIR_ATTR_WARN_UNUSED_RESULT static inline int zephir_return_call_function(zva
 		*return_value_ptr = NULL;
 	}
 
-	status = zephir_call_func_aparams(rvp, func, func_len, cache_entry, param_count, params TSRMLS_CC);
+	status = zephir_call_func_aparams(rvp, func, func_len, cache_entry, cache_slot, param_count, params TSRMLS_CC);
 
 	if (status == FAILURE) {
 		if (return_value_ptr && EG(exception)) {
@@ -576,7 +576,7 @@ ZEPHIR_ATTR_WARN_UNUSED_RESULT static inline int zephir_return_call_function(zva
  * @param param_count Number of parameters
  */
 ZEPHIR_ATTR_WARN_UNUSED_RESULT static inline int zephir_return_call_zval_function(zval *return_value, zval **return_value_ptr,
-	zval *func, zephir_fcall_cache_entry **cache_entry, uint param_count, zval **params TSRMLS_DC)
+	zval *func, zephir_fcall_cache_entry **cache_entry, int cache_slot, uint param_count, zval **params TSRMLS_DC)
 {
 	zval *rv = NULL, **rvp = return_value_ptr ? return_value_ptr : &rv;
 	int status;
@@ -586,7 +586,7 @@ ZEPHIR_ATTR_WARN_UNUSED_RESULT static inline int zephir_return_call_zval_functio
 		*return_value_ptr = NULL;
 	}
 
-	status = zephir_call_zval_func_aparams(rvp, func, cache_entry, param_count, params TSRMLS_CC);
+	status = zephir_call_zval_func_aparams(rvp, func, cache_entry, cache_slot, param_count, params TSRMLS_CC);
 
 	if (status == FAILURE) {
 		if (return_value_ptr && EG(exception)) {

--- a/ext/kernel/globals.h
+++ b/ext/kernel/globals.h
@@ -24,6 +24,7 @@
 #include <php.h>
 
 #define ZEPHIR_MAX_MEMORY_STACK 48
+#define ZEPHIR_MAX_CACHE_SLOTS 512
 
 /** Memory frame */
 typedef struct _zephir_memory_entry {

--- a/ext/kernel/globals.h
+++ b/ext/kernel/globals.h
@@ -53,6 +53,19 @@ typedef struct _zephir_function_cache {
 	zend_function *func;
 } zephir_function_cache;
 
+#ifndef ZEPHIR_RELEASE
+
+typedef struct _zephir_fcall_cache_entry {
+	zend_function *f;
+	zend_uint times;
+} zephir_fcall_cache_entry;
+
+#else
+
+typedef zend_function zephir_fcall_cache_entry;
+
+#endif
+
 #if PHP_VERSION_ID >= 50400
 	#define ZEPHIR_INIT_FUNCS(class_functions) static const zend_function_entry class_functions[] =
 #else

--- a/ext/kernel/object.c
+++ b/ext/kernel/object.c
@@ -1599,7 +1599,7 @@ int zephir_create_instance(zval *return_value, const zval *class_name TSRMLS_DC)
 
 	object_init_ex(return_value, ce);
 	if (zephir_has_constructor_ce(ce)) {
-		return zephir_call_class_method_aparams(NULL, ce, zephir_fcall_method, return_value, SL("__construct"), NULL, 0, NULL TSRMLS_CC);
+		return zephir_call_class_method_aparams(NULL, ce, zephir_fcall_method, return_value, SL("__construct"), NULL, 0, 0, NULL TSRMLS_CC);
 	}
 
 	return SUCCESS;
@@ -1661,7 +1661,7 @@ int zephir_create_instance_params(zval *return_value, const zval *class_name, zv
 			params_ptr = NULL;
 		}
 
-		outcome = zephir_call_class_method_aparams(NULL, ce, zephir_fcall_method, return_value, SL("__construct"), NULL, param_count, params_ptr TSRMLS_CC);
+		outcome = zephir_call_class_method_aparams(NULL, ce, zephir_fcall_method, return_value, SL("__construct"), NULL, 0, param_count, params_ptr TSRMLS_CC);
 
 		if (unlikely(params_arr != NULL)) {
 			efree(params_arr);
@@ -1822,4 +1822,3 @@ int zephir_create_closure_ex(zval *return_value, zval *this_ptr, zend_class_entr
 #endif
 	return SUCCESS;
 }
-

--- a/ext/kernel/string.c
+++ b/ext/kernel/string.c
@@ -522,7 +522,7 @@ void zephir_fast_str_replace(zval **return_value_ptr, zval *search, zval *replac
 	if (Z_TYPE_P(search) == IS_ARRAY) {
 		do {
 			zval *params[] = { search, replace, subject };
-			zephir_call_func_aparams(return_value_ptr, "str_replace", sizeof("str_replace")-1, NULL, 3, params TSRMLS_CC);
+			zephir_call_func_aparams(return_value_ptr, "str_replace", sizeof("str_replace")-1, NULL, 0, 3, params TSRMLS_CC);
 			return;
 		} while(0);
 	}
@@ -1303,9 +1303,9 @@ void zephir_preg_match(zval *return_value, zval *regex, zval *subject, zval *mat
 		zval *tmp_params[5] = { regex, subject, matches, &tmp_flags, &tmp_offset };
 
 		if (global) {
-			zephir_call_func_aparams(rvp, SL("preg_match_all"), NULL, 5, tmp_params TSRMLS_CC);
+			zephir_call_func_aparams(rvp, SL("preg_match_all"), NULL, 0, 5, tmp_params TSRMLS_CC);
 		} else {
-			zephir_call_func_aparams(rvp, SL("preg_match"), NULL, 5, tmp_params TSRMLS_CC);
+			zephir_call_func_aparams(rvp, SL("preg_match"), NULL, 0, 5, tmp_params TSRMLS_CC);
 		}
 	}
 	if (matches) {

--- a/ext/kernel/string.c
+++ b/ext/kernel/string.c
@@ -1366,7 +1366,7 @@ int zephir_json_encode(zval *return_value, zval **return_value_ptr, zval *v, int
 	params[0] = v;
 	params[1] = &zopts;
 
-	return zephir_return_call_function(return_value, NULL, ZEND_STRL("json_encode"), NULL, 2, params TSRMLS_CC);
+	return zephir_return_call_function(return_value, NULL, ZEND_STRL("json_encode"), NULL, 0, 2, params TSRMLS_CC);
 }
 
 int zephir_json_decode(zval *return_value, zval **return_value_ptr, zval *v, zend_bool assoc TSRMLS_DC) {
@@ -1380,7 +1380,7 @@ int zephir_json_decode(zval *return_value, zval **return_value_ptr, zval *v, zen
 	params[0] = v;
 	params[1] = &zassoc;
 
-	return zephir_return_call_function(return_value, NULL, ZEND_STRL("json_decode"), NULL, 2, params TSRMLS_CC);
+	return zephir_return_call_function(return_value, NULL, ZEND_STRL("json_decode"), NULL, 0, 2, params TSRMLS_CC);
 }
 
 #endif /* ZEPHIR_USE_PHP_JSON */

--- a/ext/php_test.h
+++ b/ext/php_test.h
@@ -40,6 +40,8 @@ ZEND_BEGIN_MODULE_GLOBALS(test)
 	/** Function cache */
 	HashTable *fcache;
 
+	zephir_fcall_cache_entry *scache[ZEPHIR_MAX_CACHE_SLOTS];
+
 	/* Cache enabled */
 	unsigned int cache_enabled;
 

--- a/ext/test.c
+++ b/ext/test.c
@@ -368,6 +368,9 @@ static void php_zephir_init_globals(zend_test_globals *zephir_globals TSRMLS_DC)
 	/* Recursive Lock */
 	zephir_globals->recursive_lock = 0;
 
+	/** Static cache */	 
+	memset(zephir_globals->scache, '\0', 1024);
+
 	zephir_globals->test.my_setting_1 = 1;
 	zephir_globals->test.my_setting_2 = 100;
 	zephir_globals->test.my_setting_3 = 7.5;

--- a/ext/test/arithmetic.zep.c
+++ b/ext/test/arithmetic.zep.c
@@ -111,7 +111,7 @@ PHP_METHOD(Test_Arithmetic, boolSumSimple) {
 PHP_METHOD(Test_Arithmetic, boolSumExpression) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL;
 	zval _0, *_1 = NULL;
 	zend_bool a;
 
@@ -120,7 +120,7 @@ PHP_METHOD(Test_Arithmetic, boolSumExpression) {
 	a = 1;
 	ZEPHIR_SINIT_VAR(_0);
 	ZVAL_LONG(&_0, 0);
-	ZEPHIR_CALL_FUNCTION(&_1, "exp", &_2, &_0);
+	ZEPHIR_CALL_FUNCTION(&_1, "exp", &_2, 1, &_0);
 	zephir_check_call_status();
 	RETURN_MM_LONG((a + zephir_get_numberval(_1)));
 
@@ -173,14 +173,14 @@ PHP_METHOD(Test_Arithmetic, doubleSum2Simple) {
 PHP_METHOD(Test_Arithmetic, doubleSumExpression) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL;
 	zval _0, *_1 = NULL;
 
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_SINIT_VAR(_0);
 	ZVAL_LONG(&_0, 0);
-	ZEPHIR_CALL_FUNCTION(&_1, "exp", &_2, &_0);
+	ZEPHIR_CALL_FUNCTION(&_1, "exp", &_2, 1, &_0);
 	zephir_check_call_status();
 	RETURN_MM_DOUBLE((1.0 + zephir_get_numberval(_1)));
 
@@ -189,7 +189,7 @@ PHP_METHOD(Test_Arithmetic, doubleSumExpression) {
 PHP_METHOD(Test_Arithmetic, doubleSumVarExpression) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL;
 	zval _0, *_1 = NULL;
 	double a;
 
@@ -198,7 +198,7 @@ PHP_METHOD(Test_Arithmetic, doubleSumVarExpression) {
 	a = 1.0;
 	ZEPHIR_SINIT_VAR(_0);
 	ZVAL_LONG(&_0, 0);
-	ZEPHIR_CALL_FUNCTION(&_1, "exp", &_2, &_0);
+	ZEPHIR_CALL_FUNCTION(&_1, "exp", &_2, 1, &_0);
 	zephir_check_call_status();
 	RETURN_MM_LONG((a + zephir_get_numberval(_1)));
 

--- a/ext/test/assign.zep.c
+++ b/ext/test/assign.zep.c
@@ -1657,8 +1657,8 @@ PHP_METHOD(Test_Assign, testConstantKeyAssign) {
 	ZEPHIR_INIT_VAR(elements);
 	zephir_create_array(elements, 3, 0 TSRMLS_CC);
 	add_assoc_long_ex(elements, SS("abc"), 1);
-	add_index_long(elements, 131072, 131079);
-	add_index_long(elements, 131073, 131080);
+	add_index_long(elements, 14, 7);
+	add_index_long(elements, 15, 8);
 	ZEPHIR_MM_RESTORE();
 
 }

--- a/ext/test/bench/foo.zep.c
+++ b/ext/test/bench/foo.zep.c
@@ -234,7 +234,7 @@ PHP_METHOD(Test_Bench_Foo, call_static) {
 			}
 			ZEPHIR_INIT_NVAR(i);
 			ZVAL_LONG(i, _1);
-			ZEPHIR_CALL_SELF(NULL, "f", &_3);
+			ZEPHIR_CALL_SELF(NULL, "f", &_3, 0);
 			zephir_check_call_status();
 		}
 	}
@@ -529,7 +529,7 @@ PHP_METHOD(Test_Bench_Foo, call) {
 			}
 			ZEPHIR_INIT_NVAR(i);
 			ZVAL_LONG(i, _1);
-			ZEPHIR_CALL_METHOD(NULL, this_ptr, "g", &_3);
+			ZEPHIR_CALL_METHOD(NULL, this_ptr, "g", &_3, 0);
 			zephir_check_call_status();
 		}
 	}

--- a/ext/test/builtin/arraymethods.zep.c
+++ b/ext/test/builtin/arraymethods.zep.c
@@ -54,7 +54,7 @@ PHP_METHOD(Test_BuiltIn_ArrayMethods, getJoin1) {
 PHP_METHOD(Test_BuiltIn_ArrayMethods, getReversed1) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_3 = NULL;
+	zephir_fcall_cache_entry *_3 = NULL;
 	zval *_1 = NULL, *_2 = NULL;
 	zval *_0;
 
@@ -71,7 +71,7 @@ PHP_METHOD(Test_BuiltIn_ArrayMethods, getReversed1) {
 	ZEPHIR_INIT_NVAR(_1);
 	ZVAL_LONG(_1, 3);
 	zephir_array_fast_append(_0, _1);
-	ZEPHIR_CALL_FUNCTION(&_2, "array_reverse", &_3, _0);
+	ZEPHIR_CALL_FUNCTION(&_2, "array_reverse", &_3, 2, _0);
 	zephir_check_call_status();
 	RETURN_CCTOR(_2);
 
@@ -80,7 +80,7 @@ PHP_METHOD(Test_BuiltIn_ArrayMethods, getReversed1) {
 PHP_METHOD(Test_BuiltIn_ArrayMethods, getMap1) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_3 = NULL;
+	zephir_fcall_cache_entry *_3 = NULL;
 	zval *_1 = NULL, *_2 = NULL;
 	zval *_0;
 
@@ -100,7 +100,7 @@ PHP_METHOD(Test_BuiltIn_ArrayMethods, getMap1) {
 	ZEPHIR_INIT_NVAR(_1);
 	ZEPHIR_INIT_NVAR(_1);
 	zephir_create_closure_ex(_1, NULL, test_0__closure_ce, SS("__invoke") TSRMLS_CC);
-	ZEPHIR_CALL_FUNCTION(&_2, "array_map", &_3, _1, _0);
+	ZEPHIR_CALL_FUNCTION(&_2, "array_map", &_3, 3, _1, _0);
 	zephir_check_call_status();
 	RETURN_CCTOR(_2);
 

--- a/ext/test/builtin/charmethods.zep.c
+++ b/ext/test/builtin/charmethods.zep.c
@@ -28,7 +28,7 @@ ZEPHIR_INIT_CLASS(Test_BuiltIn_CharMethods) {
 PHP_METHOD(Test_BuiltIn_CharMethods, getHex) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_3 = NULL;
+	zephir_fcall_cache_entry *_3 = NULL;
 	zval _0, _1, *_2 = NULL;
 
 	ZEPHIR_MM_GROW();
@@ -37,7 +37,7 @@ PHP_METHOD(Test_BuiltIn_CharMethods, getHex) {
 	ZVAL_STRING(&_0, "%X", 0);
 	ZEPHIR_SINIT_VAR(_1);
 	ZVAL_LONG(&_1, 'a');
-	ZEPHIR_CALL_FUNCTION(&_2, "sprintf", &_3, &_0, &_1);
+	ZEPHIR_CALL_FUNCTION(&_2, "sprintf", &_3, 4, &_0, &_1);
 	zephir_check_call_status();
 	RETURN_CCTOR(_2);
 
@@ -46,7 +46,7 @@ PHP_METHOD(Test_BuiltIn_CharMethods, getHex) {
 PHP_METHOD(Test_BuiltIn_CharMethods, getHexForString) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_5 = NULL;
+	zephir_fcall_cache_entry *_5 = NULL;
 	long _0;
 	char ch;
 	zval *str_param = NULL, *o, *_1 = NULL, _2 = zval_used_for_init, _3 = zval_used_for_init, *_4 = NULL;
@@ -66,7 +66,7 @@ PHP_METHOD(Test_BuiltIn_CharMethods, getHexForString) {
 		ZVAL_STRING(&_2, "%X", 0);
 		ZEPHIR_SINIT_NVAR(_3);
 		ZVAL_LONG(&_3, ch);
-		ZEPHIR_CALL_FUNCTION(&_4, "sprintf", &_5, &_2, &_3);
+		ZEPHIR_CALL_FUNCTION(&_4, "sprintf", &_5, 4, &_2, &_3);
 		zephir_check_call_status();
 		zephir_concat_self(&o, _4 TSRMLS_CC);
 	}

--- a/ext/test/builtin/intmethods.zep.c
+++ b/ext/test/builtin/intmethods.zep.c
@@ -27,7 +27,7 @@ ZEPHIR_INIT_CLASS(Test_BuiltIn_IntMethods) {
 
 PHP_METHOD(Test_BuiltIn_IntMethods, getAbs) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL;
 	zval *num_param = NULL, _0, *_1 = NULL;
 	int num, ZEPHIR_LAST_CALL_STATUS;
 
@@ -39,7 +39,7 @@ PHP_METHOD(Test_BuiltIn_IntMethods, getAbs) {
 
 	ZEPHIR_SINIT_VAR(_0);
 	ZVAL_LONG(&_0, num);
-	ZEPHIR_CALL_FUNCTION(&_1, "abs", &_2, &_0);
+	ZEPHIR_CALL_FUNCTION(&_1, "abs", &_2, 5, &_0);
 	zephir_check_call_status();
 	RETURN_CCTOR(_1);
 
@@ -48,14 +48,14 @@ PHP_METHOD(Test_BuiltIn_IntMethods, getAbs) {
 PHP_METHOD(Test_BuiltIn_IntMethods, getAbs1) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL;
 	zval _0, *_1 = NULL;
 
 	ZEPHIR_MM_GROW();
 
 	ZEPHIR_SINIT_VAR(_0);
 	ZVAL_LONG(&_0, -5);
-	ZEPHIR_CALL_FUNCTION(&_1, "abs", &_2, &_0);
+	ZEPHIR_CALL_FUNCTION(&_1, "abs", &_2, 5, &_0);
 	zephir_check_call_status();
 	RETURN_CCTOR(_1);
 
@@ -63,7 +63,7 @@ PHP_METHOD(Test_BuiltIn_IntMethods, getAbs1) {
 
 PHP_METHOD(Test_BuiltIn_IntMethods, getBinary) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL;
 	zval *num_param = NULL, _0, *_1 = NULL;
 	int num, ZEPHIR_LAST_CALL_STATUS;
 
@@ -75,7 +75,7 @@ PHP_METHOD(Test_BuiltIn_IntMethods, getBinary) {
 
 	ZEPHIR_SINIT_VAR(_0);
 	ZVAL_LONG(&_0, num);
-	ZEPHIR_CALL_FUNCTION(&_1, "decbin", &_2, &_0);
+	ZEPHIR_CALL_FUNCTION(&_1, "decbin", &_2, 6, &_0);
 	zephir_check_call_status();
 	RETURN_CCTOR(_1);
 
@@ -83,7 +83,7 @@ PHP_METHOD(Test_BuiltIn_IntMethods, getBinary) {
 
 PHP_METHOD(Test_BuiltIn_IntMethods, getHex) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL;
 	zval *num_param = NULL, _0, *_1 = NULL;
 	int num, ZEPHIR_LAST_CALL_STATUS;
 
@@ -95,7 +95,7 @@ PHP_METHOD(Test_BuiltIn_IntMethods, getHex) {
 
 	ZEPHIR_SINIT_VAR(_0);
 	ZVAL_LONG(&_0, num);
-	ZEPHIR_CALL_FUNCTION(&_1, "dechex", &_2, &_0);
+	ZEPHIR_CALL_FUNCTION(&_1, "dechex", &_2, 7, &_0);
 	zephir_check_call_status();
 	RETURN_CCTOR(_1);
 
@@ -103,7 +103,7 @@ PHP_METHOD(Test_BuiltIn_IntMethods, getHex) {
 
 PHP_METHOD(Test_BuiltIn_IntMethods, getOctal) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL;
 	zval *num_param = NULL, _0, *_1 = NULL;
 	int num, ZEPHIR_LAST_CALL_STATUS;
 
@@ -115,7 +115,7 @@ PHP_METHOD(Test_BuiltIn_IntMethods, getOctal) {
 
 	ZEPHIR_SINIT_VAR(_0);
 	ZVAL_LONG(&_0, num);
-	ZEPHIR_CALL_FUNCTION(&_1, "decoct", &_2, &_0);
+	ZEPHIR_CALL_FUNCTION(&_1, "decoct", &_2, 8, &_0);
 	zephir_check_call_status();
 	RETURN_CCTOR(_1);
 
@@ -145,7 +145,7 @@ PHP_METHOD(Test_BuiltIn_IntMethods, getPow) {
 
 PHP_METHOD(Test_BuiltIn_IntMethods, getSqrt) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL;
 	zval *num_param = NULL, _0, *_1 = NULL;
 	int num, ZEPHIR_LAST_CALL_STATUS;
 
@@ -157,7 +157,7 @@ PHP_METHOD(Test_BuiltIn_IntMethods, getSqrt) {
 
 	ZEPHIR_SINIT_VAR(_0);
 	ZVAL_LONG(&_0, num);
-	ZEPHIR_CALL_FUNCTION(&_1, "sqrt", &_2, &_0);
+	ZEPHIR_CALL_FUNCTION(&_1, "sqrt", &_2, 9, &_0);
 	zephir_check_call_status();
 	RETURN_CCTOR(_1);
 
@@ -165,7 +165,7 @@ PHP_METHOD(Test_BuiltIn_IntMethods, getSqrt) {
 
 PHP_METHOD(Test_BuiltIn_IntMethods, getExp) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL;
 	zval *num_param = NULL, _0, *_1 = NULL;
 	int num, ZEPHIR_LAST_CALL_STATUS;
 
@@ -177,7 +177,7 @@ PHP_METHOD(Test_BuiltIn_IntMethods, getExp) {
 
 	ZEPHIR_SINIT_VAR(_0);
 	ZVAL_LONG(&_0, num);
-	ZEPHIR_CALL_FUNCTION(&_1, "exp", &_2, &_0);
+	ZEPHIR_CALL_FUNCTION(&_1, "exp", &_2, 1, &_0);
 	zephir_check_call_status();
 	RETURN_CCTOR(_1);
 
@@ -185,7 +185,7 @@ PHP_METHOD(Test_BuiltIn_IntMethods, getExp) {
 
 PHP_METHOD(Test_BuiltIn_IntMethods, getSin) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL;
 	zval *num_param = NULL, _0, *_1 = NULL;
 	int num, ZEPHIR_LAST_CALL_STATUS;
 
@@ -197,7 +197,7 @@ PHP_METHOD(Test_BuiltIn_IntMethods, getSin) {
 
 	ZEPHIR_SINIT_VAR(_0);
 	ZVAL_LONG(&_0, num);
-	ZEPHIR_CALL_FUNCTION(&_1, "sin", &_2, &_0);
+	ZEPHIR_CALL_FUNCTION(&_1, "sin", &_2, 10, &_0);
 	zephir_check_call_status();
 	RETURN_CCTOR(_1);
 
@@ -205,7 +205,7 @@ PHP_METHOD(Test_BuiltIn_IntMethods, getSin) {
 
 PHP_METHOD(Test_BuiltIn_IntMethods, getCos) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL;
 	zval *num_param = NULL, _0, *_1 = NULL;
 	int num, ZEPHIR_LAST_CALL_STATUS;
 
@@ -217,7 +217,7 @@ PHP_METHOD(Test_BuiltIn_IntMethods, getCos) {
 
 	ZEPHIR_SINIT_VAR(_0);
 	ZVAL_LONG(&_0, num);
-	ZEPHIR_CALL_FUNCTION(&_1, "cos", &_2, &_0);
+	ZEPHIR_CALL_FUNCTION(&_1, "cos", &_2, 11, &_0);
 	zephir_check_call_status();
 	RETURN_CCTOR(_1);
 
@@ -225,7 +225,7 @@ PHP_METHOD(Test_BuiltIn_IntMethods, getCos) {
 
 PHP_METHOD(Test_BuiltIn_IntMethods, getTan) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL;
 	zval *num_param = NULL, _0, *_1 = NULL;
 	int num, ZEPHIR_LAST_CALL_STATUS;
 
@@ -237,7 +237,7 @@ PHP_METHOD(Test_BuiltIn_IntMethods, getTan) {
 
 	ZEPHIR_SINIT_VAR(_0);
 	ZVAL_LONG(&_0, num);
-	ZEPHIR_CALL_FUNCTION(&_1, "tan", &_2, &_0);
+	ZEPHIR_CALL_FUNCTION(&_1, "tan", &_2, 12, &_0);
 	zephir_check_call_status();
 	RETURN_CCTOR(_1);
 
@@ -245,7 +245,7 @@ PHP_METHOD(Test_BuiltIn_IntMethods, getTan) {
 
 PHP_METHOD(Test_BuiltIn_IntMethods, getAsin) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL;
 	zval *num_param = NULL, _0, *_1 = NULL;
 	int num, ZEPHIR_LAST_CALL_STATUS;
 
@@ -257,7 +257,7 @@ PHP_METHOD(Test_BuiltIn_IntMethods, getAsin) {
 
 	ZEPHIR_SINIT_VAR(_0);
 	ZVAL_LONG(&_0, num);
-	ZEPHIR_CALL_FUNCTION(&_1, "asin", &_2, &_0);
+	ZEPHIR_CALL_FUNCTION(&_1, "asin", &_2, 13, &_0);
 	zephir_check_call_status();
 	RETURN_CCTOR(_1);
 
@@ -265,7 +265,7 @@ PHP_METHOD(Test_BuiltIn_IntMethods, getAsin) {
 
 PHP_METHOD(Test_BuiltIn_IntMethods, getAcos) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL;
 	zval *num_param = NULL, _0, *_1 = NULL;
 	int num, ZEPHIR_LAST_CALL_STATUS;
 
@@ -277,7 +277,7 @@ PHP_METHOD(Test_BuiltIn_IntMethods, getAcos) {
 
 	ZEPHIR_SINIT_VAR(_0);
 	ZVAL_LONG(&_0, num);
-	ZEPHIR_CALL_FUNCTION(&_1, "acos", &_2, &_0);
+	ZEPHIR_CALL_FUNCTION(&_1, "acos", &_2, 14, &_0);
 	zephir_check_call_status();
 	RETURN_CCTOR(_1);
 
@@ -285,7 +285,7 @@ PHP_METHOD(Test_BuiltIn_IntMethods, getAcos) {
 
 PHP_METHOD(Test_BuiltIn_IntMethods, getAtan) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL;
 	zval *num_param = NULL, _0, *_1 = NULL;
 	int num, ZEPHIR_LAST_CALL_STATUS;
 
@@ -297,7 +297,7 @@ PHP_METHOD(Test_BuiltIn_IntMethods, getAtan) {
 
 	ZEPHIR_SINIT_VAR(_0);
 	ZVAL_LONG(&_0, num);
-	ZEPHIR_CALL_FUNCTION(&_1, "atan", &_2, &_0);
+	ZEPHIR_CALL_FUNCTION(&_1, "atan", &_2, 15, &_0);
 	zephir_check_call_status();
 	RETURN_CCTOR(_1);
 
@@ -305,7 +305,7 @@ PHP_METHOD(Test_BuiltIn_IntMethods, getAtan) {
 
 PHP_METHOD(Test_BuiltIn_IntMethods, getLog) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL;
 	zval *num_param = NULL, *base_param = NULL, _0 = zval_used_for_init, *_1 = NULL, _3;
 	int num, base, ZEPHIR_LAST_CALL_STATUS;
 
@@ -323,7 +323,7 @@ PHP_METHOD(Test_BuiltIn_IntMethods, getLog) {
 	if (base == -1) {
 		ZEPHIR_SINIT_VAR(_0);
 		ZVAL_LONG(&_0, num);
-		ZEPHIR_CALL_FUNCTION(&_1, "log", &_2, &_0);
+		ZEPHIR_CALL_FUNCTION(&_1, "log", &_2, 16, &_0);
 		zephir_check_call_status();
 		RETURN_CCTOR(_1);
 	}
@@ -331,7 +331,7 @@ PHP_METHOD(Test_BuiltIn_IntMethods, getLog) {
 	ZVAL_LONG(&_0, num);
 	ZEPHIR_SINIT_VAR(_3);
 	ZVAL_LONG(&_3, base);
-	ZEPHIR_CALL_FUNCTION(&_1, "log", &_2, &_0, &_3);
+	ZEPHIR_CALL_FUNCTION(&_1, "log", &_2, 16, &_0, &_3);
 	zephir_check_call_status();
 	RETURN_CCTOR(_1);
 

--- a/ext/test/builtin/stringmethods.zep.c
+++ b/ext/test/builtin/stringmethods.zep.c
@@ -235,7 +235,7 @@ PHP_METHOD(Test_BuiltIn_StringMethods, getUpper) {
 PHP_METHOD(Test_BuiltIn_StringMethods, getLowerFirst) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_1 = NULL;
+	zephir_fcall_cache_entry *_1 = NULL;
 	zval *str_param = NULL, *_0 = NULL;
 	zval *str = NULL;
 
@@ -245,7 +245,7 @@ PHP_METHOD(Test_BuiltIn_StringMethods, getLowerFirst) {
 	zephir_get_strval(str, str_param);
 
 
-	ZEPHIR_CALL_FUNCTION(&_0, "lcfirst", &_1, str);
+	ZEPHIR_CALL_FUNCTION(&_0, "lcfirst", &_1, 17, str);
 	zephir_check_call_status();
 	RETURN_CCTOR(_0);
 
@@ -271,7 +271,7 @@ PHP_METHOD(Test_BuiltIn_StringMethods, getUpperFirst) {
 PHP_METHOD(Test_BuiltIn_StringMethods, getFormatted) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL;
 	zval *str_param = NULL, _0, *_1 = NULL;
 	zval *str = NULL;
 
@@ -283,7 +283,7 @@ PHP_METHOD(Test_BuiltIn_StringMethods, getFormatted) {
 
 	ZEPHIR_SINIT_VAR(_0);
 	ZVAL_STRING(&_0, "hello %s!", 0);
-	ZEPHIR_CALL_FUNCTION(&_1, "sprintf", &_2, &_0, str);
+	ZEPHIR_CALL_FUNCTION(&_1, "sprintf", &_2, 4, &_0, str);
 	zephir_check_call_status();
 	RETURN_CCTOR(_1);
 
@@ -309,7 +309,7 @@ PHP_METHOD(Test_BuiltIn_StringMethods, getMd5) {
 PHP_METHOD(Test_BuiltIn_StringMethods, getSha1) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_1 = NULL;
+	zephir_fcall_cache_entry *_1 = NULL;
 	zval *str_param = NULL, *_0 = NULL;
 	zval *str = NULL;
 
@@ -319,7 +319,7 @@ PHP_METHOD(Test_BuiltIn_StringMethods, getSha1) {
 	zephir_get_strval(str, str_param);
 
 
-	ZEPHIR_CALL_FUNCTION(&_0, "sha1", &_1, str);
+	ZEPHIR_CALL_FUNCTION(&_0, "sha1", &_1, 18, str);
 	zephir_check_call_status();
 	RETURN_CCTOR(_0);
 
@@ -328,7 +328,7 @@ PHP_METHOD(Test_BuiltIn_StringMethods, getSha1) {
 PHP_METHOD(Test_BuiltIn_StringMethods, getNl2br) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_1 = NULL;
+	zephir_fcall_cache_entry *_1 = NULL;
 	zval *str_param = NULL, *_0 = NULL;
 	zval *str = NULL;
 
@@ -338,7 +338,7 @@ PHP_METHOD(Test_BuiltIn_StringMethods, getNl2br) {
 	zephir_get_strval(str, str_param);
 
 
-	ZEPHIR_CALL_FUNCTION(&_0, "nl2br", &_1, str);
+	ZEPHIR_CALL_FUNCTION(&_0, "nl2br", &_1, 19, str);
 	zephir_check_call_status();
 	RETURN_CCTOR(_0);
 
@@ -347,7 +347,7 @@ PHP_METHOD(Test_BuiltIn_StringMethods, getNl2br) {
 PHP_METHOD(Test_BuiltIn_StringMethods, getParsedCsv) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_1 = NULL;
+	zephir_fcall_cache_entry *_1 = NULL;
 	zval *str_param = NULL, *_0 = NULL;
 	zval *str = NULL;
 
@@ -357,7 +357,7 @@ PHP_METHOD(Test_BuiltIn_StringMethods, getParsedCsv) {
 	zephir_get_strval(str, str_param);
 
 
-	ZEPHIR_CALL_FUNCTION(&_0, "str_getcsv", &_1, str);
+	ZEPHIR_CALL_FUNCTION(&_0, "str_getcsv", &_1, 20, str);
 	zephir_check_call_status();
 	RETURN_CCTOR(_0);
 
@@ -388,7 +388,7 @@ PHP_METHOD(Test_BuiltIn_StringMethods, getParsedJson) {
 
 PHP_METHOD(Test_BuiltIn_StringMethods, getRepeatted) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL;
 	int count, ZEPHIR_LAST_CALL_STATUS;
 	zval *str_param = NULL, *count_param = NULL, _0, *_1 = NULL;
 	zval *str = NULL;
@@ -402,7 +402,7 @@ PHP_METHOD(Test_BuiltIn_StringMethods, getRepeatted) {
 
 	ZEPHIR_SINIT_VAR(_0);
 	ZVAL_LONG(&_0, count);
-	ZEPHIR_CALL_FUNCTION(&_1, "str_repeat", &_2, str, &_0);
+	ZEPHIR_CALL_FUNCTION(&_1, "str_repeat", &_2, 21, str, &_0);
 	zephir_check_call_status();
 	RETURN_CCTOR(_1);
 
@@ -411,7 +411,7 @@ PHP_METHOD(Test_BuiltIn_StringMethods, getRepeatted) {
 PHP_METHOD(Test_BuiltIn_StringMethods, getShuffled) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_1 = NULL;
+	zephir_fcall_cache_entry *_1 = NULL;
 	zval *str_param = NULL, *_0 = NULL;
 	zval *str = NULL;
 
@@ -421,7 +421,7 @@ PHP_METHOD(Test_BuiltIn_StringMethods, getShuffled) {
 	zephir_get_strval(str, str_param);
 
 
-	ZEPHIR_CALL_FUNCTION(&_0, "str_shuffle", &_1, str);
+	ZEPHIR_CALL_FUNCTION(&_0, "str_shuffle", &_1, 22, str);
 	zephir_check_call_status();
 	RETURN_CCTOR(_0);
 
@@ -430,7 +430,7 @@ PHP_METHOD(Test_BuiltIn_StringMethods, getShuffled) {
 PHP_METHOD(Test_BuiltIn_StringMethods, getSplited) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_1 = NULL;
+	zephir_fcall_cache_entry *_1 = NULL;
 	zval *str_param = NULL, *del_param = NULL, *_0 = NULL;
 	zval *str = NULL, *del = NULL;
 
@@ -441,7 +441,7 @@ PHP_METHOD(Test_BuiltIn_StringMethods, getSplited) {
 	zephir_get_strval(del, del_param);
 
 
-	ZEPHIR_CALL_FUNCTION(&_0, "str_split", &_1, str, del);
+	ZEPHIR_CALL_FUNCTION(&_0, "str_split", &_1, 23, str, del);
 	zephir_check_call_status();
 	RETURN_CCTOR(_0);
 
@@ -450,7 +450,7 @@ PHP_METHOD(Test_BuiltIn_StringMethods, getSplited) {
 PHP_METHOD(Test_BuiltIn_StringMethods, getCompare) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_1 = NULL;
+	zephir_fcall_cache_entry *_1 = NULL;
 	zval *left_param = NULL, *right_param = NULL, *_0 = NULL;
 	zval *left = NULL, *right = NULL;
 
@@ -461,7 +461,7 @@ PHP_METHOD(Test_BuiltIn_StringMethods, getCompare) {
 	zephir_get_strval(right, right_param);
 
 
-	ZEPHIR_CALL_FUNCTION(&_0, "strcmp", &_1, left, right);
+	ZEPHIR_CALL_FUNCTION(&_0, "strcmp", &_1, 24, left, right);
 	zephir_check_call_status();
 	RETURN_CCTOR(_0);
 
@@ -470,7 +470,7 @@ PHP_METHOD(Test_BuiltIn_StringMethods, getCompare) {
 PHP_METHOD(Test_BuiltIn_StringMethods, getCompareLocale) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_1 = NULL;
+	zephir_fcall_cache_entry *_1 = NULL;
 	zval *left_param = NULL, *right_param = NULL, *_0 = NULL;
 	zval *left = NULL, *right = NULL;
 
@@ -481,7 +481,7 @@ PHP_METHOD(Test_BuiltIn_StringMethods, getCompareLocale) {
 	zephir_get_strval(right, right_param);
 
 
-	ZEPHIR_CALL_FUNCTION(&_0, "strcoll", &_1, left, right);
+	ZEPHIR_CALL_FUNCTION(&_0, "strcoll", &_1, 25, left, right);
 	zephir_check_call_status();
 	RETURN_CCTOR(_0);
 
@@ -490,7 +490,7 @@ PHP_METHOD(Test_BuiltIn_StringMethods, getCompareLocale) {
 PHP_METHOD(Test_BuiltIn_StringMethods, getReversed) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_1 = NULL;
+	zephir_fcall_cache_entry *_1 = NULL;
 	zval *str_param = NULL, *_0 = NULL;
 	zval *str = NULL;
 
@@ -500,7 +500,7 @@ PHP_METHOD(Test_BuiltIn_StringMethods, getReversed) {
 	zephir_get_strval(str, str_param);
 
 
-	ZEPHIR_CALL_FUNCTION(&_0, "strrev", &_1, str);
+	ZEPHIR_CALL_FUNCTION(&_0, "strrev", &_1, 26, str);
 	zephir_check_call_status();
 	RETURN_CCTOR(_0);
 
@@ -509,7 +509,7 @@ PHP_METHOD(Test_BuiltIn_StringMethods, getReversed) {
 PHP_METHOD(Test_BuiltIn_StringMethods, getHtmlSpecialChars) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_1 = NULL;
+	zephir_fcall_cache_entry *_1 = NULL;
 	zval *str_param = NULL, *_0 = NULL;
 	zval *str = NULL;
 
@@ -519,7 +519,7 @@ PHP_METHOD(Test_BuiltIn_StringMethods, getHtmlSpecialChars) {
 	zephir_get_strval(str, str_param);
 
 
-	ZEPHIR_CALL_FUNCTION(&_0, "htmlspecialchars", &_1, str);
+	ZEPHIR_CALL_FUNCTION(&_0, "htmlspecialchars", &_1, 27, str);
 	zephir_check_call_status();
 	RETURN_CCTOR(_0);
 

--- a/ext/test/constants.zep.c
+++ b/ext/test/constants.zep.c
@@ -50,6 +50,8 @@ ZEPHIR_INIT_CLASS(Test_Constants) {
 
 	zend_declare_class_constant_string(test_constants_ce, SL("className"), "Test\\Constants" TSRMLS_CC);
 
+	zend_declare_class_constant_long(test_constants_ce, SL("STD_PROP_LIST"), 1 TSRMLS_CC);
+
 	/**
 	 * Test property addSlashes for constants
 	 */

--- a/ext/test/exceptions.zep.c
+++ b/ext/test/exceptions.zep.c
@@ -46,7 +46,7 @@ PHP_METHOD(Test_Exceptions, testExceptionStringEscape) {
 
 PHP_METHOD(Test_Exceptions, testException2) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_1 = NULL;
+	zephir_fcall_cache_entry *_1 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
 	zval *msg, *_0;
 
@@ -56,7 +56,7 @@ PHP_METHOD(Test_Exceptions, testException2) {
 	ZVAL_STRING(msg, "hello2", 1);
 	ZEPHIR_INIT_VAR(_0);
 	object_init_ex(_0, test_exception_ce);
-	ZEPHIR_CALL_METHOD(NULL, _0, "__construct", &_1, msg);
+	ZEPHIR_CALL_METHOD(NULL, _0, "__construct", &_1, 28, msg);
 	zephir_check_call_status();
 	zephir_throw_exception_debug(_0, "test/exceptions.zep", 20 TSRMLS_CC);
 	ZEPHIR_MM_RESTORE();
@@ -66,7 +66,7 @@ PHP_METHOD(Test_Exceptions, testException2) {
 
 PHP_METHOD(Test_Exceptions, testException3) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL;
+	zephir_fcall_cache_entry *_0 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
 	zval *ex, *msg;
 
@@ -76,7 +76,7 @@ PHP_METHOD(Test_Exceptions, testException3) {
 	ZVAL_STRING(msg, "hello3", 1);
 	ZEPHIR_INIT_VAR(ex);
 	object_init_ex(ex, test_exception_ce);
-	ZEPHIR_CALL_METHOD(NULL, ex, "__construct", &_0, msg);
+	ZEPHIR_CALL_METHOD(NULL, ex, "__construct", &_0, 28, msg);
 	zephir_check_call_status();
 	zephir_throw_exception_debug(ex, "test/exceptions.zep", 28 TSRMLS_CC);
 	ZEPHIR_MM_RESTORE();
@@ -86,7 +86,7 @@ PHP_METHOD(Test_Exceptions, testException3) {
 
 PHP_METHOD(Test_Exceptions, getException) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_1 = NULL;
+	zephir_fcall_cache_entry *_1 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
 	zval *_0;
 
@@ -95,7 +95,7 @@ PHP_METHOD(Test_Exceptions, getException) {
 	object_init_ex(return_value, test_exception_ce);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_STRING(_0, "hello4", ZEPHIR_TEMP_PARAM_COPY);
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", &_1, _0);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", &_1, 28, _0);
 	zephir_check_temp_parameter(_0);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -109,7 +109,7 @@ PHP_METHOD(Test_Exceptions, testException4) {
 
 	ZEPHIR_MM_GROW();
 
-	ZEPHIR_CALL_METHOD(&_0, this_ptr, "getexception", NULL);
+	ZEPHIR_CALL_METHOD(&_0, this_ptr, "getexception", NULL, 0);
 	zephir_check_call_status();
 	zephir_throw_exception_debug(_0, "test/exceptions.zep", 38 TSRMLS_CC);
 	ZEPHIR_MM_RESTORE();
@@ -119,7 +119,7 @@ PHP_METHOD(Test_Exceptions, testException4) {
 
 PHP_METHOD(Test_Exceptions, testException5) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_1 = NULL;
+	zephir_fcall_cache_entry *_1 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
 	zval *exception, *_0;
 
@@ -129,7 +129,7 @@ PHP_METHOD(Test_Exceptions, testException5) {
 	object_init_ex(exception, test_exception_ce);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_STRING(_0, "hello5", ZEPHIR_TEMP_PARAM_COPY);
-	ZEPHIR_CALL_METHOD(NULL, exception, "__construct", &_1, _0);
+	ZEPHIR_CALL_METHOD(NULL, exception, "__construct", &_1, 28, _0);
 	zephir_check_temp_parameter(_0);
 	zephir_check_call_status();
 	zephir_throw_exception_debug(exception, "test/exceptions.zep", 46 TSRMLS_CC);
@@ -175,7 +175,7 @@ PHP_METHOD(Test_Exceptions, testExceptionLiteral) {
 PHP_METHOD(Test_Exceptions, testExceptionSprintf) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL;
 	zval *name_param = NULL, _0, *_1 = NULL;
 	zval *name = NULL;
 
@@ -187,7 +187,7 @@ PHP_METHOD(Test_Exceptions, testExceptionSprintf) {
 
 	ZEPHIR_SINIT_VAR(_0);
 	ZVAL_STRING(&_0, "Hello, %s", 0);
-	ZEPHIR_CALL_FUNCTION(&_1, "sprintf", &_2, &_0, name);
+	ZEPHIR_CALL_FUNCTION(&_1, "sprintf", &_2, 4, &_0, name);
 	zephir_check_call_status();
 	zephir_throw_exception_debug(_1, "test/exceptions.zep", 65 TSRMLS_CC);
 	ZEPHIR_MM_RESTORE();
@@ -225,7 +225,7 @@ PHP_METHOD(Test_Exceptions, testExceptionRethrow) {
 
 	/* try_start_1: */
 
-		ZEPHIR_CALL_METHOD(NULL, this_ptr, "testexception1", NULL);
+		ZEPHIR_CALL_METHOD(NULL, this_ptr, "testexception1", NULL, 0);
 		zephir_check_call_status_or_jump(try_end_1);
 
 	try_end_1:

--- a/ext/test/factorial.zep.c
+++ b/ext/test/factorial.zep.c
@@ -60,7 +60,7 @@ PHP_METHOD(Test_Factorial, intIterativeFactorial) {
 
 PHP_METHOD(Test_Factorial, intRecursiveFactorial) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_4 = NULL;
+	zephir_fcall_cache_entry *_4 = NULL;
 	zend_bool _1;
 	zval *num_param = NULL, *_0, *_2 = NULL, _3;
 	int num, ZEPHIR_LAST_CALL_STATUS;
@@ -81,7 +81,7 @@ PHP_METHOD(Test_Factorial, intRecursiveFactorial) {
 	} else {
 		ZEPHIR_SINIT_VAR(_3);
 		ZVAL_LONG(&_3, (num - 1));
-		ZEPHIR_CALL_METHOD(&_2, this_ptr, "intrecursivefactorial", &_4, &_3);
+		ZEPHIR_CALL_METHOD(&_2, this_ptr, "intrecursivefactorial", &_4, 29, &_3);
 		zephir_check_call_status();
 		ZVAL_LONG(_0, (num * zephir_get_numberval(_2)));
 	}

--- a/ext/test/fasta.zep.c
+++ b/ext/test/fasta.zep.c
@@ -166,7 +166,7 @@ PHP_METHOD(Test_Fasta, main) {
 	php_printf("%s", ">ONE Homo sapiens alu");
 	ZEPHIR_INIT_VAR(_1);
 	ZVAL_LONG(_1, (2 * zephir_get_numberval(n)));
-	ZEPHIR_CALL_METHOD(NULL, this_ptr, "fastarepeat", NULL, _1, alu);
+	ZEPHIR_CALL_METHOD(NULL, this_ptr, "fastarepeat", NULL, 0, _1, alu);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();
 

--- a/ext/test/fcall.zep.c
+++ b/ext/test/fcall.zep.c
@@ -48,7 +48,7 @@ PHP_METHOD(Test_Fcall, testCall1) {
 PHP_METHOD(Test_Fcall, testCall2) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL;
 	zval _0 = zval_used_for_init, _1 = zval_used_for_init;
 
 	ZEPHIR_MM_GROW();
@@ -58,7 +58,7 @@ PHP_METHOD(Test_Fcall, testCall2) {
 		ZVAL_LONG(&_0, 0);
 		ZEPHIR_SINIT_NVAR(_1);
 		ZVAL_LONG(&_1, 100);
-		ZEPHIR_RETURN_CALL_FUNCTION("mt_rand", &_2, &_0, &_1);
+		ZEPHIR_RETURN_CALL_FUNCTION("mt_rand", &_2, 30, &_0, &_1);
 		zephir_check_call_status();
 		RETURN_MM();
 	}
@@ -68,7 +68,7 @@ PHP_METHOD(Test_Fcall, testCall2) {
 PHP_METHOD(Test_Fcall, testCall3) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL, *_3 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL, *_3 = NULL;
 	zval *handle = NULL, *handle2 = NULL, *buffer = NULL, _0 = zval_used_for_init, _1 = zval_used_for_init;
 
 	ZEPHIR_MM_GROW();
@@ -77,19 +77,19 @@ PHP_METHOD(Test_Fcall, testCall3) {
 	ZVAL_STRING(&_0, "inputfile.txt", 0);
 	ZEPHIR_SINIT_VAR(_1);
 	ZVAL_STRING(&_1, "r", 0);
-	ZEPHIR_CALL_FUNCTION(&handle, "fopen", &_2, &_0, &_1);
+	ZEPHIR_CALL_FUNCTION(&handle, "fopen", &_2, 31, &_0, &_1);
 	zephir_check_call_status();
 	ZEPHIR_SINIT_NVAR(_0);
 	ZVAL_STRING(&_0, "outputfile.txt", 0);
 	ZEPHIR_SINIT_NVAR(_1);
 	ZVAL_STRING(&_1, "w", 0);
-	ZEPHIR_CALL_FUNCTION(&handle2, "fopen", &_2, &_0, &_1);
+	ZEPHIR_CALL_FUNCTION(&handle2, "fopen", &_2, 31, &_0, &_1);
 	zephir_check_call_status();
 	if (zephir_is_true(handle)) {
 		while (1) {
 			ZEPHIR_SINIT_NVAR(_0);
 			ZVAL_LONG(&_0, 4096);
-			ZEPHIR_CALL_FUNCTION(&buffer, "fgets", &_3, handle, &_0);
+			ZEPHIR_CALL_FUNCTION(&buffer, "fgets", &_3, 32, handle, &_0);
 			zephir_check_call_status();
 			if (ZEPHIR_IS_FALSE_IDENTICAL(buffer)) {
 				break;
@@ -106,7 +106,7 @@ PHP_METHOD(Test_Fcall, testCall3) {
 PHP_METHOD(Test_Fcall, testCall4) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL, *_3 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL, *_3 = NULL;
 	zval *handle = NULL, *handle2 = NULL, *buffer = NULL, _0 = zval_used_for_init, _1 = zval_used_for_init;
 
 	ZEPHIR_MM_GROW();
@@ -115,19 +115,19 @@ PHP_METHOD(Test_Fcall, testCall4) {
 	ZVAL_STRING(&_0, "r", 0);
 	ZEPHIR_SINIT_VAR(_1);
 	ZVAL_STRING(&_1, "inputfile.txt", 0);
-	ZEPHIR_CALL_FUNCTION(&handle, "fopen", &_2, &_0, &_1);
+	ZEPHIR_CALL_FUNCTION(&handle, "fopen", &_2, 31, &_0, &_1);
 	zephir_check_call_status();
 	ZEPHIR_SINIT_NVAR(_0);
 	ZVAL_STRING(&_0, "outputfile.txt", 0);
 	ZEPHIR_SINIT_NVAR(_1);
 	ZVAL_STRING(&_1, "w", 0);
-	ZEPHIR_CALL_FUNCTION(&handle2, "fopen", &_2, &_0, &_1);
+	ZEPHIR_CALL_FUNCTION(&handle2, "fopen", &_2, 31, &_0, &_1);
 	zephir_check_call_status();
 	if (zephir_is_true(handle)) {
 		while (1) {
 			ZEPHIR_SINIT_NVAR(_0);
 			ZVAL_LONG(&_0, 4096);
-			ZEPHIR_CALL_FUNCTION(&buffer, "fgets", &_3, handle, &_0);
+			ZEPHIR_CALL_FUNCTION(&buffer, "fgets", &_3, 32, handle, &_0);
 			zephir_check_call_status();
 			if (ZEPHIR_IS_FALSE_IDENTICAL(buffer)) {
 				break;
@@ -144,7 +144,7 @@ PHP_METHOD(Test_Fcall, testCall4) {
 PHP_METHOD(Test_Fcall, testCall5) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL;
+	zephir_fcall_cache_entry *_0 = NULL;
 	zval *a, *b;
 
 	ZEPHIR_MM_GROW();
@@ -152,7 +152,7 @@ PHP_METHOD(Test_Fcall, testCall5) {
 
 
 
-	ZEPHIR_RETURN_CALL_FUNCTION("str_repeat", &_0, a, b);
+	ZEPHIR_RETURN_CALL_FUNCTION("str_repeat", &_0, 21, a, b);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -161,11 +161,11 @@ PHP_METHOD(Test_Fcall, testCall5) {
 PHP_METHOD(Test_Fcall, testCall6) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL;
+	zephir_fcall_cache_entry *_0 = NULL;
 
 	ZEPHIR_MM_GROW();
 
-	ZEPHIR_RETURN_CALL_FUNCTION("rand", &_0);
+	ZEPHIR_RETURN_CALL_FUNCTION("rand", &_0, 33);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -174,11 +174,11 @@ PHP_METHOD(Test_Fcall, testCall6) {
 PHP_METHOD(Test_Fcall, testCall7) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL;
+	zephir_fcall_cache_entry *_0 = NULL;
 
 	ZEPHIR_MM_GROW();
 
-	ZEPHIR_CALL_FUNCTION(NULL, "memory_get_usage", &_0);
+	ZEPHIR_CALL_FUNCTION(NULL, "memory_get_usage", &_0, 34);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();
 
@@ -187,7 +187,7 @@ PHP_METHOD(Test_Fcall, testCall7) {
 PHP_METHOD(Test_Fcall, testCall8) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL;
+	zephir_fcall_cache_entry *_0 = NULL;
 	zval *a, *b, *x = NULL;
 
 	ZEPHIR_MM_GROW();
@@ -195,7 +195,7 @@ PHP_METHOD(Test_Fcall, testCall8) {
 
 
 
-	ZEPHIR_CALL_FUNCTION(&x, "str_repeat", &_0, a, b);
+	ZEPHIR_CALL_FUNCTION(&x, "str_repeat", &_0, 21, a, b);
 	zephir_check_call_status();
 	RETURN_CCTOR(x);
 
@@ -214,7 +214,7 @@ PHP_METHOD(Test_Fcall, testCall1FromVar) {
 	ZVAL_STRING(_0, "hello", ZEPHIR_TEMP_PARAM_COPY);
 	ZEPHIR_INIT_VAR(_1);
 	ZVAL_STRING(_1, "l", ZEPHIR_TEMP_PARAM_COPY);
-	ZEPHIR_RETURN_CALL_ZVAL_FUNCTION(funcName, NULL, _0, _1);
+	ZEPHIR_RETURN_CALL_ZVAL_FUNCTION(funcName, NULL, 0, _0, _1);
 	zephir_check_temp_parameter(_0);
 	zephir_check_temp_parameter(_1);
 	zephir_check_call_status();
@@ -232,7 +232,7 @@ PHP_METHOD(Test_Fcall, testStrtokFalse) {
 PHP_METHOD(Test_Fcall, testStrtokVarBySlash) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_1 = NULL;
+	zephir_fcall_cache_entry *_1 = NULL;
 	zval *value, _0;
 
 	ZEPHIR_MM_GROW();
@@ -242,7 +242,7 @@ PHP_METHOD(Test_Fcall, testStrtokVarBySlash) {
 
 	ZEPHIR_SINIT_VAR(_0);
 	ZVAL_STRING(&_0, "/", 0);
-	ZEPHIR_RETURN_CALL_FUNCTION("strtok", &_1, value, &_0);
+	ZEPHIR_RETURN_CALL_FUNCTION("strtok", &_1, 35, value, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -251,7 +251,7 @@ PHP_METHOD(Test_Fcall, testStrtokVarBySlash) {
 PHP_METHOD(Test_Fcall, testFunctionGetArgs) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL;
+	zephir_fcall_cache_entry *_0 = NULL;
 	zval *param1, *param2;
 
 	ZEPHIR_MM_GROW();
@@ -259,7 +259,7 @@ PHP_METHOD(Test_Fcall, testFunctionGetArgs) {
 
 
 
-	ZEPHIR_RETURN_CALL_FUNCTION("func_get_args", &_0);
+	ZEPHIR_RETURN_CALL_FUNCTION("func_get_args", &_0, 36);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -268,7 +268,7 @@ PHP_METHOD(Test_Fcall, testFunctionGetArgs) {
 PHP_METHOD(Test_Fcall, testArrayFill) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_3 = NULL;
+	zephir_fcall_cache_entry *_3 = NULL;
 	zval *v1 = NULL, *v2 = NULL, *_0 = NULL, *_1 = NULL, *_2 = NULL;
 
 	ZEPHIR_MM_GROW();
@@ -279,7 +279,7 @@ PHP_METHOD(Test_Fcall, testArrayFill) {
 	ZVAL_LONG(_1, 5);
 	ZEPHIR_INIT_VAR(_2);
 	ZVAL_STRING(_2, "?", ZEPHIR_TEMP_PARAM_COPY);
-	ZEPHIR_CALL_FUNCTION(&v1, "array_fill", &_3, _0, _1, _2);
+	ZEPHIR_CALL_FUNCTION(&v1, "array_fill", &_3, 37, _0, _1, _2);
 	zephir_check_temp_parameter(_2);
 	zephir_check_call_status();
 	ZEPHIR_INIT_NVAR(_0);
@@ -288,7 +288,7 @@ PHP_METHOD(Test_Fcall, testArrayFill) {
 	ZVAL_LONG(_1, 6);
 	ZEPHIR_INIT_NVAR(_2);
 	ZVAL_STRING(_2, "?", ZEPHIR_TEMP_PARAM_COPY);
-	ZEPHIR_CALL_FUNCTION(&v2, "array_fill", &_3, _0, _1, _2);
+	ZEPHIR_CALL_FUNCTION(&v2, "array_fill", &_3, 37, _0, _1, _2);
 	zephir_check_temp_parameter(_2);
 	zephir_check_call_status();
 	zephir_create_array(return_value, 2, 0 TSRMLS_CC);
@@ -299,7 +299,7 @@ PHP_METHOD(Test_Fcall, testArrayFill) {
 }
 
 PHP_FUNCTION(g_test_zephir_global_method_test) {
-	zephir_nts_static zephir_fcall_cache_entry *_1 = NULL;
+	zephir_fcall_cache_entry *_1 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
 	zval *str, *_0;
 
@@ -311,17 +311,17 @@ PHP_FUNCTION(g_test_zephir_global_method_test) {
 	ZEPHIR_INIT_VAR(_0);
 	object_init_ex(_0, test_fcall_ce);
 	if (zephir_has_constructor(_0 TSRMLS_CC)) {
-		ZEPHIR_CALL_METHOD(NULL, _0, "__construct", NULL);
+		ZEPHIR_CALL_METHOD(NULL, _0, "__construct", NULL, 0);
 		zephir_check_call_status();
 	}
-	ZEPHIR_RETURN_CALL_METHOD(_0, "teststrtokvarbyslash", &_1, str);
+	ZEPHIR_RETURN_CALL_METHOD(_0, "teststrtokvarbyslash", &_1, 38, str);
 	zephir_check_call_status();
 	RETURN_MM();
 
 }
 
 PHP_FUNCTION(f_Test_zephir_namespaced_method_test) {
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
 	zval *str, *_0, *_1;
 
@@ -333,12 +333,12 @@ PHP_FUNCTION(f_Test_zephir_namespaced_method_test) {
 	ZEPHIR_INIT_VAR(_0);
 	object_init_ex(_0, test_fcall_ce);
 	if (zephir_has_constructor(_0 TSRMLS_CC)) {
-		ZEPHIR_CALL_METHOD(NULL, _0, "__construct", NULL);
+		ZEPHIR_CALL_METHOD(NULL, _0, "__construct", NULL, 0);
 		zephir_check_call_status();
 	}
 	ZEPHIR_INIT_VAR(_1);
 	ZVAL_LONG(_1, 5);
-	ZEPHIR_RETURN_CALL_METHOD(_0, "testcall5", &_2, str, _1);
+	ZEPHIR_RETURN_CALL_METHOD(_0, "testcall5", &_2, 39, str, _1);
 	zephir_check_call_status();
 	RETURN_MM();
 

--- a/ext/test/fibonnaci.zep.c
+++ b/ext/test/fibonnaci.zep.c
@@ -136,7 +136,7 @@ PHP_METHOD(Test_Fibonnaci, fibArray2) {
 
 PHP_METHOD(Test_Fibonnaci, fibonacciRecursive) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL;
 	zval *n_param = NULL, *_0 = NULL, _1 = zval_used_for_init, *_3 = NULL;
 	int n, ZEPHIR_LAST_CALL_STATUS;
 
@@ -154,11 +154,11 @@ PHP_METHOD(Test_Fibonnaci, fibonacciRecursive) {
 		} else {
 			ZEPHIR_SINIT_VAR(_1);
 			ZVAL_LONG(&_1, (n - 1));
-			ZEPHIR_CALL_METHOD(&_0, this_ptr, "fibonaccirecursive", &_2, &_1);
+			ZEPHIR_CALL_METHOD(&_0, this_ptr, "fibonaccirecursive", &_2, 40, &_1);
 			zephir_check_call_status();
 			ZEPHIR_SINIT_NVAR(_1);
 			ZVAL_LONG(&_1, (n - 2));
-			ZEPHIR_CALL_METHOD(&_3, this_ptr, "fibonaccirecursive", &_2, &_1);
+			ZEPHIR_CALL_METHOD(&_3, this_ptr, "fibonaccirecursive", &_2, 40, &_1);
 			zephir_check_call_status();
 			zephir_add_function_ex(return_value, _0, _3 TSRMLS_CC);
 			RETURN_MM();
@@ -169,7 +169,7 @@ PHP_METHOD(Test_Fibonnaci, fibonacciRecursive) {
 
 PHP_METHOD(Test_Fibonnaci, fibonacciFinalRecursive) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL;
 	zval *n_param = NULL, *_0 = NULL, _1 = zval_used_for_init, *_3 = NULL;
 	int n, ZEPHIR_LAST_CALL_STATUS;
 
@@ -187,11 +187,11 @@ PHP_METHOD(Test_Fibonnaci, fibonacciFinalRecursive) {
 		} else {
 			ZEPHIR_SINIT_VAR(_1);
 			ZVAL_LONG(&_1, (n - 1));
-			ZEPHIR_CALL_METHOD(&_0, this_ptr, "fibonaccifinalrecursive", &_2, &_1);
+			ZEPHIR_CALL_METHOD(&_0, this_ptr, "fibonaccifinalrecursive", &_2, 41, &_1);
 			zephir_check_call_status();
 			ZEPHIR_SINIT_NVAR(_1);
 			ZVAL_LONG(&_1, (n - 2));
-			ZEPHIR_CALL_METHOD(&_3, this_ptr, "fibonaccifinalrecursive", &_2, &_1);
+			ZEPHIR_CALL_METHOD(&_3, this_ptr, "fibonaccifinalrecursive", &_2, 41, &_1);
 			zephir_check_call_status();
 			zephir_add_function_ex(return_value, _0, _3 TSRMLS_CC);
 			RETURN_MM();

--- a/ext/test/flow.zep.c
+++ b/ext/test/flow.zep.c
@@ -647,7 +647,7 @@ PHP_METHOD(Test_Flow, testDoWhile1) {
 PHP_METHOD(Test_Flow, testWhileNextTest) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_1 = NULL, *_3 = NULL;
+	zephir_fcall_cache_entry *_1 = NULL, *_3 = NULL;
 	zval *variable, *returnValue, *_0 = NULL, *_2 = NULL;
 
 	ZEPHIR_MM_GROW();
@@ -659,14 +659,14 @@ PHP_METHOD(Test_Flow, testWhileNextTest) {
 	array_init(returnValue);
 	while (1) {
 		Z_SET_ISREF_P(variable);
-		ZEPHIR_CALL_FUNCTION(&_0, "next", &_1, variable);
+		ZEPHIR_CALL_FUNCTION(&_0, "next", &_1, 42, variable);
 		Z_UNSET_ISREF_P(variable);
 		zephir_check_call_status();
 		if (!(zephir_is_true(_0))) {
 			break;
 		}
 		Z_SET_ISREF_P(variable);
-		ZEPHIR_CALL_FUNCTION(&_2, "current", &_3, variable);
+		ZEPHIR_CALL_FUNCTION(&_2, "current", &_3, 43, variable);
 		Z_UNSET_ISREF_P(variable);
 		zephir_check_call_status();
 		zephir_array_append(&returnValue, _2, PH_SEPARATE, "test/flow.zep", 420);
@@ -678,7 +678,7 @@ PHP_METHOD(Test_Flow, testWhileNextTest) {
 PHP_METHOD(Test_Flow, testWhileDoNextTest) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_1 = NULL, *_2 = NULL;
+	zephir_fcall_cache_entry *_1 = NULL, *_2 = NULL;
 	zval *variable, *returnValue, *_0 = NULL;
 
 	ZEPHIR_MM_GROW();
@@ -690,12 +690,12 @@ PHP_METHOD(Test_Flow, testWhileDoNextTest) {
 
 	do {
 		Z_SET_ISREF_P(variable);
-		ZEPHIR_CALL_FUNCTION(&_0, "current", &_1, variable);
+		ZEPHIR_CALL_FUNCTION(&_0, "current", &_1, 43, variable);
 		Z_UNSET_ISREF_P(variable);
 		zephir_check_call_status();
 		zephir_array_append(&returnValue, _0, PH_SEPARATE, "test/flow.zep", 430);
 		Z_SET_ISREF_P(variable);
-		ZEPHIR_CALL_FUNCTION(&_0, "next", &_2, variable);
+		ZEPHIR_CALL_FUNCTION(&_0, "next", &_2, 42, variable);
 		Z_UNSET_ISREF_P(variable);
 		zephir_check_call_status();
 	} while (zephir_is_true(_0));
@@ -1664,7 +1664,7 @@ PHP_METHOD(Test_Flow, testFor35) {
 			ZVAL_LONG(i, _1);
 			ZEPHIR_INIT_NVAR(_3);
 			ZVAL_STRING(_3, "hello", ZEPHIR_TEMP_PARAM_COPY);
-			ZEPHIR_CALL_METHOD(NULL, this_ptr, "testfor35aux", &_4, _3);
+			ZEPHIR_CALL_METHOD(NULL, this_ptr, "testfor35aux", &_4, 0, _3);
 			zephir_check_temp_parameter(_3);
 			zephir_check_call_status();
 		}
@@ -1713,7 +1713,7 @@ PHP_METHOD(Test_Flow, testFor36) {
 			ZVAL_LONG(i, _1);
 			ZEPHIR_INIT_NVAR(_3);
 			ZVAL_STRING(_3, "hello", ZEPHIR_TEMP_PARAM_COPY);
-			ZEPHIR_CALL_METHOD(NULL, this_ptr, "testfor36aux", &_4, _3);
+			ZEPHIR_CALL_METHOD(NULL, this_ptr, "testfor36aux", &_4, 0, _3);
 			zephir_check_temp_parameter(_3);
 			zephir_check_call_status();
 		}
@@ -1803,7 +1803,7 @@ PHP_METHOD(Test_Flow, testFor39) {
 
 PHP_METHOD(Test_Flow, testFor40) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_4 = NULL;
+	zephir_fcall_cache_entry *_4 = NULL;
 	int _1, _2, ZEPHIR_LAST_CALL_STATUS;
 	zend_bool _0;
 	zval *a = NULL, *b, *_3 = NULL;
@@ -1827,7 +1827,7 @@ PHP_METHOD(Test_Flow, testFor40) {
 			}
 			ZEPHIR_INIT_NVAR(a);
 			ZVAL_LONG(a, _1);
-			ZEPHIR_CALL_FUNCTION(&_3, "sqrt", &_4, a);
+			ZEPHIR_CALL_FUNCTION(&_3, "sqrt", &_4, 9, a);
 			zephir_check_call_status();
 			ZEPHIR_ADD_ASSIGN(b, _3);
 		}

--- a/ext/test/functional.zep.c
+++ b/ext/test/functional.zep.c
@@ -29,7 +29,7 @@ ZEPHIR_INIT_CLASS(Test_Functional) {
 PHP_METHOD(Test_Functional, map1) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL;
 	zval *a_param = NULL, *_0 = NULL, *_1 = NULL;
 	zval *a = NULL;
 
@@ -42,7 +42,7 @@ PHP_METHOD(Test_Functional, map1) {
 	ZEPHIR_INIT_VAR(_0);
 	ZEPHIR_INIT_NVAR(_0);
 	zephir_create_closure_ex(_0, NULL, test_8__closure_ce, SS("__invoke") TSRMLS_CC);
-	ZEPHIR_CALL_FUNCTION(&_1, "array_map", &_2, _0, a);
+	ZEPHIR_CALL_FUNCTION(&_1, "array_map", &_2, 3, _0, a);
 	zephir_check_call_status();
 	RETURN_CCTOR(_1);
 
@@ -51,7 +51,7 @@ PHP_METHOD(Test_Functional, map1) {
 PHP_METHOD(Test_Functional, map2) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_1 = NULL;
+	zephir_fcall_cache_entry *_1 = NULL;
 	zval *a_param = NULL, *b, *_0 = NULL;
 	zval *a = NULL;
 
@@ -61,7 +61,7 @@ PHP_METHOD(Test_Functional, map2) {
 	zephir_get_arrval(a, a_param);
 
 
-	ZEPHIR_CALL_FUNCTION(&_0, "array_map", &_1, b, a);
+	ZEPHIR_CALL_FUNCTION(&_0, "array_map", &_1, 3, b, a);
 	zephir_check_call_status();
 	RETURN_CCTOR(_0);
 

--- a/ext/test/instanceoff.zep.c
+++ b/ext/test/instanceoff.zep.c
@@ -50,7 +50,7 @@ PHP_METHOD(Test_Instanceoff, testInstanceOf2) {
 	ZEPHIR_INIT_VAR(a);
 	object_init_ex(a, test_instanceoff_ce);
 	if (zephir_has_constructor(a TSRMLS_CC)) {
-		ZEPHIR_CALL_METHOD(NULL, a, "__construct", NULL);
+		ZEPHIR_CALL_METHOD(NULL, a, "__construct", NULL, 0);
 		zephir_check_call_status();
 	}
 	RETURN_MM_BOOL(zephir_instance_of_ev(a, test_instanceoff_ce TSRMLS_CC));

--- a/ext/test/internalclasses.zep.c
+++ b/ext/test/internalclasses.zep.c
@@ -31,8 +31,8 @@ PHP_METHOD(Test_InternalClasses, testStaticCall) {
 
 	ZEPHIR_MM_GROW();
 
-	_0 = zend_fetch_class(SL("Phalcon\\DI"), ZEND_FETCH_CLASS_AUTO TSRMLS_CC);
-	ZEPHIR_RETURN_CALL_CE_STATIC(_0, "getdefault", NULL);
+	_0 = zend_fetch_class(SL("Phalcon\\Di"), ZEND_FETCH_CLASS_AUTO TSRMLS_CC);
+	ZEPHIR_RETURN_CALL_CE_STATIC(_0, "getdefault", NULL, 0);
 	zephir_check_call_status();
 	RETURN_MM();
 

--- a/ext/test/issues.zep.c
+++ b/ext/test/issues.zep.c
@@ -50,7 +50,7 @@ PHP_METHOD(Test_Issues, someMethod) {
 
 
 	_0 = zephir_fetch_nproperty_this(this_ptr, SL("adapter"), PH_NOISY_CC);
-	ZEPHIR_RETURN_CALL_METHOD_ZVAL(_0, methodName, NULL);
+	ZEPHIR_RETURN_CALL_METHOD_ZVAL(_0, methodName, NULL, 0);
 	zephir_check_call_status();
 	RETURN_MM();
 

--- a/ext/test/mcall.zep.c
+++ b/ext/test/mcall.zep.c
@@ -106,7 +106,7 @@ PHP_METHOD(Test_Mcall, testCall1) {
 
 	ZEPHIR_MM_GROW();
 
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "testmethod1", NULL);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "testmethod1", NULL, 0);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -118,7 +118,7 @@ PHP_METHOD(Test_Mcall, testCall2) {
 
 	ZEPHIR_MM_GROW();
 
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "testmethod2", NULL);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "testmethod2", NULL, 0);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -126,12 +126,12 @@ PHP_METHOD(Test_Mcall, testCall2) {
 
 PHP_METHOD(Test_Mcall, testCall3) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL;
+	zephir_fcall_cache_entry *_0 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
 
 	ZEPHIR_MM_GROW();
 
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "testmethod3", &_0);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "testmethod3", &_0, 44);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -147,7 +147,7 @@ PHP_METHOD(Test_Mcall, testCall4) {
 
 
 
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "testmethod4", NULL, a, b);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "testmethod4", NULL, 0, a, b);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -163,7 +163,7 @@ PHP_METHOD(Test_Mcall, testCall5) {
 
 
 
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "testmethod5", NULL, a, b);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "testmethod5", NULL, 0, a, b);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -171,7 +171,7 @@ PHP_METHOD(Test_Mcall, testCall5) {
 
 PHP_METHOD(Test_Mcall, testCall6) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL;
+	zephir_fcall_cache_entry *_0 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
 	zval *a, *b;
 
@@ -180,7 +180,7 @@ PHP_METHOD(Test_Mcall, testCall6) {
 
 
 
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "testmethod6", &_0, a, b);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "testmethod6", &_0, 45, a, b);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -197,9 +197,9 @@ PHP_METHOD(Test_Mcall, testCall7) {
 
 
 
-	ZEPHIR_CALL_METHOD(&_0, this_ptr, "testmethod4", &_1, a, b);
+	ZEPHIR_CALL_METHOD(&_0, this_ptr, "testmethod4", &_1, 0, a, b);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(&_2, this_ptr, "testmethod4", &_1, a, b);
+	ZEPHIR_CALL_METHOD(&_2, this_ptr, "testmethod4", &_1, 0, a, b);
 	zephir_check_call_status();
 	zephir_add_function_ex(return_value, _0, _2 TSRMLS_CC);
 	RETURN_MM();
@@ -217,9 +217,9 @@ PHP_METHOD(Test_Mcall, testCall8) {
 
 
 
-	ZEPHIR_CALL_METHOD(&_0, this_ptr, "testmethod5", &_1, a, b);
+	ZEPHIR_CALL_METHOD(&_0, this_ptr, "testmethod5", &_1, 0, a, b);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(&_2, this_ptr, "testmethod5", &_1, a, b);
+	ZEPHIR_CALL_METHOD(&_2, this_ptr, "testmethod5", &_1, 0, a, b);
 	zephir_check_call_status();
 	zephir_add_function_ex(return_value, _0, _2 TSRMLS_CC);
 	RETURN_MM();
@@ -228,7 +228,7 @@ PHP_METHOD(Test_Mcall, testCall8) {
 
 PHP_METHOD(Test_Mcall, testCall9) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_1 = NULL;
+	zephir_fcall_cache_entry *_1 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
 	zval *a, *b, *_0 = NULL, *_2 = NULL;
 
@@ -237,9 +237,9 @@ PHP_METHOD(Test_Mcall, testCall9) {
 
 
 
-	ZEPHIR_CALL_METHOD(&_0, this_ptr, "testmethod6", &_1, a, b);
+	ZEPHIR_CALL_METHOD(&_0, this_ptr, "testmethod6", &_1, 45, a, b);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(&_2, this_ptr, "testmethod5", NULL, a, b);
+	ZEPHIR_CALL_METHOD(&_2, this_ptr, "testmethod5", NULL, 0, a, b);
 	zephir_check_call_status();
 	zephir_add_function_ex(return_value, _0, _2 TSRMLS_CC);
 	RETURN_MM();
@@ -252,7 +252,7 @@ PHP_METHOD(Test_Mcall, testCall10) {
 
 	ZEPHIR_MM_GROW();
 
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "testmethod1", NULL);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "testmethod1", NULL, 0);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -264,7 +264,7 @@ PHP_METHOD(Test_Mcall, testCall11) {
 
 	ZEPHIR_MM_GROW();
 
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "testmethod2", NULL);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "testmethod2", NULL, 0);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -276,7 +276,7 @@ PHP_METHOD(Test_Mcall, testCall12) {
 
 	ZEPHIR_MM_GROW();
 
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "testmethod3", NULL);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "testmethod3", NULL, 0);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -292,7 +292,7 @@ PHP_METHOD(Test_Mcall, testCall13) {
 
 
 
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "testmethod4", NULL, a, b);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "testmethod4", NULL, 0, a, b);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -308,7 +308,7 @@ PHP_METHOD(Test_Mcall, testCall14) {
 
 
 
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "testmethod5", NULL, a, b);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "testmethod5", NULL, 0, a, b);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -324,7 +324,7 @@ PHP_METHOD(Test_Mcall, testCall15) {
 
 
 
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "testmethod6", NULL, a, b);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "testmethod6", NULL, 0, a, b);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -340,7 +340,7 @@ PHP_METHOD(Test_Mcall, testCall16) {
 
 
 
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "testmethod4", NULL, c, d);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "testmethod4", NULL, 0, c, d);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -356,7 +356,7 @@ PHP_METHOD(Test_Mcall, testCall17) {
 
 
 
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "testmethod4", NULL, c, d);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "testmethod4", NULL, 0, c, d);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -364,12 +364,12 @@ PHP_METHOD(Test_Mcall, testCall17) {
 
 PHP_METHOD(Test_Mcall, testCall18) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL;
+	zephir_fcall_cache_entry *_0 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
 
 	ZEPHIR_MM_GROW();
 
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "testmethod7", &_0);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "testmethod7", &_0, 46);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -418,7 +418,7 @@ PHP_METHOD(Test_Mcall, testCall20) {
 				_0 = 1;
 			}
 			i = _1;
-			ZEPHIR_CALL_METHOD(&_3, this_ptr, "testmethod19", &_4, p, p);
+			ZEPHIR_CALL_METHOD(&_3, this_ptr, "testmethod19", &_4, 0, p, p);
 			zephir_check_call_status();
 			j += zephir_get_numberval(_3);
 		}
@@ -444,7 +444,7 @@ PHP_METHOD(Test_Mcall, testMethod21) {
 
 PHP_METHOD(Test_Mcall, testCall22) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_4 = NULL;
+	zephir_fcall_cache_entry *_4 = NULL;
 	int _1, ZEPHIR_LAST_CALL_STATUS;
 	zend_bool _0;
 	zval *k_param = NULL, *p, *_3 = NULL;
@@ -470,7 +470,7 @@ PHP_METHOD(Test_Mcall, testCall22) {
 				_0 = 1;
 			}
 			i = _1;
-			ZEPHIR_CALL_METHOD(&_3, this_ptr, "testmethod21", &_4, p, p);
+			ZEPHIR_CALL_METHOD(&_3, this_ptr, "testmethod21", &_4, 47, p, p);
 			zephir_check_call_status();
 			j += zephir_get_numberval(_3);
 		}
@@ -753,7 +753,7 @@ PHP_METHOD(Test_Mcall, bb) {
 
 PHP_METHOD(Test_Mcall, testCallablePass) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_1 = NULL;
+	zephir_fcall_cache_entry *_1 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
 	zval *a, *_0 = NULL;
 
@@ -762,13 +762,13 @@ PHP_METHOD(Test_Mcall, testCallablePass) {
 	ZEPHIR_INIT_VAR(a);
 	object_init_ex(a, test_oo_ooparams_ce);
 	if (zephir_has_constructor(a TSRMLS_CC)) {
-		ZEPHIR_CALL_METHOD(NULL, a, "__construct", NULL);
+		ZEPHIR_CALL_METHOD(NULL, a, "__construct", NULL, 0);
 		zephir_check_call_status();
 	}
 	ZEPHIR_INIT_VAR(_0);
 	ZEPHIR_INIT_NVAR(_0);
 	zephir_create_closure_ex(_0, NULL, test_9__closure_ce, SS("__invoke") TSRMLS_CC);
-	ZEPHIR_RETURN_CALL_METHOD(a, "setcallable", &_1, _0);
+	ZEPHIR_RETURN_CALL_METHOD(a, "setcallable", &_1, 48, _0);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -776,7 +776,7 @@ PHP_METHOD(Test_Mcall, testCallablePass) {
 
 PHP_METHOD(Test_Mcall, testCallableArrayThisMethodPass) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL;
 	zval *_0;
 	int ZEPHIR_LAST_CALL_STATUS;
 	zval *a, *_1;
@@ -786,7 +786,7 @@ PHP_METHOD(Test_Mcall, testCallableArrayThisMethodPass) {
 	ZEPHIR_INIT_VAR(a);
 	object_init_ex(a, test_oo_ooparams_ce);
 	if (zephir_has_constructor(a TSRMLS_CC)) {
-		ZEPHIR_CALL_METHOD(NULL, a, "__construct", NULL);
+		ZEPHIR_CALL_METHOD(NULL, a, "__construct", NULL, 0);
 		zephir_check_call_status();
 	}
 	ZEPHIR_INIT_VAR(_0);
@@ -795,7 +795,7 @@ PHP_METHOD(Test_Mcall, testCallableArrayThisMethodPass) {
 	ZEPHIR_INIT_VAR(_1);
 	ZVAL_STRING(_1, "bb", 1);
 	zephir_array_fast_append(_0, _1);
-	ZEPHIR_RETURN_CALL_METHOD(a, "setcallable", &_2, _0);
+	ZEPHIR_RETURN_CALL_METHOD(a, "setcallable", &_2, 48, _0);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -803,7 +803,7 @@ PHP_METHOD(Test_Mcall, testCallableArrayThisMethodPass) {
 
 PHP_METHOD(Test_Mcall, aa) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL;
+	zephir_fcall_cache_entry *_0 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
 	zval *a;
 
@@ -812,10 +812,10 @@ PHP_METHOD(Test_Mcall, aa) {
 	ZEPHIR_INIT_VAR(a);
 	object_init_ex(a, test_mcall_ce);
 	if (zephir_has_constructor(a TSRMLS_CC)) {
-		ZEPHIR_CALL_METHOD(NULL, a, "__construct", NULL);
+		ZEPHIR_CALL_METHOD(NULL, a, "__construct", NULL, 0);
 		zephir_check_call_status();
 	}
-	ZEPHIR_RETURN_CALL_METHOD(a, "bb", &_0);
+	ZEPHIR_RETURN_CALL_METHOD(a, "bb", &_0, 49);
 	zephir_check_call_status();
 	RETURN_MM();
 

--- a/ext/test/mcallchained.zep.c
+++ b/ext/test/mcallchained.zep.c
@@ -58,9 +58,9 @@ PHP_METHOD(Test_McallChained, testChained1) {
 
 	ZEPHIR_MM_GROW();
 
-	ZEPHIR_CALL_METHOD(&_0, this_ptr, "testmethod1", NULL);
+	ZEPHIR_CALL_METHOD(&_0, this_ptr, "testmethod1", NULL, 0);
 	zephir_check_call_status();
-	ZEPHIR_RETURN_CALL_METHOD(_0, "testmethod2", NULL);
+	ZEPHIR_RETURN_CALL_METHOD(_0, "testmethod2", NULL, 0);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -73,11 +73,11 @@ PHP_METHOD(Test_McallChained, testChained2) {
 
 	ZEPHIR_MM_GROW();
 
-	ZEPHIR_CALL_METHOD(&_0, this_ptr, "testmethod1", NULL);
+	ZEPHIR_CALL_METHOD(&_0, this_ptr, "testmethod1", NULL, 0);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(&_1, _0, "testmethod3", NULL);
+	ZEPHIR_CALL_METHOD(&_1, _0, "testmethod3", NULL, 0);
 	zephir_check_call_status();
-	ZEPHIR_RETURN_CALL_METHOD(_1, "testmethod2", NULL);
+	ZEPHIR_RETURN_CALL_METHOD(_1, "testmethod2", NULL, 0);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -85,17 +85,17 @@ PHP_METHOD(Test_McallChained, testChained2) {
 
 PHP_METHOD(Test_McallChained, testChained3) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_1 = NULL;
+	zephir_fcall_cache_entry *_1 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
 	zval *_0 = NULL, *_2 = NULL;
 
 	ZEPHIR_MM_GROW();
 
-	ZEPHIR_CALL_METHOD(&_0, this_ptr, "testmethod3", &_1);
+	ZEPHIR_CALL_METHOD(&_0, this_ptr, "testmethod3", &_1, 50);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(&_2, _0, "testmethod2", NULL);
+	ZEPHIR_CALL_METHOD(&_2, _0, "testmethod2", NULL, 0);
 	zephir_check_call_status();
-	ZEPHIR_RETURN_CALL_METHOD(_2, "testmethod1", NULL);
+	ZEPHIR_RETURN_CALL_METHOD(_2, "testmethod1", NULL, 0);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -110,9 +110,9 @@ PHP_METHOD(Test_McallChained, testChained4) {
 
 	zephir_update_property_this(this_ptr, SL("temp"), this_ptr TSRMLS_CC);
 	_0 = zephir_fetch_nproperty_this(this_ptr, SL("temp"), PH_NOISY_CC);
-	ZEPHIR_CALL_METHOD(&_1, _0, "testmethod1", NULL);
+	ZEPHIR_CALL_METHOD(&_1, _0, "testmethod1", NULL, 0);
 	zephir_check_call_status();
-	ZEPHIR_RETURN_CALL_METHOD(_1, "testmethod2", NULL);
+	ZEPHIR_RETURN_CALL_METHOD(_1, "testmethod2", NULL, 0);
 	zephir_check_call_status();
 	RETURN_MM();
 

--- a/ext/test/mcalldynamic.zep.c
+++ b/ext/test/mcalldynamic.zep.c
@@ -43,9 +43,9 @@ PHP_METHOD(Test_McallDynamic, testMagicCall1) {
 
 	ZEPHIR_MM_GROW();
 
-	ZEPHIR_CALL_METHOD(&_0, this_ptr, "method1", NULL);
+	ZEPHIR_CALL_METHOD(&_0, this_ptr, "method1", NULL, 0);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(&_1, this_ptr, "method1", NULL);
+	ZEPHIR_CALL_METHOD(&_1, this_ptr, "method1", NULL, 0);
 	zephir_check_call_status();
 	zephir_add_function_ex(return_value, _0, _1 TSRMLS_CC);
 	RETURN_MM();
@@ -64,7 +64,7 @@ PHP_METHOD(Test_McallDynamic, __call) {
 
 	ZEPHIR_INIT_VAR(realMethod);
 	ZEPHIR_CONCAT_SV(realMethod, "test", method);
-	ZEPHIR_RETURN_CALL_METHOD_ZVAL(this_ptr, realMethod, NULL);
+	ZEPHIR_RETURN_CALL_METHOD_ZVAL(this_ptr, realMethod, NULL, 0);
 	zephir_check_call_status();
 	RETURN_MM();
 

--- a/ext/test/methodabstract.zep.c
+++ b/ext/test/methodabstract.zep.c
@@ -31,7 +31,7 @@ PHP_METHOD(Test_MethodAbstract, testInterfaceMetho) {
 
 	ZEPHIR_MM_GROW();
 
-	ZEPHIR_CALL_METHOD(NULL, this_ptr, "testmethod", NULL);
+	ZEPHIR_CALL_METHOD(NULL, this_ptr, "testmethod", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();
 

--- a/ext/test/nativearray.zep.c
+++ b/ext/test/nativearray.zep.c
@@ -1503,7 +1503,7 @@ PHP_METHOD(Test_NativeArray, issue743c) {
  */
 PHP_METHOD(Test_NativeArray, issue709) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_6 = NULL;
+	zephir_fcall_cache_entry *_6 = NULL;
 	int _1, _2, ZEPHIR_LAST_CALL_STATUS;
 	zend_bool works = 1, _0, _7;
 	zval *c = NULL, *arr = NULL, *_3 = NULL, *_4, *_5 = NULL;
@@ -1533,7 +1533,7 @@ PHP_METHOD(Test_NativeArray, issue709) {
 			ZEPHIR_INIT_NVAR(_3);
 			ZVAL_LONG(_3, 2);
 			zephir_array_fast_append(arr, _3);
-			ZEPHIR_CALL_FUNCTION(&_5, "array_rand", &_6, arr);
+			ZEPHIR_CALL_FUNCTION(&_5, "array_rand", &_6, 51, arr);
 			zephir_check_call_status();
 			zephir_array_fetch(&_4, arr, _5, PH_NOISY | PH_READONLY, "test/nativearray.zep", 636 TSRMLS_CC);
 			ZEPHIR_CPY_WRT(arr, _4);

--- a/ext/test/oo.zep.c
+++ b/ext/test/oo.zep.c
@@ -41,7 +41,7 @@ PHP_METHOD(Test_Oo, testInstance1) {
 
 PHP_METHOD(Test_Oo, testInstance2) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL;
+	zephir_fcall_cache_entry *_0 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
 	zval *o;
 
@@ -49,7 +49,7 @@ PHP_METHOD(Test_Oo, testInstance2) {
 
 	ZEPHIR_INIT_VAR(o);
 	object_init_ex(o, test_oo_ooconstruct_ce);
-	ZEPHIR_CALL_METHOD(NULL, o, "__construct", &_0);
+	ZEPHIR_CALL_METHOD(NULL, o, "__construct", &_0, 52);
 	zephir_check_call_status();
 	RETURN_CCTOR(o);
 
@@ -65,7 +65,7 @@ PHP_METHOD(Test_Oo, testInstance3) {
 	ZEPHIR_INIT_VAR(o);
 	object_init_ex(o, test_oo_oonoconstruct_ce);
 	if (zephir_has_constructor(o TSRMLS_CC)) {
-		ZEPHIR_CALL_METHOD(NULL, o, "__construct", NULL);
+		ZEPHIR_CALL_METHOD(NULL, o, "__construct", NULL, 0);
 		zephir_check_call_status();
 	}
 	RETURN_CCTOR(o);
@@ -74,7 +74,7 @@ PHP_METHOD(Test_Oo, testInstance3) {
 
 PHP_METHOD(Test_Oo, testInstance4) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL;
+	zephir_fcall_cache_entry *_0 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
 	zval *o, *a, *b;
 
@@ -86,7 +86,7 @@ PHP_METHOD(Test_Oo, testInstance4) {
 	ZVAL_STRING(b, "b", 1);
 	ZEPHIR_INIT_VAR(o);
 	object_init_ex(o, test_oo_ooconstructparams_ce);
-	ZEPHIR_CALL_METHOD(NULL, o, "__construct", &_0, a, b);
+	ZEPHIR_CALL_METHOD(NULL, o, "__construct", &_0, 53, a, b);
 	zephir_check_call_status();
 	RETURN_CCTOR(o);
 
@@ -94,7 +94,7 @@ PHP_METHOD(Test_Oo, testInstance4) {
 
 PHP_METHOD(Test_Oo, testInstance5) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
 	zval *o, *_0, *_1;
 
@@ -106,7 +106,7 @@ PHP_METHOD(Test_Oo, testInstance5) {
 	ZVAL_STRING(_0, "a", ZEPHIR_TEMP_PARAM_COPY);
 	ZEPHIR_INIT_VAR(_1);
 	ZVAL_STRING(_1, "b", ZEPHIR_TEMP_PARAM_COPY);
-	ZEPHIR_CALL_METHOD(NULL, o, "__construct", &_2, _0, _1);
+	ZEPHIR_CALL_METHOD(NULL, o, "__construct", &_2, 53, _0, _1);
 	zephir_check_temp_parameter(_0);
 	zephir_check_temp_parameter(_1);
 	zephir_check_call_status();
@@ -116,7 +116,7 @@ PHP_METHOD(Test_Oo, testInstance5) {
 
 PHP_METHOD(Test_Oo, testInstance6) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
 	zval *o, *_0, *_1;
 
@@ -128,7 +128,7 @@ PHP_METHOD(Test_Oo, testInstance6) {
 	ZVAL_LONG(_0, 1);
 	ZEPHIR_INIT_VAR(_1);
 	ZVAL_LONG(_1, 2);
-	ZEPHIR_CALL_METHOD(NULL, o, "__construct", &_2, _0, _1);
+	ZEPHIR_CALL_METHOD(NULL, o, "__construct", &_2, 53, _0, _1);
 	zephir_check_call_status();
 	RETURN_CCTOR(o);
 
@@ -136,7 +136,7 @@ PHP_METHOD(Test_Oo, testInstance6) {
 
 PHP_METHOD(Test_Oo, testInstance7) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
 	zval *o, *_0, *_1;
 
@@ -148,7 +148,7 @@ PHP_METHOD(Test_Oo, testInstance7) {
 	ZVAL_BOOL(_0, 0);
 	ZEPHIR_INIT_VAR(_1);
 	ZVAL_BOOL(_1, 1);
-	ZEPHIR_CALL_METHOD(NULL, o, "__construct", &_2, _0, _1);
+	ZEPHIR_CALL_METHOD(NULL, o, "__construct", &_2, 53, _0, _1);
 	zephir_check_call_status();
 	RETURN_CCTOR(o);
 
@@ -156,7 +156,7 @@ PHP_METHOD(Test_Oo, testInstance7) {
 
 PHP_METHOD(Test_Oo, testInstance8) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
 	zval *o, *_0, *_1;
 
@@ -168,7 +168,7 @@ PHP_METHOD(Test_Oo, testInstance8) {
 	ZVAL_DOUBLE(_0, 1.2);
 	ZEPHIR_INIT_VAR(_1);
 	ZVAL_DOUBLE(_1, 7.30);
-	ZEPHIR_CALL_METHOD(NULL, o, "__construct", &_2, _0, _1);
+	ZEPHIR_CALL_METHOD(NULL, o, "__construct", &_2, 53, _0, _1);
 	zephir_check_call_status();
 	RETURN_CCTOR(o);
 
@@ -177,12 +177,12 @@ PHP_METHOD(Test_Oo, testInstance8) {
 PHP_METHOD(Test_Oo, testInstance9) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL;
+	zephir_fcall_cache_entry *_0 = NULL;
 	zval *o = NULL;
 
 	ZEPHIR_MM_GROW();
 
-	ZEPHIR_CALL_CE_STATIC(&o, test_oo_oodynamica_ce, "getnew", &_0);
+	ZEPHIR_CALL_CE_STATIC(&o, test_oo_oodynamica_ce, "getnew", &_0, 54);
 	zephir_check_call_status();
 	RETURN_CCTOR(o);
 
@@ -191,12 +191,12 @@ PHP_METHOD(Test_Oo, testInstance9) {
 PHP_METHOD(Test_Oo, testInstance10) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL;
+	zephir_fcall_cache_entry *_0 = NULL;
 	zval *o = NULL;
 
 	ZEPHIR_MM_GROW();
 
-	ZEPHIR_CALL_CE_STATIC(&o, test_oo_oodynamicb_ce, "getnew", &_0);
+	ZEPHIR_CALL_CE_STATIC(&o, test_oo_oodynamicb_ce, "getnew", &_0, 54);
 	zephir_check_call_status();
 	RETURN_CCTOR(o);
 
@@ -204,7 +204,7 @@ PHP_METHOD(Test_Oo, testInstance10) {
 
 PHP_METHOD(Test_Oo, testInstance11) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
 	zval *o, *_0, *_1;
 
@@ -216,7 +216,7 @@ PHP_METHOD(Test_Oo, testInstance11) {
 	ZVAL_LONG(_0, 1);
 	ZEPHIR_INIT_VAR(_1);
 	ZVAL_LONG(_1, 2);
-	ZEPHIR_CALL_METHOD(NULL, o, "__construct", &_2, _0, _1);
+	ZEPHIR_CALL_METHOD(NULL, o, "__construct", &_2, 53, _0, _1);
 	zephir_check_call_status();
 	RETURN_CCTOR(o);
 

--- a/ext/test/oo/deprecatedmethods.zep.c
+++ b/ext/test/oo/deprecatedmethods.zep.c
@@ -33,12 +33,12 @@ PHP_METHOD(Test_Oo_DeprecatedMethods, deprecatedMethod) {
 
 PHP_METHOD(Test_Oo_DeprecatedMethods, normalMethod) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL;
+	zephir_fcall_cache_entry *_0 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
 
 	ZEPHIR_MM_GROW();
 
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "privatedepricatedmethod", &_0);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "privatedepricatedmethod", &_0, 55);
 	zephir_check_call_status();
 	RETURN_MM();
 

--- a/ext/test/oo/extendpdoclass.zep.c
+++ b/ext/test/oo/extendpdoclass.zep.c
@@ -64,7 +64,7 @@ PHP_METHOD(Test_Oo_ExtendPdoClass, __construct) {
 	ZVAL_STRING(_1, "Test\\PdoStatement", 1);
 	zephir_array_fast_append(_0, _1);
 	zephir_array_update_long(&attrs, 13, &_0, PH_COPY | PH_SEPARATE, "test/oo/extendpdoclass.zep", 8);
-	ZEPHIR_CALL_PARENT(NULL, test_oo_extendpdoclass_ce, this_ptr, "__construct", NULL, dsn, username, password, attrs);
+	ZEPHIR_CALL_PARENT(NULL, test_oo_extendpdoclass_ce, this_ptr, "__construct", NULL, 0, dsn, username, password, attrs);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();
 

--- a/ext/test/oo/oodynamica.zep.c
+++ b/ext/test/oo/oodynamica.zep.c
@@ -45,7 +45,7 @@ PHP_METHOD(Test_Oo_OoDynamicA, getNew) {
 	_1 = zend_fetch_class(Z_STRVAL_P(_0), Z_STRLEN_P(_0), ZEND_FETCH_CLASS_AUTO TSRMLS_CC);
 	object_init_ex(return_value, _1);
 	if (zephir_has_constructor(return_value TSRMLS_CC)) {
-		ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL);
+		ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 0);
 		zephir_check_call_status();
 	}
 	RETURN_MM();

--- a/ext/test/oo/ooparams.zep.c
+++ b/ext/test/oo/ooparams.zep.c
@@ -38,7 +38,7 @@ PHP_METHOD(Test_Oo_OoParams, createThisClassWithoutWriteCurrentNamespace) {
 
 	object_init_ex(return_value, test_oo_ooparams_ce);
 	if (zephir_has_constructor(return_value TSRMLS_CC)) {
-		ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL);
+		ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 0);
 		zephir_check_call_status();
 	}
 	RETURN_MM();
@@ -53,7 +53,7 @@ PHP_METHOD(Test_Oo_OoParams, createOtherClassWithoutWriteCurrentNamespace) {
 
 	object_init_ex(return_value, test_oo_oodynamica_ce);
 	if (zephir_has_constructor(return_value TSRMLS_CC)) {
-		ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL);
+		ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 0);
 		zephir_check_call_status();
 	}
 	RETURN_MM();

--- a/ext/test/pregmatch.zep.c
+++ b/ext/test/pregmatch.zep.c
@@ -101,7 +101,7 @@ PHP_METHOD(Test_Pregmatch, testPregMatchAll) {
 PHP_METHOD(Test_Pregmatch, testPregMatchFallback) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL;
 	zval *pattern, *subject, *matches = NULL, *_0, *_1;
 
 	ZEPHIR_MM_GROW();
@@ -119,7 +119,7 @@ PHP_METHOD(Test_Pregmatch, testPregMatchFallback) {
 	ZEPHIR_INIT_VAR(_1);
 	ZVAL_LONG(_1, 0);
 	Z_SET_ISREF_P(matches);
-	ZEPHIR_RETURN_CALL_FUNCTION("preg_match", &_2, pattern, subject, matches, _0, _1);
+	ZEPHIR_RETURN_CALL_FUNCTION("preg_match", &_2, 56, pattern, subject, matches, _0, _1);
 	Z_UNSET_ISREF_P(matches);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -157,7 +157,7 @@ PHP_METHOD(Test_Pregmatch, testPregMatch3Params) {
 PHP_METHOD(Test_Pregmatch, testPregMatch4Params) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL;
+	zephir_fcall_cache_entry *_0 = NULL;
 	zval *pattern, *subject, *matches, *flags;
 
 	ZEPHIR_MM_GROW();
@@ -166,7 +166,7 @@ PHP_METHOD(Test_Pregmatch, testPregMatch4Params) {
 
 
 	Z_SET_ISREF_P(matches);
-	ZEPHIR_RETURN_CALL_FUNCTION("preg_match", &_0, pattern, subject, matches, flags);
+	ZEPHIR_RETURN_CALL_FUNCTION("preg_match", &_0, 56, pattern, subject, matches, flags);
 	Z_UNSET_ISREF_P(matches);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -176,7 +176,7 @@ PHP_METHOD(Test_Pregmatch, testPregMatch4Params) {
 PHP_METHOD(Test_Pregmatch, testPregMatch5Params) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL;
+	zephir_fcall_cache_entry *_0 = NULL;
 	zval *pattern, *subject, *matches, *flags, *offset;
 
 	ZEPHIR_MM_GROW();
@@ -185,7 +185,7 @@ PHP_METHOD(Test_Pregmatch, testPregMatch5Params) {
 
 
 	Z_SET_ISREF_P(matches);
-	ZEPHIR_RETURN_CALL_FUNCTION("preg_match", &_0, pattern, subject, matches, flags, offset);
+	ZEPHIR_RETURN_CALL_FUNCTION("preg_match", &_0, 56, pattern, subject, matches, flags, offset);
 	Z_UNSET_ISREF_P(matches);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -218,7 +218,7 @@ PHP_METHOD(Test_Pregmatch, testPregMatchSaveMatches) {
 PHP_METHOD(Test_Pregmatch, testMatchAll) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_1 = NULL;
+	zephir_fcall_cache_entry *_1 = NULL;
 	zval *flags, *text, *matches, *_0;
 
 	ZEPHIR_MM_GROW();
@@ -233,7 +233,7 @@ PHP_METHOD(Test_Pregmatch, testMatchAll) {
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_STRING(_0, "/(test[0-9]+)/", ZEPHIR_TEMP_PARAM_COPY);
 	Z_SET_ISREF_P(matches);
-	ZEPHIR_CALL_FUNCTION(NULL, "preg_match_all", &_1, _0, text, matches, flags);
+	ZEPHIR_CALL_FUNCTION(NULL, "preg_match_all", &_1, 57, _0, text, matches, flags);
 	zephir_check_temp_parameter(_0);
 	Z_UNSET_ISREF_P(matches);
 	zephir_check_call_status();
@@ -251,11 +251,11 @@ PHP_METHOD(Test_Pregmatch, testMatchAllInZep) {
 
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, 1);
-	ZEPHIR_CALL_METHOD(&m1, this_ptr, "testmatchall", &_1, _0);
+	ZEPHIR_CALL_METHOD(&m1, this_ptr, "testmatchall", &_1, 0, _0);
 	zephir_check_call_status();
 	ZEPHIR_INIT_NVAR(_0);
 	ZVAL_LONG(_0, 2);
-	ZEPHIR_CALL_METHOD(&m2, this_ptr, "testmatchall", &_1, _0);
+	ZEPHIR_CALL_METHOD(&m2, this_ptr, "testmatchall", &_1, 0, _0);
 	zephir_check_call_status();
 	zephir_create_array(return_value, 2, 0 TSRMLS_CC);
 	zephir_array_fast_append(return_value, m1);

--- a/ext/test/quantum.zep.c
+++ b/ext/test/quantum.zep.c
@@ -34,7 +34,7 @@ PHP_METHOD(Test_Quantum, harmos) {
 
 	zend_bool _14, _17, _33, _36;
 	zval *_11 = NULL, *_12 = NULL, *_13 = NULL;
-	zephir_nts_static zephir_fcall_cache_entry *_3 = NULL, *_5 = NULL, *_7 = NULL, *_9 = NULL, *_37 = NULL;
+	zephir_fcall_cache_entry *_3 = NULL, *_5 = NULL, *_7 = NULL, *_9 = NULL, *_37 = NULL;
 	int i, j, n, ZEPHIR_LAST_CALL_STATUS, _15, _16, _18, _19, _34, _35;
 	zval *x_param = NULL, *psr, *psi, *p2, *v, *paramater, *fp = NULL, *tmp, *_0 = NULL, _1 = zval_used_for_init, _2 = zval_used_for_init, *_4 = NULL, *_6 = NULL, *_8 = NULL, *_10 = NULL, *_20, *_21, *_22, *_23, *_24, *_25, *_26, *_27, _28 = zval_used_for_init, *_29, *_30, *_31, *_32;
 	double x, dt, dx, k0, item_psr, item_psi;
@@ -75,7 +75,7 @@ PHP_METHOD(Test_Quantum, harmos) {
 	ZVAL_STRING(&_1, "harmos.txt", 0);
 	ZEPHIR_SINIT_VAR(_2);
 	ZVAL_STRING(&_2, "w", 0);
-	ZEPHIR_CALL_FUNCTION(&fp, "fopen", &_3, &_1, &_2);
+	ZEPHIR_CALL_FUNCTION(&fp, "fopen", &_3, 31, &_1, &_2);
 	zephir_check_call_status();
 	if (!(zephir_is_true(fp))) {
 		RETURN_MM_LONG(1);
@@ -86,22 +86,22 @@ PHP_METHOD(Test_Quantum, harmos) {
 		}
 		ZEPHIR_SINIT_NVAR(_1);
 		ZVAL_DOUBLE(&_1, (k0 * x));
-		ZEPHIR_CALL_FUNCTION(&_4, "sin", &_5, &_1);
+		ZEPHIR_CALL_FUNCTION(&_4, "sin", &_5, 10, &_1);
 		zephir_check_call_status();
 		ZEPHIR_SINIT_NVAR(_1);
 		ZVAL_DOUBLE(&_1, ((x * x) * 2.0));
-		ZEPHIR_CALL_FUNCTION(&_6, "exp", &_7, &_1);
+		ZEPHIR_CALL_FUNCTION(&_6, "exp", &_7, 1, &_1);
 		zephir_check_call_status();
 		ZEPHIR_INIT_LNVAR(_8);
 		div_function(_8, _4, _6 TSRMLS_CC);
 		item_psi = zephir_get_numberval(_8);
 		ZEPHIR_SINIT_NVAR(_1);
 		ZVAL_DOUBLE(&_1, (k0 * x));
-		ZEPHIR_CALL_FUNCTION(&_4, "cos", &_9, &_1);
+		ZEPHIR_CALL_FUNCTION(&_4, "cos", &_9, 11, &_1);
 		zephir_check_call_status();
 		ZEPHIR_SINIT_NVAR(_1);
 		ZVAL_DOUBLE(&_1, ((x * x) * 2.0));
-		ZEPHIR_CALL_FUNCTION(&_6, "exp", &_7, &_1);
+		ZEPHIR_CALL_FUNCTION(&_6, "exp", &_7, 1, &_1);
 		zephir_check_call_status();
 		ZEPHIR_INIT_LNVAR(_10);
 		div_function(_10, _4, _6 TSRMLS_CC);
@@ -294,13 +294,13 @@ PHP_METHOD(Test_Quantum, harmos) {
 					ZVAL_DOUBLE(&_2, ((double) i * dx));
 					ZEPHIR_SINIT_NVAR(_28);
 					ZVAL_DOUBLE(&_28, ((double) n * dt));
-					ZEPHIR_CALL_FUNCTION(NULL, "fprintf", &_37, fp, &_1, &_2, &_28, _20);
+					ZEPHIR_CALL_FUNCTION(NULL, "fprintf", &_37, 58, fp, &_1, &_2, &_28, _20);
 					zephir_check_call_status();
 					i = (i + 10);
 				}
 				ZEPHIR_SINIT_NVAR(_1);
 				ZVAL_STRING(&_1, "\n", 0);
-				ZEPHIR_CALL_FUNCTION(NULL, "fprintf", &_37, fp, &_1);
+				ZEPHIR_CALL_FUNCTION(NULL, "fprintf", &_37, 58, fp, &_1);
 				zephir_check_call_status();
 			}
 			j = 1;

--- a/ext/test/range.zep.c
+++ b/ext/test/range.zep.c
@@ -32,7 +32,7 @@ PHP_METHOD(Test_Range, inclusive1) {
 
 	zval *_4 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_3 = NULL;
+	zephir_fcall_cache_entry *_3 = NULL;
 	zval _0, _1, *_2 = NULL;
 
 	ZEPHIR_MM_GROW();
@@ -41,7 +41,7 @@ PHP_METHOD(Test_Range, inclusive1) {
 	ZVAL_LONG(&_0, 0);
 	ZEPHIR_SINIT_VAR(_1);
 	ZVAL_LONG(&_1, 10);
-	ZEPHIR_CALL_FUNCTION(&_2, "range", &_3, &_0, &_1);
+	ZEPHIR_CALL_FUNCTION(&_2, "range", &_3, 59, &_0, &_1);
 	zephir_check_call_status();
 	zephir_get_arrval(_4, _2);
 	RETURN_CTOR(_4);
@@ -52,7 +52,7 @@ PHP_METHOD(Test_Range, exclusive1) {
 
 	zval *_4 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_3 = NULL;
+	zephir_fcall_cache_entry *_3 = NULL;
 	zval _0, _1, *_2 = NULL;
 
 	ZEPHIR_MM_GROW();
@@ -61,7 +61,7 @@ PHP_METHOD(Test_Range, exclusive1) {
 	ZVAL_LONG(&_0, 0);
 	ZEPHIR_SINIT_VAR(_1);
 	ZVAL_LONG(&_1, 10);
-	ZEPHIR_CALL_FUNCTION(&_2, "range", &_3, &_0, &_1);
+	ZEPHIR_CALL_FUNCTION(&_2, "range", &_3, 59, &_0, &_1);
 	zephir_check_call_status();
 	zephir_get_arrval(_4, _2);
 	RETURN_CTOR(_4);

--- a/ext/test/regexdna.zep.c
+++ b/ext/test/regexdna.zep.c
@@ -39,7 +39,7 @@ PHP_METHOD(Test_RegexDNA, process) {
 	HashTable *_5;
 	HashPosition _4;
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_3 = NULL;
+	zephir_fcall_cache_entry *_3 = NULL;
 	zval *path, *variants, *vIUB, *vIUBnew, *stuffToRemove, *contents = NULL, *initialLength, *regex = NULL, *codeLength, *discard = NULL, *_0 = NULL, *_1, *_2 = NULL, **_6, *_7 = NULL;
 
 	ZEPHIR_MM_GROW();
@@ -160,7 +160,7 @@ PHP_METHOD(Test_RegexDNA, process) {
 	ZEPHIR_CONCAT_SVS(_1, "/", stuffToRemove, "/mS");
 	ZEPHIR_INIT_NVAR(_0);
 	ZVAL_STRING(_0, "", ZEPHIR_TEMP_PARAM_COPY);
-	ZEPHIR_CALL_FUNCTION(&_2, "preg_replace", &_3, _1, _0, contents);
+	ZEPHIR_CALL_FUNCTION(&_2, "preg_replace", &_3, 60, _1, _0, contents);
 	zephir_check_temp_parameter(_0);
 	zephir_check_call_status();
 	ZEPHIR_CPY_WRT(contents, _2);
@@ -181,7 +181,7 @@ PHP_METHOD(Test_RegexDNA, process) {
 		zend_print_zval(_0, 0);
 		php_printf("%c", '\n');
 	}
-	ZEPHIR_CALL_FUNCTION(&_2, "preg_replace", &_3, vIUB, vIUBnew, contents);
+	ZEPHIR_CALL_FUNCTION(&_2, "preg_replace", &_3, 60, vIUB, vIUBnew, contents);
 	zephir_check_call_status();
 	ZEPHIR_CPY_WRT(contents, _2);
 	php_printf("%c", '\n');

--- a/ext/test/resourcetest.zep.c
+++ b/ext/test/resourcetest.zep.c
@@ -89,7 +89,7 @@ PHP_METHOD(Test_ResourceTest, testIsResource) {
 PHP_METHOD(Test_ResourceTest, testFunctionsForSTDIN) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_1 = NULL;
+	zephir_fcall_cache_entry *_1 = NULL;
 	zval *a = NULL, _0;
 
 	ZEPHIR_MM_GROW();
@@ -98,7 +98,7 @@ PHP_METHOD(Test_ResourceTest, testFunctionsForSTDIN) {
 	ZEPHIR_GET_CONSTANT(a, "STDIN");
 	ZEPHIR_SINIT_VAR(_0);
 	ZVAL_LONG(&_0, 1);
-	ZEPHIR_CALL_FUNCTION(NULL, "stream_set_blocking", &_1, a, &_0);
+	ZEPHIR_CALL_FUNCTION(NULL, "stream_set_blocking", &_1, 61, a, &_0);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();
 

--- a/ext/test/router.zep.c
+++ b/ext/test/router.zep.c
@@ -104,7 +104,7 @@ ZEPHIR_INIT_CLASS(Test_Router) {
  */
 PHP_METHOD(Test_Router, __construct) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_3 = NULL;
+	zephir_fcall_cache_entry *_3 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
 	zval *_1, *_4;
 	zval *defaultRoutes_param = NULL, *routes, *_0 = NULL, *_2 = NULL, *_5;
@@ -130,7 +130,7 @@ PHP_METHOD(Test_Router, __construct) {
 		add_assoc_long_ex(_1, SS("controller"), 1);
 		ZEPHIR_INIT_VAR(_2);
 		ZVAL_STRING(_2, "#^/([a-zA-Z0-9\\_\\-]+)[/]{0,1}$#", ZEPHIR_TEMP_PARAM_COPY);
-		ZEPHIR_CALL_METHOD(NULL, _0, "__construct", &_3, _2, _1);
+		ZEPHIR_CALL_METHOD(NULL, _0, "__construct", &_3, 62, _2, _1);
 		zephir_check_temp_parameter(_2);
 		zephir_check_call_status();
 		zephir_array_append(&routes, _0, PH_SEPARATE, "test/router.zep", 89);
@@ -143,7 +143,7 @@ PHP_METHOD(Test_Router, __construct) {
 		add_assoc_long_ex(_4, SS("params"), 3);
 		ZEPHIR_INIT_VAR(_5);
 		ZVAL_STRING(_5, "#^/([a-zA-Z0-9\\_\\-]+)/([a-zA-Z0-9\\.\\_]+)(/.*)*$#", ZEPHIR_TEMP_PARAM_COPY);
-		ZEPHIR_CALL_METHOD(NULL, _2, "__construct", &_3, _5, _4);
+		ZEPHIR_CALL_METHOD(NULL, _2, "__construct", &_3, 62, _5, _4);
 		zephir_check_temp_parameter(_5);
 		zephir_check_call_status();
 		zephir_array_append(&routes, _2, PH_SEPARATE, "test/router.zep", 95);
@@ -430,14 +430,14 @@ PHP_METHOD(Test_Router, handle) {
 
 
 	if (!(zephir_is_true(uri))) {
-		ZEPHIR_CALL_METHOD(&realUri, this_ptr, "getrewriteuri", NULL);
+		ZEPHIR_CALL_METHOD(&realUri, this_ptr, "getrewriteuri", NULL, 0);
 		zephir_check_call_status();
 	} else {
 		ZEPHIR_CPY_WRT(realUri, uri);
 	}
 	_0 = zephir_fetch_nproperty_this(this_ptr, SL("_removeExtraSlashes"), PH_NOISY_CC);
 	if (zephir_is_true(_0)) {
-		ZEPHIR_CALL_METHOD(&handledUri, this_ptr, "doremoveextraslashes", NULL, realUri);
+		ZEPHIR_CALL_METHOD(&handledUri, this_ptr, "doremoveextraslashes", NULL, 0, realUri);
 		zephir_check_call_status();
 	} else {
 		ZEPHIR_CPY_WRT(handledUri, realUri);
@@ -463,7 +463,7 @@ PHP_METHOD(Test_Router, handle) {
 	  ; zephir_hash_move_backwards_ex(_3, &_2)
 	) {
 		ZEPHIR_GET_HVALUE(route, _4);
-		ZEPHIR_CALL_METHOD(&methods, route, "gethttpmethods", NULL);
+		ZEPHIR_CALL_METHOD(&methods, route, "gethttpmethods", NULL, 0);
 		zephir_check_call_status();
 		if (Z_TYPE_P(methods) != IS_NULL) {
 			if (Z_TYPE_P(request) == IS_NULL) {
@@ -475,17 +475,17 @@ PHP_METHOD(Test_Router, handle) {
 				}
 				ZEPHIR_INIT_NVAR(_6);
 				ZVAL_STRING(_6, "request", ZEPHIR_TEMP_PARAM_COPY);
-				ZEPHIR_CALL_METHOD(&request, dependencyInjector, "getshared", &_7, _6);
+				ZEPHIR_CALL_METHOD(&request, dependencyInjector, "getshared", &_7, 0, _6);
 				zephir_check_temp_parameter(_6);
 				zephir_check_call_status();
 			}
-			ZEPHIR_CALL_METHOD(&_8, request, "ismethod", NULL, methods);
+			ZEPHIR_CALL_METHOD(&_8, request, "ismethod", NULL, 0, methods);
 			zephir_check_call_status();
 			if (ZEPHIR_IS_FALSE_IDENTICAL(_8)) {
 				continue;
 			}
 		}
-		ZEPHIR_CALL_METHOD(&hostname, route, "gethostname", NULL);
+		ZEPHIR_CALL_METHOD(&hostname, route, "gethostname", NULL, 0);
 		zephir_check_call_status();
 		if (Z_TYPE_P(hostname) != IS_NULL) {
 			if (Z_TYPE_P(request) == IS_NULL) {
@@ -497,12 +497,12 @@ PHP_METHOD(Test_Router, handle) {
 				}
 				ZEPHIR_INIT_NVAR(_6);
 				ZVAL_STRING(_6, "request", ZEPHIR_TEMP_PARAM_COPY);
-				ZEPHIR_CALL_METHOD(&request, dependencyInjector, "getshared", &_7, _6);
+				ZEPHIR_CALL_METHOD(&request, dependencyInjector, "getshared", &_7, 0, _6);
 				zephir_check_temp_parameter(_6);
 				zephir_check_call_status();
 			}
 			if (Z_TYPE_P(currentHostName) != IS_OBJECT) {
-				ZEPHIR_CALL_METHOD(&currentHostName, request, "gethttphost", NULL);
+				ZEPHIR_CALL_METHOD(&currentHostName, request, "gethttphost", NULL, 0);
 				zephir_check_call_status();
 			}
 			if (Z_TYPE_P(currentHostName) != IS_NULL) {
@@ -526,7 +526,7 @@ PHP_METHOD(Test_Router, handle) {
 				continue;
 			}
 		}
-		ZEPHIR_CALL_METHOD(&pattern, route, "getcompiledpattern", NULL);
+		ZEPHIR_CALL_METHOD(&pattern, route, "getcompiledpattern", NULL, 0);
 		zephir_check_call_status();
 		if (zephir_memnstr_str(pattern, SL("^"), "test/router.zep", 399)) {
 			ZEPHIR_INIT_NVAR(routeFound);
@@ -536,7 +536,7 @@ PHP_METHOD(Test_Router, handle) {
 			ZVAL_BOOL(routeFound, ZEPHIR_IS_EQUAL(pattern, handledUri));
 		}
 		if (zephir_is_true(routeFound)) {
-			ZEPHIR_CALL_METHOD(&beforeMatch, route, "getbeforematch", NULL);
+			ZEPHIR_CALL_METHOD(&beforeMatch, route, "getbeforematch", NULL, 0);
 			zephir_check_call_status();
 			if (Z_TYPE_P(beforeMatch) != IS_NULL) {
 				if (zephir_is_callable(beforeMatch TSRMLS_CC)) {
@@ -546,11 +546,11 @@ PHP_METHOD(Test_Router, handle) {
 			}
 		}
 		if (zephir_is_true(routeFound)) {
-			ZEPHIR_CALL_METHOD(&paths, route, "getpaths", NULL);
+			ZEPHIR_CALL_METHOD(&paths, route, "getpaths", NULL, 0);
 			zephir_check_call_status();
 			ZEPHIR_CPY_WRT(parts, paths);
 			if (Z_TYPE_P(matches) == IS_ARRAY) {
-				ZEPHIR_CALL_METHOD(&converters, route, "getconverters", NULL);
+				ZEPHIR_CALL_METHOD(&converters, route, "getconverters", NULL, 0);
 				zephir_check_call_status();
 				zephir_is_iterable(paths, &_11, &_10, 0, 0, "test/router.zep", 465);
 				for (
@@ -684,7 +684,7 @@ PHP_METHOD(Test_Router, handle) {
  */
 PHP_METHOD(Test_Router, add) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL;
+	zephir_fcall_cache_entry *_0 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
 	zval *pattern, *paths = NULL, *httpMethods = NULL, *route;
 
@@ -701,7 +701,7 @@ PHP_METHOD(Test_Router, add) {
 
 	ZEPHIR_INIT_VAR(route);
 	object_init_ex(route, test_router_route_ce);
-	ZEPHIR_CALL_METHOD(NULL, route, "__construct", &_0, pattern, paths, httpMethods);
+	ZEPHIR_CALL_METHOD(NULL, route, "__construct", &_0, 62, pattern, paths, httpMethods);
 	zephir_check_call_status();
 	zephir_update_property_array_append(this_ptr, SL("_routes"), route TSRMLS_CC);
 	RETURN_CCTOR(route);
@@ -730,7 +730,7 @@ PHP_METHOD(Test_Router, addGet) {
 
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_STRING(_0, "GET", ZEPHIR_TEMP_PARAM_COPY);
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "add", NULL, pattern, paths, _0);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "add", NULL, 0, pattern, paths, _0);
 	zephir_check_temp_parameter(_0);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -759,7 +759,7 @@ PHP_METHOD(Test_Router, addPost) {
 
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_STRING(_0, "POST", ZEPHIR_TEMP_PARAM_COPY);
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "add", NULL, pattern, paths, _0);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "add", NULL, 0, pattern, paths, _0);
 	zephir_check_temp_parameter(_0);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -788,7 +788,7 @@ PHP_METHOD(Test_Router, addPut) {
 
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_STRING(_0, "PUT", ZEPHIR_TEMP_PARAM_COPY);
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "add", NULL, pattern, paths, _0);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "add", NULL, 0, pattern, paths, _0);
 	zephir_check_temp_parameter(_0);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -817,7 +817,7 @@ PHP_METHOD(Test_Router, addPatch) {
 
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_STRING(_0, "PATCH", ZEPHIR_TEMP_PARAM_COPY);
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "add", NULL, pattern, paths, _0);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "add", NULL, 0, pattern, paths, _0);
 	zephir_check_temp_parameter(_0);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -846,7 +846,7 @@ PHP_METHOD(Test_Router, addDelete) {
 
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_STRING(_0, "DELETE", ZEPHIR_TEMP_PARAM_COPY);
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "add", NULL, pattern, paths, _0);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "add", NULL, 0, pattern, paths, _0);
 	zephir_check_temp_parameter(_0);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -875,7 +875,7 @@ PHP_METHOD(Test_Router, addOptions) {
 
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_STRING(_0, "OPTIONS", ZEPHIR_TEMP_PARAM_COPY);
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "add", NULL, pattern, paths, _0);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "add", NULL, 0, pattern, paths, _0);
 	zephir_check_temp_parameter(_0);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -904,7 +904,7 @@ PHP_METHOD(Test_Router, addHead) {
 
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_STRING(_0, "HEAD", ZEPHIR_TEMP_PARAM_COPY);
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "add", NULL, pattern, paths, _0);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "add", NULL, 0, pattern, paths, _0);
 	zephir_check_temp_parameter(_0);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -933,13 +933,13 @@ PHP_METHOD(Test_Router, mount) {
 		ZEPHIR_THROW_EXCEPTION_DEBUG_STR(test_router_exception_ce, "The group of routes is not valid", "test/router.zep", 677);
 		return;
 	}
-	ZEPHIR_CALL_METHOD(&groupRoutes, group, "getroutes", NULL);
+	ZEPHIR_CALL_METHOD(&groupRoutes, group, "getroutes", NULL, 0);
 	zephir_check_call_status();
 	if (!(zephir_fast_count_int(groupRoutes TSRMLS_CC))) {
 		ZEPHIR_THROW_EXCEPTION_DEBUG_STR(test_router_exception_ce, "The group of routes does not contain any routes", "test/router.zep", 682);
 		return;
 	}
-	ZEPHIR_CALL_METHOD(&beforeMatch, group, "getbeforematch", NULL);
+	ZEPHIR_CALL_METHOD(&beforeMatch, group, "getbeforematch", NULL, 0);
 	zephir_check_call_status();
 	if (Z_TYPE_P(beforeMatch) != IS_NULL) {
 		zephir_is_iterable(groupRoutes, &_1, &_0, 0, 0, "test/router.zep", 692);
@@ -948,11 +948,11 @@ PHP_METHOD(Test_Router, mount) {
 		  ; zephir_hash_move_forward_ex(_1, &_0)
 		) {
 			ZEPHIR_GET_HVALUE(route, _2);
-			ZEPHIR_CALL_METHOD(NULL, route, "beforematch", NULL, beforeMatch);
+			ZEPHIR_CALL_METHOD(NULL, route, "beforematch", NULL, 0, beforeMatch);
 			zephir_check_call_status();
 		}
 	}
-	ZEPHIR_CALL_METHOD(&hostname, group, "gethostname", NULL);
+	ZEPHIR_CALL_METHOD(&hostname, group, "gethostname", NULL, 0);
 	zephir_check_call_status();
 	if (Z_TYPE_P(hostname) != IS_NULL) {
 		zephir_is_iterable(groupRoutes, &_4, &_3, 0, 0, "test/router.zep", 701);
@@ -961,7 +961,7 @@ PHP_METHOD(Test_Router, mount) {
 		  ; zephir_hash_move_forward_ex(_4, &_3)
 		) {
 			ZEPHIR_GET_HVALUE(route, _5);
-			ZEPHIR_CALL_METHOD(NULL, route, "sethostname", NULL, hostname);
+			ZEPHIR_CALL_METHOD(NULL, route, "sethostname", NULL, 0, hostname);
 			zephir_check_call_status();
 		}
 	}
@@ -1152,7 +1152,7 @@ PHP_METHOD(Test_Router, getRouteById) {
 	  ; zephir_hash_move_forward_ex(_2, &_1)
 	) {
 		ZEPHIR_GET_HVALUE(route, _3);
-		ZEPHIR_CALL_METHOD(&_4, route, "getrouteid", NULL);
+		ZEPHIR_CALL_METHOD(&_4, route, "getrouteid", NULL, 0);
 		zephir_check_call_status();
 		if (ZEPHIR_IS_EQUAL(_4, id)) {
 			RETURN_CCTOR(route);
@@ -1187,7 +1187,7 @@ PHP_METHOD(Test_Router, getRouteByName) {
 	  ; zephir_hash_move_forward_ex(_2, &_1)
 	) {
 		ZEPHIR_GET_HVALUE(route, _3);
-		ZEPHIR_CALL_METHOD(&_4, route, "getname", NULL);
+		ZEPHIR_CALL_METHOD(&_4, route, "getname", NULL, 0);
 		zephir_check_call_status();
 		if (ZEPHIR_IS_EQUAL(_4, name)) {
 			RETURN_CCTOR(route);

--- a/ext/test/router/route.zep.c
+++ b/ext/test/router/route.zep.c
@@ -77,7 +77,7 @@ PHP_METHOD(Test_Router_Route, __construct) {
 	}
 
 
-	ZEPHIR_CALL_METHOD(NULL, this_ptr, "reconfigure", NULL, pattern, paths);
+	ZEPHIR_CALL_METHOD(NULL, this_ptr, "reconfigure", NULL, 0, pattern, paths);
 	zephir_check_call_status();
 	zephir_update_property_this(this_ptr, SL("_methods"), httpMethods TSRMLS_CC);
 	ZEPHIR_MM_RESTORE();
@@ -495,7 +495,7 @@ PHP_METHOD(Test_Router_Route, reConfigure) {
 	}
 	if (!(zephir_start_with_str(pattern, SL("#")))) {
 		if (zephir_memnstr_str(pattern, SL("{"), "test/router/route.zep", 348)) {
-			ZEPHIR_CALL_METHOD(&extracted, this_ptr, "extractnamedparams", NULL, pattern);
+			ZEPHIR_CALL_METHOD(&extracted, this_ptr, "extractnamedparams", NULL, 0, pattern);
 			zephir_check_call_status();
 			ZEPHIR_OBS_VAR(pcrePattern);
 			zephir_array_fetch_long(&pcrePattern, extracted, 0, PH_NOISY, "test/router/route.zep", 351 TSRMLS_CC);
@@ -506,7 +506,7 @@ PHP_METHOD(Test_Router_Route, reConfigure) {
 		} else {
 			ZEPHIR_CPY_WRT(pcrePattern, pattern);
 		}
-		ZEPHIR_CALL_METHOD(&compiledPattern, this_ptr, "compilepattern", NULL, pcrePattern);
+		ZEPHIR_CALL_METHOD(&compiledPattern, this_ptr, "compilepattern", NULL, 0, pcrePattern);
 		zephir_check_call_status();
 	} else {
 		ZEPHIR_CPY_WRT(compiledPattern, pattern);

--- a/ext/test/scall.zep.c
+++ b/ext/test/scall.zep.c
@@ -102,7 +102,7 @@ PHP_METHOD(Test_Scall, testCall1) {
 
 	ZEPHIR_MM_GROW();
 
-	ZEPHIR_RETURN_CALL_SELF("testmethod1", NULL);
+	ZEPHIR_RETURN_CALL_SELF("testmethod1", NULL, 0);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -114,7 +114,7 @@ PHP_METHOD(Test_Scall, testCall2) {
 
 	ZEPHIR_MM_GROW();
 
-	ZEPHIR_RETURN_CALL_SELF("testmethod2", NULL);
+	ZEPHIR_RETURN_CALL_SELF("testmethod2", NULL, 0);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -123,11 +123,11 @@ PHP_METHOD(Test_Scall, testCall2) {
 PHP_METHOD(Test_Scall, testCall3) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL;
+	zephir_fcall_cache_entry *_0 = NULL;
 
 	ZEPHIR_MM_GROW();
 
-	ZEPHIR_RETURN_CALL_SELF("testmethod3", &_0);
+	ZEPHIR_RETURN_CALL_SELF("testmethod3", &_0, 63);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -143,7 +143,7 @@ PHP_METHOD(Test_Scall, testCall4) {
 
 
 
-	ZEPHIR_RETURN_CALL_SELF("testmethod4", NULL, a, b);
+	ZEPHIR_RETURN_CALL_SELF("testmethod4", NULL, 0, a, b);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -159,7 +159,7 @@ PHP_METHOD(Test_Scall, testCall5) {
 
 
 
-	ZEPHIR_RETURN_CALL_SELF("testmethod5", NULL, a, b);
+	ZEPHIR_RETURN_CALL_SELF("testmethod5", NULL, 0, a, b);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -168,7 +168,7 @@ PHP_METHOD(Test_Scall, testCall5) {
 PHP_METHOD(Test_Scall, testCall6) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL;
+	zephir_fcall_cache_entry *_0 = NULL;
 	zval *a, *b;
 
 	ZEPHIR_MM_GROW();
@@ -176,7 +176,7 @@ PHP_METHOD(Test_Scall, testCall6) {
 
 
 
-	ZEPHIR_RETURN_CALL_SELF("testmethod6", &_0, a, b);
+	ZEPHIR_RETURN_CALL_SELF("testmethod6", &_0, 64, a, b);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -188,7 +188,7 @@ PHP_METHOD(Test_Scall, testCall7) {
 
 	ZEPHIR_MM_GROW();
 
-	ZEPHIR_RETURN_CALL_SELF("testmethod1", NULL);
+	ZEPHIR_RETURN_CALL_SELF("testmethod1", NULL, 0);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -200,7 +200,7 @@ PHP_METHOD(Test_Scall, testCall8) {
 
 	ZEPHIR_MM_GROW();
 
-	ZEPHIR_RETURN_CALL_SELF("testmethod2", NULL);
+	ZEPHIR_RETURN_CALL_SELF("testmethod2", NULL, 0);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -209,11 +209,11 @@ PHP_METHOD(Test_Scall, testCall8) {
 PHP_METHOD(Test_Scall, testCall9) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL;
+	zephir_fcall_cache_entry *_0 = NULL;
 
 	ZEPHIR_MM_GROW();
 
-	ZEPHIR_RETURN_CALL_SELF("testmethod3", &_0);
+	ZEPHIR_RETURN_CALL_SELF("testmethod3", &_0, 63);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -229,7 +229,7 @@ PHP_METHOD(Test_Scall, testCall10) {
 
 
 
-	ZEPHIR_RETURN_CALL_SELF("testmethod4", NULL, a, b);
+	ZEPHIR_RETURN_CALL_SELF("testmethod4", NULL, 0, a, b);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -245,7 +245,7 @@ PHP_METHOD(Test_Scall, testCall11) {
 
 
 
-	ZEPHIR_RETURN_CALL_SELF("testmethod5", NULL, a, b);
+	ZEPHIR_RETURN_CALL_SELF("testmethod5", NULL, 0, a, b);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -254,7 +254,7 @@ PHP_METHOD(Test_Scall, testCall11) {
 PHP_METHOD(Test_Scall, testCall12) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL;
+	zephir_fcall_cache_entry *_0 = NULL;
 	zval *a, *b;
 
 	ZEPHIR_MM_GROW();
@@ -262,7 +262,7 @@ PHP_METHOD(Test_Scall, testCall12) {
 
 
 
-	ZEPHIR_RETURN_CALL_SELF("testmethod6", &_0, a, b);
+	ZEPHIR_RETURN_CALL_SELF("testmethod6", &_0, 64, a, b);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -271,11 +271,11 @@ PHP_METHOD(Test_Scall, testCall12) {
 PHP_METHOD(Test_Scall, testCall13) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL;
+	zephir_fcall_cache_entry *_0 = NULL;
 
 	ZEPHIR_MM_GROW();
 
-	ZEPHIR_RETURN_CALL_PARENT(test_scall_ce, this_ptr, "testmethod1", &_0);
+	ZEPHIR_RETURN_CALL_PARENT(test_scall_ce, this_ptr, "testmethod1", &_0, 65);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -284,11 +284,11 @@ PHP_METHOD(Test_Scall, testCall13) {
 PHP_METHOD(Test_Scall, testCall14) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL;
+	zephir_fcall_cache_entry *_0 = NULL;
 
 	ZEPHIR_MM_GROW();
 
-	ZEPHIR_RETURN_CALL_PARENT(test_scall_ce, this_ptr, "testmethod2", &_0);
+	ZEPHIR_RETURN_CALL_PARENT(test_scall_ce, this_ptr, "testmethod2", &_0, 66);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -300,7 +300,7 @@ PHP_METHOD(Test_Scall, testCall15) {
 
 	ZEPHIR_MM_GROW();
 
-	ZEPHIR_RETURN_CALL_SELF("testmethod7", NULL);
+	ZEPHIR_RETURN_CALL_SELF("testmethod7", NULL, 0);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -349,7 +349,7 @@ PHP_METHOD(Test_Scall, testCall17) {
 				_0 = 1;
 			}
 			i = _1;
-			ZEPHIR_CALL_CE_STATIC(&_3, test_scallexternal_ce, "testmethod3", &_4, p, p);
+			ZEPHIR_CALL_CE_STATIC(&_3, test_scallexternal_ce, "testmethod3", &_4, 0, p, p);
 			zephir_check_call_status();
 			j += zephir_get_numberval(_3);
 		}
@@ -386,7 +386,7 @@ PHP_METHOD(Test_Scall, testCall18) {
 				_0 = 1;
 			}
 			i = _1;
-			ZEPHIR_CALL_SELF(&_3, "testmethod16", &_4, p, p);
+			ZEPHIR_CALL_SELF(&_3, "testmethod16", &_4, 0, p, p);
 			zephir_check_call_status();
 			j += zephir_get_numberval(_3);
 		}

--- a/ext/test/scallexternal.zep.c
+++ b/ext/test/scallexternal.zep.c
@@ -33,11 +33,11 @@ ZEPHIR_INIT_CLASS(Test_ScallExternal) {
 PHP_METHOD(Test_ScallExternal, testCall1) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL;
+	zephir_fcall_cache_entry *_0 = NULL;
 
 	ZEPHIR_MM_GROW();
 
-	ZEPHIR_RETURN_CALL_CE_STATIC(test_scall_ce, "testmethod1", &_0);
+	ZEPHIR_RETURN_CALL_CE_STATIC(test_scall_ce, "testmethod1", &_0, 67);
 	zephir_check_call_status();
 	RETURN_MM();
 
@@ -46,7 +46,7 @@ PHP_METHOD(Test_ScallExternal, testCall1) {
 PHP_METHOD(Test_ScallExternal, testCall2) {
 
 	int ZEPHIR_LAST_CALL_STATUS;
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL;
+	zephir_fcall_cache_entry *_0 = NULL;
 	zval *a, *b;
 
 	ZEPHIR_MM_GROW();
@@ -54,7 +54,7 @@ PHP_METHOD(Test_ScallExternal, testCall2) {
 
 
 
-	ZEPHIR_RETURN_CALL_CE_STATIC(test_scall_ce, "testmethod4", &_0, a, b);
+	ZEPHIR_RETURN_CALL_CE_STATIC(test_scall_ce, "testmethod4", &_0, 68, a, b);
 	zephir_check_call_status();
 	RETURN_MM();
 

--- a/ext/test/scallparent.zep.c
+++ b/ext/test/scallparent.zep.c
@@ -47,7 +47,7 @@ PHP_METHOD(Test_ScallParent, testCallStatic) {
 
 	ZEPHIR_MM_GROW();
 
-	ZEPHIR_RETURN_CALL_STATIC("testmethodstatic", NULL);
+	ZEPHIR_RETURN_CALL_STATIC("testmethodstatic", NULL, 0);
 	zephir_check_call_status();
 	RETURN_MM();
 

--- a/ext/test/sort.zep.c
+++ b/ext/test/sort.zep.c
@@ -28,7 +28,7 @@ ZEPHIR_INIT_CLASS(Test_Sort) {
 
 PHP_METHOD(Test_Sort, quick) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_7 = NULL, *_10 = NULL;
+	zephir_fcall_cache_entry *_7 = NULL, *_10 = NULL;
 	zend_bool _1;
 	int i, length, pivot, item, _2, _3, ZEPHIR_LAST_CALL_STATUS;
 	zval *arr_param = NULL, *left, *right, *_0, *_4 = NULL, *_5 = NULL, *_6 = NULL, *_9 = NULL;
@@ -79,16 +79,16 @@ PHP_METHOD(Test_Sort, quick) {
 			}
 		}
 	}
-	ZEPHIR_CALL_METHOD(&_6, this_ptr, "quick", &_7, left);
+	ZEPHIR_CALL_METHOD(&_6, this_ptr, "quick", &_7, 69, left);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(_8);
 	zephir_create_array(_8, 1, 0 TSRMLS_CC);
 	ZEPHIR_INIT_NVAR(_5);
 	ZVAL_LONG(_5, pivot);
 	zephir_array_fast_append(_8, _5);
-	ZEPHIR_CALL_METHOD(&_9, this_ptr, "quick", &_7, right);
+	ZEPHIR_CALL_METHOD(&_9, this_ptr, "quick", &_7, 69, right);
 	zephir_check_call_status();
-	ZEPHIR_RETURN_CALL_FUNCTION("array_merge", &_10, _6, _8, _9);
+	ZEPHIR_RETURN_CALL_FUNCTION("array_merge", &_10, 70, _6, _8, _9);
 	zephir_check_call_status();
 	RETURN_MM();
 

--- a/ext/test/spectralnorm.zep.c
+++ b/ext/test/spectralnorm.zep.c
@@ -50,8 +50,7 @@ PHP_METHOD(Test_SpectralNorm, Ax) {
 
 PHP_METHOD(Test_SpectralNorm, Au) {
 
-	zephir_fcall_cache_entry *_11 = NULL, *_13 = NULL;
-	zephir_nts_static zephir_fcall_cache_entry *_9 = NULL;
+	zephir_fcall_cache_entry *_9 = NULL, *_11 = NULL, *_13 = NULL;
 	zend_bool _0, _3;
 	zval *n_param = NULL, *u, *v, *_6 = NULL, *_7 = NULL, *_8 = NULL, *_10 = NULL, *_12 = NULL;
 	int n, t, i, j, _1, _2, _4, _5, ZEPHIR_LAST_CALL_STATUS;
@@ -95,11 +94,11 @@ PHP_METHOD(Test_SpectralNorm, Au) {
 					ZVAL_LONG(_7, i);
 					ZEPHIR_INIT_NVAR(_8);
 					ZVAL_LONG(_8, j);
-					ZEPHIR_CALL_METHOD(&_6, this_ptr, "ax", &_9, _7, _8);
+					ZEPHIR_CALL_METHOD(&_6, this_ptr, "ax", &_9, 71, _7, _8);
 					zephir_check_call_status();
 					ZEPHIR_INIT_NVAR(_7);
 					ZVAL_LONG(_7, j);
-					ZEPHIR_CALL_METHOD(&_10, u, "offsetget", &_11, _7);
+					ZEPHIR_CALL_METHOD(&_10, u, "offsetget", &_11, 0, _7);
 					zephir_check_call_status();
 					ZEPHIR_INIT_LNVAR(_12);
 					mul_function(_12, _6, _10 TSRMLS_CC);
@@ -110,7 +109,7 @@ PHP_METHOD(Test_SpectralNorm, Au) {
 			ZVAL_LONG(_7, i);
 			ZEPHIR_INIT_NVAR(_8);
 			ZVAL_LONG(_8, t);
-			ZEPHIR_CALL_METHOD(NULL, v, "offsetset", &_13, _7, _8);
+			ZEPHIR_CALL_METHOD(NULL, v, "offsetset", &_13, 0, _7, _8);
 			zephir_check_call_status();
 		}
 	}
@@ -120,8 +119,7 @@ PHP_METHOD(Test_SpectralNorm, Au) {
 
 PHP_METHOD(Test_SpectralNorm, Atu) {
 
-	zephir_fcall_cache_entry *_11 = NULL, *_13 = NULL;
-	zephir_nts_static zephir_fcall_cache_entry *_9 = NULL;
+	zephir_fcall_cache_entry *_9 = NULL, *_11 = NULL, *_13 = NULL;
 	zend_bool _0, _3;
 	zval *n_param = NULL, *u, *v, *_6 = NULL, *_7 = NULL, *_8 = NULL, *_10 = NULL, *_12 = NULL;
 	int n, t, i, j, _1, _2, _4, _5, ZEPHIR_LAST_CALL_STATUS;
@@ -165,11 +163,11 @@ PHP_METHOD(Test_SpectralNorm, Atu) {
 					ZVAL_LONG(_7, j);
 					ZEPHIR_INIT_NVAR(_8);
 					ZVAL_LONG(_8, i);
-					ZEPHIR_CALL_METHOD(&_6, this_ptr, "ax", &_9, _7, _8);
+					ZEPHIR_CALL_METHOD(&_6, this_ptr, "ax", &_9, 71, _7, _8);
 					zephir_check_call_status();
 					ZEPHIR_INIT_NVAR(_7);
 					ZVAL_LONG(_7, j);
-					ZEPHIR_CALL_METHOD(&_10, u, "offsetget", &_11, _7);
+					ZEPHIR_CALL_METHOD(&_10, u, "offsetget", &_11, 0, _7);
 					zephir_check_call_status();
 					ZEPHIR_INIT_LNVAR(_12);
 					mul_function(_12, _6, _10 TSRMLS_CC);
@@ -180,7 +178,7 @@ PHP_METHOD(Test_SpectralNorm, Atu) {
 			ZVAL_LONG(_7, i);
 			ZEPHIR_INIT_NVAR(_8);
 			ZVAL_LONG(_8, t);
-			ZEPHIR_CALL_METHOD(NULL, v, "offsetset", &_13, _7, _8);
+			ZEPHIR_CALL_METHOD(NULL, v, "offsetset", &_13, 0, _7, _8);
 			zephir_check_call_status();
 		}
 	}
@@ -190,7 +188,7 @@ PHP_METHOD(Test_SpectralNorm, Atu) {
 
 PHP_METHOD(Test_SpectralNorm, AtAu) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL, *_1 = NULL;
+	zephir_fcall_cache_entry *_0 = NULL, *_1 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
 	zval *n, *u, *v, *w;
 
@@ -199,9 +197,9 @@ PHP_METHOD(Test_SpectralNorm, AtAu) {
 
 
 
-	ZEPHIR_CALL_METHOD(NULL, this_ptr, "au", &_0, n, u, w);
+	ZEPHIR_CALL_METHOD(NULL, this_ptr, "au", &_0, 72, n, u, w);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(NULL, this_ptr, "atu", &_1, n, w, v);
+	ZEPHIR_CALL_METHOD(NULL, this_ptr, "atu", &_1, 73, n, w, v);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();
 
@@ -209,9 +207,8 @@ PHP_METHOD(Test_SpectralNorm, AtAu) {
 
 PHP_METHOD(Test_SpectralNorm, process) {
 
-	zephir_fcall_cache_entry *_6 = NULL, *_15 = NULL;
 	zend_bool _2, _7, _11;
-	zephir_nts_static zephir_fcall_cache_entry *_1 = NULL, *_10 = NULL, *_20 = NULL;
+	zephir_fcall_cache_entry *_1 = NULL, *_6 = NULL, *_10 = NULL, *_15 = NULL, *_20 = NULL;
 	zval *n_param = NULL, *u, *v, *w, *_0 = NULL, *_5 = NULL, *_14 = NULL, *_16 = NULL, *_17 = NULL, *_18 = NULL, _19;
 	int n, i, vv = 0, vBv = 0, ZEPHIR_LAST_CALL_STATUS, _3, _4, _8, _9, _12, _13;
 
@@ -225,19 +222,19 @@ PHP_METHOD(Test_SpectralNorm, process) {
 	object_init_ex(u, spl_ce_SplFixedArray);
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, n);
-	ZEPHIR_CALL_METHOD(NULL, u, "__construct", &_1, _0);
+	ZEPHIR_CALL_METHOD(NULL, u, "__construct", &_1, 74, _0);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(v);
 	object_init_ex(v, spl_ce_SplFixedArray);
 	ZEPHIR_INIT_NVAR(_0);
 	ZVAL_LONG(_0, n);
-	ZEPHIR_CALL_METHOD(NULL, v, "__construct", &_1, _0);
+	ZEPHIR_CALL_METHOD(NULL, v, "__construct", &_1, 74, _0);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(w);
 	object_init_ex(w, spl_ce_SplFixedArray);
 	ZEPHIR_INIT_NVAR(_0);
 	ZVAL_LONG(_0, n);
-	ZEPHIR_CALL_METHOD(NULL, w, "__construct", &_1, _0);
+	ZEPHIR_CALL_METHOD(NULL, w, "__construct", &_1, 74, _0);
 	zephir_check_call_status();
 	_4 = (n - 1);
 	_3 = 0;
@@ -257,19 +254,19 @@ PHP_METHOD(Test_SpectralNorm, process) {
 			ZVAL_LONG(_0, i);
 			ZEPHIR_INIT_NVAR(_5);
 			ZVAL_LONG(_5, 1);
-			ZEPHIR_CALL_METHOD(NULL, u, "offsetset", &_6, _0, _5);
+			ZEPHIR_CALL_METHOD(NULL, u, "offsetset", &_6, 0, _0, _5);
 			zephir_check_call_status();
 			ZEPHIR_INIT_NVAR(_0);
 			ZVAL_LONG(_0, i);
 			ZEPHIR_INIT_NVAR(_5);
 			ZVAL_LONG(_5, 1);
-			ZEPHIR_CALL_METHOD(NULL, v, "offsetset", &_6, _0, _5);
+			ZEPHIR_CALL_METHOD(NULL, v, "offsetset", &_6, 0, _0, _5);
 			zephir_check_call_status();
 			ZEPHIR_INIT_NVAR(_0);
 			ZVAL_LONG(_0, i);
 			ZEPHIR_INIT_NVAR(_5);
 			ZVAL_LONG(_5, 1);
-			ZEPHIR_CALL_METHOD(NULL, w, "offsetset", &_6, _0, _5);
+			ZEPHIR_CALL_METHOD(NULL, w, "offsetset", &_6, 0, _0, _5);
 			zephir_check_call_status();
 		}
 	}
@@ -289,11 +286,11 @@ PHP_METHOD(Test_SpectralNorm, process) {
 			i = _8;
 			ZEPHIR_INIT_NVAR(_0);
 			ZVAL_LONG(_0, n);
-			ZEPHIR_CALL_METHOD(NULL, this_ptr, "atau", &_10, _0, u, v, w);
+			ZEPHIR_CALL_METHOD(NULL, this_ptr, "atau", &_10, 75, _0, u, v, w);
 			zephir_check_call_status();
 			ZEPHIR_INIT_NVAR(_0);
 			ZVAL_LONG(_0, n);
-			ZEPHIR_CALL_METHOD(NULL, this_ptr, "atau", &_10, _0, v, u, w);
+			ZEPHIR_CALL_METHOD(NULL, this_ptr, "atau", &_10, 75, _0, v, u, w);
 			zephir_check_call_status();
 		}
 	}
@@ -313,22 +310,22 @@ PHP_METHOD(Test_SpectralNorm, process) {
 			i = _12;
 			ZEPHIR_INIT_NVAR(_0);
 			ZVAL_LONG(_0, i);
-			ZEPHIR_CALL_METHOD(&_14, u, "offsetget", &_15, _0);
+			ZEPHIR_CALL_METHOD(&_14, u, "offsetget", &_15, 0, _0);
 			zephir_check_call_status();
 			ZEPHIR_INIT_NVAR(_0);
 			ZVAL_LONG(_0, i);
-			ZEPHIR_CALL_METHOD(&_16, v, "offsetget", &_15, _0);
+			ZEPHIR_CALL_METHOD(&_16, v, "offsetget", &_15, 0, _0);
 			zephir_check_call_status();
 			ZEPHIR_INIT_LNVAR(_17);
 			mul_function(_17, _14, _16 TSRMLS_CC);
 			vBv += zephir_get_numberval(_17);
 			ZEPHIR_INIT_NVAR(_0);
 			ZVAL_LONG(_0, i);
-			ZEPHIR_CALL_METHOD(&_14, v, "offsetget", &_15, _0);
+			ZEPHIR_CALL_METHOD(&_14, v, "offsetget", &_15, 0, _0);
 			zephir_check_call_status();
 			ZEPHIR_INIT_NVAR(_0);
 			ZVAL_LONG(_0, i);
-			ZEPHIR_CALL_METHOD(&_16, v, "offsetget", &_15, _0);
+			ZEPHIR_CALL_METHOD(&_16, v, "offsetget", &_15, 0, _0);
 			zephir_check_call_status();
 			ZEPHIR_INIT_LNVAR(_18);
 			mul_function(_18, _14, _16 TSRMLS_CC);
@@ -337,7 +334,7 @@ PHP_METHOD(Test_SpectralNorm, process) {
 	}
 	ZEPHIR_SINIT_VAR(_19);
 	ZVAL_DOUBLE(&_19, zephir_safe_div_long_long(vBv, vv TSRMLS_CC));
-	ZEPHIR_RETURN_CALL_FUNCTION("sqrt", &_20, &_19);
+	ZEPHIR_RETURN_CALL_FUNCTION("sqrt", &_20, 9, &_19);
 	zephir_check_call_status();
 	RETURN_MM();
 

--- a/ext/test/statements.zep.c
+++ b/ext/test/statements.zep.c
@@ -137,7 +137,7 @@ PHP_METHOD(Test_Statements, testElseIf2) {
 
 PHP_METHOD(Test_Statements, test544Issue) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_8 = NULL;
+	zephir_fcall_cache_entry *_8 = NULL;
 	zval *step_param = NULL, *_0, *_1, *_2, *_3, *_4, *_5, _6 = zval_used_for_init, *_7 = NULL, *_9, *_10, *_11 = NULL;
 	int step, filledWidth, unfilledWidth, ZEPHIR_LAST_CALL_STATUS;
 
@@ -163,26 +163,26 @@ PHP_METHOD(Test_Statements, test544Issue) {
 		_5 = zephir_fetch_nproperty_this(this_ptr, SL("filledChar"), PH_NOISY_CC);
 		ZEPHIR_SINIT_VAR(_6);
 		ZVAL_LONG(&_6, filledWidth);
-		ZEPHIR_CALL_FUNCTION(&_7, "str_repeat", &_8, _5, &_6);
+		ZEPHIR_CALL_FUNCTION(&_7, "str_repeat", &_8, 21, _5, &_6);
 		zephir_check_call_status();
 		_9 = zephir_fetch_nproperty_this(this_ptr, SL("arrow"), PH_NOISY_CC);
 		_10 = zephir_fetch_nproperty_this(this_ptr, SL("unfilledChar"), PH_NOISY_CC);
 		ZEPHIR_SINIT_NVAR(_6);
 		ZVAL_LONG(&_6, unfilledWidth);
-		ZEPHIR_CALL_FUNCTION(&_11, "str_repeat", &_8, _10, &_6);
+		ZEPHIR_CALL_FUNCTION(&_11, "str_repeat", &_8, 21, _10, &_6);
 		zephir_check_call_status();
 		ZEPHIR_CONCAT_VVV(return_value, _7, _9, _11);
 		RETURN_MM();
 	} else if (ZEPHIR_IS_LONG_IDENTICAL(_1, step)) {
 		_2 = zephir_fetch_nproperty_this(this_ptr, SL("filledChar"), PH_NOISY_CC);
 		_3 = zephir_fetch_nproperty_this(this_ptr, SL("width"), PH_NOISY_CC);
-		ZEPHIR_RETURN_CALL_FUNCTION("str_repeat", &_8, _2, _3);
+		ZEPHIR_RETURN_CALL_FUNCTION("str_repeat", &_8, 21, _2, _3);
 		zephir_check_call_status();
 		RETURN_MM();
 	} else {
 		_2 = zephir_fetch_nproperty_this(this_ptr, SL("unfilledChar"), PH_NOISY_CC);
 		_3 = zephir_fetch_nproperty_this(this_ptr, SL("width"), PH_NOISY_CC);
-		ZEPHIR_RETURN_CALL_FUNCTION("str_repeat", &_8, _2, _3);
+		ZEPHIR_RETURN_CALL_FUNCTION("str_repeat", &_8, 21, _2, _3);
 		zephir_check_call_status();
 		RETURN_MM();
 	}
@@ -191,7 +191,7 @@ PHP_METHOD(Test_Statements, test544Issue) {
 
 PHP_METHOD(Test_Statements, test544IssueWithVariable) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_6 = NULL;
+	zephir_fcall_cache_entry *_6 = NULL;
 	zval *step_param = NULL, *_0, *_1, *_2, *_3, _4 = zval_used_for_init, *_5 = NULL, *_7, *_8, *_9 = NULL;
 	int step, filledWidth, unfilledWidth, totalSteps, ZEPHIR_LAST_CALL_STATUS;
 
@@ -216,26 +216,26 @@ PHP_METHOD(Test_Statements, test544IssueWithVariable) {
 		_3 = zephir_fetch_nproperty_this(this_ptr, SL("filledChar"), PH_NOISY_CC);
 		ZEPHIR_SINIT_VAR(_4);
 		ZVAL_LONG(&_4, filledWidth);
-		ZEPHIR_CALL_FUNCTION(&_5, "str_repeat", &_6, _3, &_4);
+		ZEPHIR_CALL_FUNCTION(&_5, "str_repeat", &_6, 21, _3, &_4);
 		zephir_check_call_status();
 		_7 = zephir_fetch_nproperty_this(this_ptr, SL("arrow"), PH_NOISY_CC);
 		_8 = zephir_fetch_nproperty_this(this_ptr, SL("unfilledChar"), PH_NOISY_CC);
 		ZEPHIR_SINIT_NVAR(_4);
 		ZVAL_LONG(&_4, unfilledWidth);
-		ZEPHIR_CALL_FUNCTION(&_9, "str_repeat", &_6, _8, &_4);
+		ZEPHIR_CALL_FUNCTION(&_9, "str_repeat", &_6, 21, _8, &_4);
 		zephir_check_call_status();
 		ZEPHIR_CONCAT_VVV(return_value, _5, _7, _9);
 		RETURN_MM();
 	} else if (step == totalSteps) {
 		_1 = zephir_fetch_nproperty_this(this_ptr, SL("filledChar"), PH_NOISY_CC);
 		_2 = zephir_fetch_nproperty_this(this_ptr, SL("width"), PH_NOISY_CC);
-		ZEPHIR_RETURN_CALL_FUNCTION("str_repeat", &_6, _1, _2);
+		ZEPHIR_RETURN_CALL_FUNCTION("str_repeat", &_6, 21, _1, _2);
 		zephir_check_call_status();
 		RETURN_MM();
 	} else {
 		_1 = zephir_fetch_nproperty_this(this_ptr, SL("unfilledChar"), PH_NOISY_CC);
 		_2 = zephir_fetch_nproperty_this(this_ptr, SL("width"), PH_NOISY_CC);
-		ZEPHIR_RETURN_CALL_FUNCTION("str_repeat", &_6, _1, _2);
+		ZEPHIR_RETURN_CALL_FUNCTION("str_repeat", &_6, 21, _1, _2);
 		zephir_check_call_status();
 		RETURN_MM();
 	}

--- a/ext/test/ternary.zep.c
+++ b/ext/test/ternary.zep.c
@@ -80,10 +80,10 @@ PHP_METHOD(Test_Ternary, testTernaryComplex1) {
 	if (100) {
 		ZVAL_LONG(_0, (1 + 100));
 	} else {
-		ZEPHIR_CALL_METHOD(&_1, a, "y", NULL);
+		ZEPHIR_CALL_METHOD(&_1, a, "y", NULL, 0);
 		zephir_check_call_status();
 		if (zephir_is_true(_1)) {
-			ZEPHIR_CALL_METHOD(&_0, a, "x", NULL);
+			ZEPHIR_CALL_METHOD(&_0, a, "x", NULL, 0);
 			zephir_check_call_status();
 		} else {
 			ZEPHIR_INIT_NVAR(_0);
@@ -109,10 +109,10 @@ PHP_METHOD(Test_Ternary, testTernaryComplex2) {
 		ZEPHIR_INIT_NVAR(_0);
 		ZVAL_LONG(_0, (1 + 100));
 	} else {
-		ZEPHIR_CALL_METHOD(&_1, a, "y", NULL);
+		ZEPHIR_CALL_METHOD(&_1, a, "y", NULL, 0);
 		zephir_check_call_status();
 		if (zephir_is_true(_1)) {
-			ZEPHIR_CALL_METHOD(&_0, a, "x", NULL);
+			ZEPHIR_CALL_METHOD(&_0, a, "x", NULL, 0);
 			zephir_check_call_status();
 		} else {
 			ZEPHIR_INIT_NVAR(_0);

--- a/ext/test/trytest.zep.c
+++ b/ext/test/trytest.zep.c
@@ -38,7 +38,7 @@ PHP_METHOD(Test_TryTest, testThrow1) {
 
 PHP_METHOD(Test_TryTest, testThrow2) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_1 = NULL;
+	zephir_fcall_cache_entry *_1 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
 	zval *message, *_0;
 
@@ -48,7 +48,7 @@ PHP_METHOD(Test_TryTest, testThrow2) {
 
 	ZEPHIR_INIT_VAR(_0);
 	object_init_ex(_0, zend_exception_get_default(TSRMLS_C));
-	ZEPHIR_CALL_METHOD(NULL, _0, "__construct", &_1, message);
+	ZEPHIR_CALL_METHOD(NULL, _0, "__construct", &_1, 28, message);
 	zephir_check_call_status();
 	zephir_throw_exception_debug(_0, "test/trytest.zep", 16 TSRMLS_CC);
 	ZEPHIR_MM_RESTORE();
@@ -71,7 +71,7 @@ PHP_METHOD(Test_TryTest, testTry1) {
 
 PHP_METHOD(Test_TryTest, testTry2) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
 	zval *_0, *_1;
 
@@ -84,7 +84,7 @@ PHP_METHOD(Test_TryTest, testTry2) {
 		object_init_ex(_0, zend_exception_get_default(TSRMLS_C));
 		ZEPHIR_INIT_VAR(_1);
 		ZVAL_STRING(_1, "error!", ZEPHIR_TEMP_PARAM_COPY);
-		ZEPHIR_CALL_METHOD(NULL, _0, "__construct", &_2, _1);
+		ZEPHIR_CALL_METHOD(NULL, _0, "__construct", &_2, 28, _1);
 		zephir_check_temp_parameter(_1);
 		zephir_check_call_status_or_jump(try_end_1);
 		zephir_throw_exception_debug(_0, "test/trytest.zep", 27 TSRMLS_CC);
@@ -99,7 +99,7 @@ PHP_METHOD(Test_TryTest, testTry2) {
 
 PHP_METHOD(Test_TryTest, testTry3) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
 	zval *_0 = NULL, *_1;
 
@@ -112,7 +112,7 @@ PHP_METHOD(Test_TryTest, testTry3) {
 		object_init_ex(_0, zend_exception_get_default(TSRMLS_C));
 		ZEPHIR_INIT_VAR(_1);
 		ZVAL_STRING(_1, "error!", ZEPHIR_TEMP_PARAM_COPY);
-		ZEPHIR_CALL_METHOD(NULL, _0, "__construct", &_2, _1);
+		ZEPHIR_CALL_METHOD(NULL, _0, "__construct", &_2, 28, _1);
 		zephir_check_temp_parameter(_1);
 		zephir_check_call_status_or_jump(try_end_1);
 		zephir_throw_exception_debug(_0, "test/trytest.zep", 34 TSRMLS_CC);
@@ -135,7 +135,7 @@ PHP_METHOD(Test_TryTest, testTry3) {
 
 PHP_METHOD(Test_TryTest, testTry4) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL, *_3 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL, *_3 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
 	zval *a_param = NULL, *_0 = NULL, *_1 = NULL;
 	zend_bool a;
@@ -154,7 +154,7 @@ PHP_METHOD(Test_TryTest, testTry4) {
 			object_init_ex(_0, zend_exception_get_default(TSRMLS_C));
 			ZEPHIR_INIT_VAR(_1);
 			ZVAL_STRING(_1, "error!", ZEPHIR_TEMP_PARAM_COPY);
-			ZEPHIR_CALL_METHOD(NULL, _0, "__construct", &_2, _1);
+			ZEPHIR_CALL_METHOD(NULL, _0, "__construct", &_2, 28, _1);
 			zephir_check_temp_parameter(_1);
 			zephir_check_call_status_or_jump(try_end_1);
 			zephir_throw_exception_debug(_0, "test/trytest.zep", 46 TSRMLS_CC);
@@ -165,7 +165,7 @@ PHP_METHOD(Test_TryTest, testTry4) {
 			object_init_ex(_0, spl_ce_RuntimeException);
 			ZEPHIR_INIT_NVAR(_1);
 			ZVAL_STRING(_1, "error!", ZEPHIR_TEMP_PARAM_COPY);
-			ZEPHIR_CALL_METHOD(NULL, _0, "__construct", &_3, _1);
+			ZEPHIR_CALL_METHOD(NULL, _0, "__construct", &_3, 76, _1);
 			zephir_check_temp_parameter(_1);
 			zephir_check_call_status_or_jump(try_end_1);
 			zephir_throw_exception_debug(_0, "test/trytest.zep", 48 TSRMLS_CC);
@@ -195,7 +195,7 @@ PHP_METHOD(Test_TryTest, testTry4) {
 
 PHP_METHOD(Test_TryTest, testTry5) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL, *_3 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL, *_3 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
 	zval *a_param = NULL, *_0 = NULL, *_1 = NULL;
 	zend_bool a;
@@ -214,7 +214,7 @@ PHP_METHOD(Test_TryTest, testTry5) {
 			object_init_ex(_0, zend_exception_get_default(TSRMLS_C));
 			ZEPHIR_INIT_VAR(_1);
 			ZVAL_STRING(_1, "error!", ZEPHIR_TEMP_PARAM_COPY);
-			ZEPHIR_CALL_METHOD(NULL, _0, "__construct", &_2, _1);
+			ZEPHIR_CALL_METHOD(NULL, _0, "__construct", &_2, 28, _1);
 			zephir_check_temp_parameter(_1);
 			zephir_check_call_status_or_jump(try_end_1);
 			zephir_throw_exception_debug(_0, "test/trytest.zep", 63 TSRMLS_CC);
@@ -225,7 +225,7 @@ PHP_METHOD(Test_TryTest, testTry5) {
 			object_init_ex(_0, spl_ce_RuntimeException);
 			ZEPHIR_INIT_NVAR(_1);
 			ZVAL_STRING(_1, "error!", ZEPHIR_TEMP_PARAM_COPY);
-			ZEPHIR_CALL_METHOD(NULL, _0, "__construct", &_3, _1);
+			ZEPHIR_CALL_METHOD(NULL, _0, "__construct", &_3, 76, _1);
 			zephir_check_temp_parameter(_1);
 			zephir_check_call_status_or_jump(try_end_1);
 			zephir_throw_exception_debug(_0, "test/trytest.zep", 65 TSRMLS_CC);
@@ -253,7 +253,7 @@ PHP_METHOD(Test_TryTest, testTry5) {
 
 PHP_METHOD(Test_TryTest, testTry6) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL, *_3 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL, *_3 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
 	zval *a_param = NULL, *e = NULL, *_0 = NULL, *_1 = NULL;
 	zend_bool a;
@@ -272,7 +272,7 @@ PHP_METHOD(Test_TryTest, testTry6) {
 			object_init_ex(_0, zend_exception_get_default(TSRMLS_C));
 			ZEPHIR_INIT_VAR(_1);
 			ZVAL_STRING(_1, "error!", ZEPHIR_TEMP_PARAM_COPY);
-			ZEPHIR_CALL_METHOD(NULL, _0, "__construct", &_2, _1);
+			ZEPHIR_CALL_METHOD(NULL, _0, "__construct", &_2, 28, _1);
 			zephir_check_temp_parameter(_1);
 			zephir_check_call_status_or_jump(try_end_1);
 			zephir_throw_exception_debug(_0, "test/trytest.zep", 80 TSRMLS_CC);
@@ -283,7 +283,7 @@ PHP_METHOD(Test_TryTest, testTry6) {
 			object_init_ex(_0, spl_ce_RuntimeException);
 			ZEPHIR_INIT_NVAR(_1);
 			ZVAL_STRING(_1, "error!", ZEPHIR_TEMP_PARAM_COPY);
-			ZEPHIR_CALL_METHOD(NULL, _0, "__construct", &_3, _1);
+			ZEPHIR_CALL_METHOD(NULL, _0, "__construct", &_3, 76, _1);
 			zephir_check_temp_parameter(_1);
 			zephir_check_call_status_or_jump(try_end_1);
 			zephir_throw_exception_debug(_0, "test/trytest.zep", 82 TSRMLS_CC);
@@ -311,7 +311,7 @@ PHP_METHOD(Test_TryTest, testTry6) {
 
 PHP_METHOD(Test_TryTest, testTry7) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL, *_3 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL, *_3 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
 	zval *a_param = NULL, *e = NULL, *_0 = NULL, *_1 = NULL;
 	zend_bool a;
@@ -330,7 +330,7 @@ PHP_METHOD(Test_TryTest, testTry7) {
 			object_init_ex(_0, zend_exception_get_default(TSRMLS_C));
 			ZEPHIR_INIT_VAR(_1);
 			ZVAL_STRING(_1, "error!", ZEPHIR_TEMP_PARAM_COPY);
-			ZEPHIR_CALL_METHOD(NULL, _0, "__construct", &_2, _1);
+			ZEPHIR_CALL_METHOD(NULL, _0, "__construct", &_2, 28, _1);
 			zephir_check_temp_parameter(_1);
 			zephir_check_call_status_or_jump(try_end_1);
 			zephir_throw_exception_debug(_0, "test/trytest.zep", 99 TSRMLS_CC);
@@ -341,7 +341,7 @@ PHP_METHOD(Test_TryTest, testTry7) {
 			object_init_ex(_0, spl_ce_RuntimeException);
 			ZEPHIR_INIT_NVAR(_1);
 			ZVAL_STRING(_1, "error!", ZEPHIR_TEMP_PARAM_COPY);
-			ZEPHIR_CALL_METHOD(NULL, _0, "__construct", &_3, _1);
+			ZEPHIR_CALL_METHOD(NULL, _0, "__construct", &_3, 76, _1);
 			zephir_check_temp_parameter(_1);
 			zephir_check_call_status_or_jump(try_end_1);
 			zephir_throw_exception_debug(_0, "test/trytest.zep", 101 TSRMLS_CC);
@@ -367,7 +367,7 @@ PHP_METHOD(Test_TryTest, testTry7) {
 
 PHP_METHOD(Test_TryTest, testTry8) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_2 = NULL;
+	zephir_fcall_cache_entry *_2 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
 	zval *_0, *_1;
 
@@ -380,7 +380,7 @@ PHP_METHOD(Test_TryTest, testTry8) {
 		object_init_ex(_0, zend_exception_get_default(TSRMLS_C));
 		ZEPHIR_INIT_VAR(_1);
 		ZVAL_STRING(_1, "error 1!", ZEPHIR_TEMP_PARAM_COPY);
-		ZEPHIR_CALL_METHOD(NULL, _0, "__construct", &_2, _1);
+		ZEPHIR_CALL_METHOD(NULL, _0, "__construct", &_2, 28, _1);
 		zephir_check_temp_parameter(_1);
 		zephir_check_call_status_or_jump(try_end_1);
 		zephir_throw_exception_debug(_0, "test/trytest.zep", 111 TSRMLS_CC);
@@ -413,7 +413,7 @@ PHP_METHOD(Test_TryTest, someMethod2) {
 
 PHP_METHOD(Test_TryTest, testTry9) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL;
+	zephir_fcall_cache_entry *_0 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
 	zval *e = NULL;
 
@@ -422,7 +422,7 @@ PHP_METHOD(Test_TryTest, testTry9) {
 
 	/* try_start_1: */
 
-		ZEPHIR_CALL_METHOD(NULL, this_ptr, "somemethod1", &_0);
+		ZEPHIR_CALL_METHOD(NULL, this_ptr, "somemethod1", &_0, 77);
 		zephir_check_call_status_or_jump(try_end_1);
 		RETURN_MM_STRING("not catched", 1);
 
@@ -441,7 +441,7 @@ PHP_METHOD(Test_TryTest, testTry9) {
 
 PHP_METHOD(Test_TryTest, testTry10) {
 
-	zephir_nts_static zephir_fcall_cache_entry *_0 = NULL;
+	zephir_fcall_cache_entry *_0 = NULL;
 	int ZEPHIR_LAST_CALL_STATUS;
 	zval *e = NULL;
 
@@ -450,7 +450,7 @@ PHP_METHOD(Test_TryTest, testTry10) {
 
 	/* try_start_1: */
 
-		ZEPHIR_CALL_METHOD(NULL, this_ptr, "somemethod2", &_0);
+		ZEPHIR_CALL_METHOD(NULL, this_ptr, "somemethod2", &_0, 78);
 		zephir_check_call_status_or_jump(try_end_1);
 		RETURN_MM_STRING("not catched", 1);
 

--- a/ext/test/typeinstances.zep.c
+++ b/ext/test/typeinstances.zep.c
@@ -39,7 +39,7 @@ PHP_METHOD(Test_TypeInstances, testInstanceOfString1) {
 
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, 24);
-	ZEPHIR_CALL_FUNCTION(&_1, "create_string", NULL, _0);
+	ZEPHIR_CALL_FUNCTION(&_1, "create_string", NULL, 0, _0);
 	zephir_check_call_status();
 	zephir_get_strval(_2, _1);
 	RETURN_CTOR(_2);
@@ -56,7 +56,7 @@ PHP_METHOD(Test_TypeInstances, testInstanceOfString2) {
 
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, -24);
-	ZEPHIR_CALL_FUNCTION(&_1, "create_string", NULL, _0);
+	ZEPHIR_CALL_FUNCTION(&_1, "create_string", NULL, 0, _0);
 	zephir_check_call_status();
 	zephir_get_strval(_2, _1);
 	RETURN_CTOR(_2);
@@ -73,7 +73,7 @@ PHP_METHOD(Test_TypeInstances, testInstanceOfString3) {
 
 	ZEPHIR_INIT_VAR(_0);
 	ZVAL_LONG(_0, 0);
-	ZEPHIR_CALL_FUNCTION(&_1, "create_string", NULL, _0);
+	ZEPHIR_CALL_FUNCTION(&_1, "create_string", NULL, 0, _0);
 	zephir_check_call_status();
 	zephir_get_strval(_2, _1);
 	RETURN_CTOR(_2);

--- a/ext/test/usetest.zep.c
+++ b/ext/test/usetest.zep.c
@@ -52,7 +52,7 @@ PHP_METHOD(Test_UseTest, testUseClass1) {
 	}
 	object_init_ex(return_value, _0);
 	if (zephir_has_constructor(return_value TSRMLS_CC)) {
-		ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL);
+		ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 0);
 		zephir_check_call_status();
 	}
 	RETURN_MM();
@@ -71,7 +71,7 @@ PHP_METHOD(Test_UseTest, testUseClass2) {
 	}
 	object_init_ex(return_value, _0);
 	if (zephir_has_constructor(return_value TSRMLS_CC)) {
-		ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL);
+		ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 0);
 		zephir_check_call_status();
 	}
 	RETURN_MM();
@@ -90,7 +90,7 @@ PHP_METHOD(Test_UseTest, testUseNamespaceAlias) {
 	}
 	object_init_ex(return_value, _0);
 	if (zephir_has_constructor(return_value TSRMLS_CC)) {
-		ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL);
+		ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 0);
 		zephir_check_call_status();
 	}
 	RETURN_MM();

--- a/templates/php_project.h
+++ b/templates/php_project.h
@@ -34,6 +34,8 @@ ZEND_BEGIN_MODULE_GLOBALS(%PROJECT_LOWER%)
 	/** Function cache */
 	HashTable *fcache;
 
+	zephir_fcall_cache_entry *scache[1024];
+
 	/* Cache enabled */
 	unsigned int cache_enabled;
 

--- a/templates/php_project.h
+++ b/templates/php_project.h
@@ -34,7 +34,7 @@ ZEND_BEGIN_MODULE_GLOBALS(%PROJECT_LOWER%)
 	/** Function cache */
 	HashTable *fcache;
 
-	zephir_fcall_cache_entry *scache[1024];
+	zephir_fcall_cache_entry *scache[ZEPHIR_MAX_CACHE_SLOTS];
 
 	/* Cache enabled */
 	unsigned int cache_enabled;

--- a/templates/project.c
+++ b/templates/project.c
@@ -86,8 +86,8 @@ static void php_zephir_init_globals(zend_%PROJECT_LOWER%_globals *zephir_globals
 	/* Recursive Lock */
 	zephir_globals->recursive_lock = 0;
 
-	/** Static cache */	 
-	memset(zephir_globals->scache, '\0', 1024);
+	/** Static cache */
+	memset(zephir_globals->scache, '\0', ZEPHIR_MAX_CACHE_SLOTS);
 
 %INIT_GLOBALS%
 }

--- a/templates/project.c
+++ b/templates/project.c
@@ -86,6 +86,9 @@ static void php_zephir_init_globals(zend_%PROJECT_LOWER%_globals *zephir_globals
 	/* Recursive Lock */
 	zephir_globals->recursive_lock = 0;
 
+	/** Static cache */	 
+	memset(zephir_globals->scache, '\0', 1024);
+
 %INIT_GLOBALS%
 }
 


### PR DESCRIPTION
Previous static-variable based cache in Zephir had problems in PHP-FPM or when functions/methods were overriden and it also wasn't available on Windows. This new cache implements a slot-based cache where functions and methods candidates of being cached are stored in a global indexed cache which should be safer than the static-variable based cache.
- Methods marked as final/private are candidates to use this cache
- Functions that are always bundled with PHP also benefit from this
