### PR TITLE
Low overhead fcall (only PHP 5.6)

### DIFF
--- a/ext/kernel/extended/fcall.c
+++ b/ext/kernel/extended/fcall.c
@@ -32,99 +32,6 @@
 #include "kernel/exception.h"
 #include "kernel/backtrace.h"
 
-/**
- * Calls a function/method in the PHP userland
- */
-int zephir_call_user_function_fast(zval **retval_ptr_ptr, zephir_fcall_cache_entry **cache_entry, zend_uint param_count, zval *params[] TSRMLS_DC)
-{
-	zval ***params_ptr, ***params_array = NULL;
-	zval **static_params_array[10];
-	zval *local_retval_ptr = NULL;
-	int status;
-	zend_fcall_info fci;
-	zend_fcall_info_cache fcic;
-	zend_class_entry *old_scope = EG(scope);
-
-#if PHP_VERSION_ID >= 50600
-	zephir_fcall_info info;
-
-	info.type = ZEPHIR_FCALL_TYPE_FUNC;
-	info.class_name = NULL;
-	info.func_name = "";
-	info.func_length = 0;
-#endif
-
-fprintf(stderr, "here\n");
-
-	if (retval_ptr_ptr && *retval_ptr_ptr) {
-		zval_ptr_dtor(retval_ptr_ptr);
-		*retval_ptr_ptr = NULL;
-	}
-
-	if (param_count) {
-		zend_uint i;
-
-		if (UNEXPECTED(param_count > 10)) {
-			params_array = (zval***) emalloc(param_count * sizeof(zval**));
-			params_ptr   = params_array;
-			for (i = 0; i < param_count; ++i) {
-				params_array[i] = &params[i];
-			}
-		} else {
-			params_ptr = static_params_array;
-			for (i = 0; i < param_count; ++i) {
-				static_params_array[i] = &params[i];
-			}
-		}
-	} else {
-		params_ptr = NULL;
-	}
-
-	fci.size           = sizeof(fci);
-	fci.function_table = EG(function_table);
-	fci.object_ptr     = NULL;
-	fci.function_name  = NULL;
-	fci.retval_ptr_ptr = retval_ptr_ptr ? retval_ptr_ptr : &local_retval_ptr;
-	fci.param_count    = param_count;
-	fci.params         = params_ptr;
-	fci.no_separation  = 1;
-	fci.symbol_table   = NULL;
-
-	fcic.initialized = 0;
-	fcic.function_handler = NULL;
-	fcic.calling_scope = NULL;
-	fcic.called_scope = NULL;
-	fcic.object_ptr    = NULL;
-	fcic.initialized   = 1;
-
-#ifndef ZEPHIR_RELEASE
-	fcic.function_handler = (*cache_entry)->f;
-	++(*cache_entry)->times;
-#else
-	fcic.function_handler = *cache_entry;
-#endif
-
-#if PHP_VERSION_ID >= 50600
-	status = ZEPHIR_ZEND_CALL_FUNCTION_WRAPPER(&fci, &fcic, &info TSRMLS_CC);
-#else
-	status = ZEPHIR_ZEND_CALL_FUNCTION_WRAPPER(&fci, &fcic TSRMLS_CC);
-#endif
-
-	EG(scope) = old_scope;
-
-	if (UNEXPECTED(params_array != NULL)) {
-		efree(params_array);
-	}
-
-	if (!retval_ptr_ptr) {
-		if (local_retval_ptr) {
-			zval_ptr_dtor(&local_retval_ptr);
-		}
-	}
-
-	return status;
-}
-
 #if PHP_VERSION_ID >= 50600
 
 #if ZEND_MODULE_API_NO >= 20141001
@@ -183,6 +90,217 @@ static void zephir_throw_exception_internal(zval *exception TSRMLS_DC)
 
 	EG(opline_before_exception) = EG(current_execute_data)->opline;
 	EG(current_execute_data)->opline = EG(exception_op);
+}
+
+int zephir_call_function_opt_fast(zval **retval_ptr_ptr, zephir_fcall_cache_entry **cache_entry, zend_uint param_count, zval *pparams[] TSRMLS_DC)
+{
+	zend_uint i;
+	zval **original_return_value;
+	HashTable *calling_symbol_table;
+	zend_op_array *original_op_array;
+	zend_op **original_opline_ptr;
+	zend_class_entry *current_scope;
+	zend_class_entry *current_called_scope;
+	zend_class_entry *calling_scope = NULL;
+	zend_class_entry *called_scope = NULL;
+	zend_execute_data execute_data;
+	zval ***params, ***params_ptr, ***params_array = NULL;
+	zval **static_params_array[10];
+	zend_class_entry *old_scope = EG(scope);
+	zend_function_state *function_state = &EX(function_state);
+	zend_function *func;
+
+	if (retval_ptr_ptr && *retval_ptr_ptr) {
+		zval_ptr_dtor(retval_ptr_ptr);
+		*retval_ptr_ptr = NULL;
+	}
+
+	if (param_count) {
+
+		if (UNEXPECTED(param_count > 10)) {
+			params_array = (zval***) emalloc(param_count * sizeof(zval**));
+			params   = params_array;
+			for (i = 0; i < param_count; ++i) {
+				params_array[i] = &pparams[i];
+			}
+		} else {
+			params = static_params_array;
+			for (i = 0; i < param_count; ++i) {
+				static_params_array[i] = &pparams[i];
+			}
+		}
+	} else {
+		params_ptr = NULL;
+	}
+
+	if (!EG(active)) {
+		return FAILURE; /* executor is already inactive */
+	}
+
+	if (EG(exception)) {
+		return FAILURE; /* we would result in an instable executor otherwise */
+	}
+
+	/* Initialize execute_data */
+	if (EG(current_execute_data)) {
+		execute_data = *EG(current_execute_data);
+		EX(op_array) = NULL;
+		EX(opline) = NULL;
+		EX(object) = NULL;
+	} else {
+		/* This only happens when we're called outside any execute()'s
+		 * It shouldn't be strictly necessary to NULL execute_data out,
+		 * but it may make bugs easier to spot
+		 */
+		memset(&execute_data, 0, sizeof(zend_execute_data));
+	}
+
+#ifndef ZEPHIR_RELEASE
+	function_state->function = (*cache_entry)->f;
+	++(*cache_entry)->times;
+#else
+	function_state->function = *cache_entry;
+#endif
+	func = function_state->function;
+
+	calling_scope = NULL;
+	called_scope = NULL;
+	EX(object) = NULL;
+
+	ZEND_VM_STACK_GROW_IF_NEEDED(param_count + 1);
+
+	for (i = 0; i < param_count; i++) {
+		zval *param;
+
+		if (ARG_SHOULD_BE_SENT_BY_REF(func, i + 1)) {
+			if (!PZVAL_IS_REF(*params[i]) && Z_REFCOUNT_PP(params[i]) > 1) {
+				zval *new_zval;
+
+				if (!ARG_MAY_BE_SENT_BY_REF(func, i + 1)) {
+					if (i || UNEXPECTED(ZEND_VM_STACK_ELEMETS(EG(argument_stack)) == (EG(argument_stack)->top))) {
+						/* hack to clean up the stack */
+						zend_vm_stack_push((void *) (zend_uintptr_t)i TSRMLS_CC);
+						zend_vm_stack_clear_multiple(0 TSRMLS_CC);
+					}
+
+					zend_error(E_WARNING, "Parameter %d to %s%s%s() expected to be a reference, value given",
+						i+1,
+						func->common.scope ? func->common.scope->name : "",
+						func->common.scope ? "::" : "",
+						func->common.function_name);
+					return FAILURE;
+				}
+
+				ALLOC_ZVAL(new_zval);
+				*new_zval = **params[i];
+				zval_copy_ctor(new_zval);
+				Z_SET_REFCOUNT_P(new_zval, 1);
+				Z_DELREF_PP(params[i]);
+				*params[i] = new_zval;
+			}
+			Z_ADDREF_PP(params[i]);
+			Z_SET_ISREF_PP(params[i]);
+			param = *params[i];
+		} else if (PZVAL_IS_REF(*params[i]) && (func->common.fn_flags & ZEND_ACC_CALL_VIA_HANDLER) == 0 ) {
+			ALLOC_ZVAL(param);
+			*param = **(params[i]);
+			INIT_PZVAL(param);
+			zval_copy_ctor(param);
+		} else if (*params[i] != &EG(uninitialized_zval)) {
+			Z_ADDREF_PP(params[i]);
+			param = *params[i];
+		} else {
+			ALLOC_ZVAL(param);
+			*param = **(params[i]);
+			INIT_PZVAL(param);
+		}
+		zend_vm_stack_push(param TSRMLS_CC);
+	}
+
+	function_state->arguments = zend_vm_stack_top(TSRMLS_C);
+	zend_vm_stack_push((void*)(zend_uintptr_t)param_count TSRMLS_CC);
+
+	current_scope = EG(scope);
+	EG(scope) = calling_scope;
+
+	current_called_scope = EG(called_scope);
+	if (called_scope) {
+		EG(called_scope) = called_scope;
+	} else if (func->type != ZEND_INTERNAL_FUNCTION) {
+		EG(called_scope) = NULL;
+	}
+
+	EX(prev_execute_data) = EG(current_execute_data);
+	EG(current_execute_data) = &execute_data;
+
+	if (func->type == ZEND_USER_FUNCTION) {
+
+		calling_symbol_table = EG(active_symbol_table);
+		EG(scope) = func->common.scope;
+		EG(active_symbol_table) = NULL;
+
+		original_return_value = EG(return_value_ptr_ptr);
+		original_op_array = EG(active_op_array);
+		EG(return_value_ptr_ptr) = retval_ptr_ptr;
+		EG(active_op_array) = (zend_op_array *) function_state->function;
+		original_opline_ptr = EG(opline_ptr);
+
+		zend_execute(EG(active_op_array) TSRMLS_CC);
+
+		if (EG(active_symbol_table)) {
+			zephir_clean_and_cache_symbol_table(EG(active_symbol_table) TSRMLS_CC);
+		}
+		EG(active_symbol_table) = calling_symbol_table;
+		EG(active_op_array) = original_op_array;
+		EG(return_value_ptr_ptr)=original_return_value;
+		EG(opline_ptr) = original_opline_ptr;
+	} else if (func->type == ZEND_INTERNAL_FUNCTION) {
+
+		ALLOC_INIT_ZVAL(*retval_ptr_ptr);
+		if (func->common.scope) {
+			EG(scope) = func->common.scope;
+		}
+
+		func->internal_function.handler(param_count, *retval_ptr_ptr, retval_ptr_ptr, NULL, 1 TSRMLS_CC);
+
+		if (EG(exception) && retval_ptr_ptr) {
+			zval_ptr_dtor(retval_ptr_ptr);
+			*retval_ptr_ptr = NULL;
+		}
+
+	} else { /* ZEND_OVERLOADED_FUNCTION */
+		ALLOC_INIT_ZVAL(*retval_ptr_ptr);
+
+		/* Not sure what should be done here if it's a static method */
+		zend_error_noreturn(E_ERROR, "Cannot call overloaded function for non-object");
+
+		if (func->type == ZEND_OVERLOADED_FUNCTION_TEMPORARY) {
+			efree((char*)func->common.function_name);
+		}
+		efree(function_state->function);
+
+		if (EG(exception) && retval_ptr_ptr) {
+			zval_ptr_dtor(retval_ptr_ptr);
+			*retval_ptr_ptr = NULL;
+		}
+	}
+	zend_vm_stack_clear_multiple(0 TSRMLS_CC);
+
+	EG(called_scope) = current_called_scope;
+	EG(scope) = current_scope;
+	EG(current_execute_data) = EX(prev_execute_data);
+
+	if (EG(exception)) {
+		zephir_throw_exception_internal(NULL TSRMLS_CC);
+	}
+
+	EG(scope) = old_scope;
+
+	if (UNEXPECTED(params_array != NULL)) {
+		efree(params_array);
+	}
+
+	return SUCCESS;
 }
 
 static int zephir_is_callable_check_class(const char *name, int name_len, zend_fcall_info_cache *fcc, int *strict_class, char **error TSRMLS_DC) /* {{{ */

--- a/ext/kernel/extended/fcall.c
+++ b/ext/kernel/extended/fcall.c
@@ -92,7 +92,7 @@ static void zephir_throw_exception_internal(zval *exception TSRMLS_DC)
 	EG(current_execute_data)->opline = EG(exception_op);
 }
 
-int zephir_call_function_opt_fast(zval **retval_ptr_ptr, zephir_fcall_cache_entry **cache_entry, zend_uint param_count, zval *pparams[] TSRMLS_DC)
+int zephir_call_func_aparams_fast(zval **retval_ptr_ptr, zephir_fcall_cache_entry **cache_entry, zend_uint param_count, zval *pparams[] TSRMLS_DC)
 {
 	zend_uint i;
 	zval **original_return_value;
@@ -108,7 +108,7 @@ int zephir_call_function_opt_fast(zval **retval_ptr_ptr, zephir_fcall_cache_entr
 	zval **static_params_array[10];
 	zend_class_entry *old_scope = EG(scope);
 	zend_function_state *function_state = &EX(function_state);
-	zend_function *func;
+	zend_function *func;	
 
 	if (retval_ptr_ptr && *retval_ptr_ptr) {
 		zval_ptr_dtor(retval_ptr_ptr);

--- a/ext/kernel/extended/fcall.h
+++ b/ext/kernel/extended/fcall.h
@@ -38,6 +38,6 @@ typedef struct _zephir_fcall_info {
 } zephir_fcall_info;
 
 int zephir_call_function_opt(zend_fcall_info *fci, zend_fcall_info_cache *fci_cache, zephir_fcall_info *info TSRMLS_DC);
-int zephir_call_user_function_fast(zval **retval_ptr_ptr, zephir_fcall_cache_entry **cache_entry, zend_uint param_count, zval *params[] TSRMLS_DC);
+int zephir_call_func_aparams_fast(zval **return_value_ptr, zephir_fcall_cache_entry **cache_entry, uint param_count, zval **params TSRMLS_DC);
 
 #endif

--- a/ext/kernel/extended/fcall.h
+++ b/ext/kernel/extended/fcall.h
@@ -38,5 +38,6 @@ typedef struct _zephir_fcall_info {
 } zephir_fcall_info;
 
 int zephir_call_function_opt(zend_fcall_info *fci, zend_fcall_info_cache *fci_cache, zephir_fcall_info *info TSRMLS_DC);
+int zephir_call_user_function_fast(zval **retval_ptr_ptr, zephir_fcall_cache_entry **cache_entry, zend_uint param_count, zval *params[] TSRMLS_DC);
 
 #endif

--- a/ext/kernel/fcall.c
+++ b/ext/kernel/fcall.c
@@ -715,6 +715,34 @@ int zephir_call_func_aparams(zval **return_value_ptr, const char *func_name, uin
 	return status;
 }
 
+int zephir_call_func_aparams_fast(zval **return_value_ptr, zephir_fcall_cache_entry **cache_entry, uint param_count, zval **params TSRMLS_DC)
+{
+	int status;
+	zval *rv = NULL, **rvp = return_value_ptr ? return_value_ptr : &rv;
+
+	status = zephir_call_user_function_fast(rvp, cache_entry, param_count, params TSRMLS_CC);
+	if (status == FAILURE && !EG(exception)) {
+		zephir_throw_exception_format(spl_ce_RuntimeException TSRMLS_CC, "Call to undefined function ?()");
+		if (return_value_ptr) {
+			*return_value_ptr = NULL;
+		}
+	} else {
+		if (EG(exception)) {
+			status = FAILURE;
+			if (return_value_ptr) {
+				*return_value_ptr = NULL;
+			}
+		}
+	}
+
+	if (rv) {
+		zval_ptr_dtor(&rv);
+	}
+
+	return status;
+}
+
+
 int zephir_call_zval_func_aparams(zval **return_value_ptr, zval *func_name,
 	zephir_fcall_cache_entry **cache_entry, int cache_slot,
 	uint param_count, zval **params TSRMLS_DC)

--- a/ext/kernel/fcall.c
+++ b/ext/kernel/fcall.c
@@ -720,19 +720,12 @@ int zephir_call_func_aparams_fast(zval **return_value_ptr, zephir_fcall_cache_en
 	int status;
 	zval *rv = NULL, **rvp = return_value_ptr ? return_value_ptr : &rv;
 
-	status = zephir_call_user_function_fast(rvp, cache_entry, param_count, params TSRMLS_CC);
-	if (status == FAILURE && !EG(exception)) {
-		zephir_throw_exception_format(spl_ce_RuntimeException TSRMLS_CC, "Call to undefined function ?()");
+	status = zephir_call_function_opt_fast(rvp, cache_entry, param_count, params TSRMLS_CC);
+	if (EG(exception)) {
+		status = FAILURE;
 		if (return_value_ptr) {
 			*return_value_ptr = NULL;
-		}
-	} else {
-		if (EG(exception)) {
-			status = FAILURE;
-			if (return_value_ptr) {
-				*return_value_ptr = NULL;
-			}
-		}
+		}		
 	}
 
 	if (rv) {
@@ -741,7 +734,6 @@ int zephir_call_func_aparams_fast(zval **return_value_ptr, zephir_fcall_cache_en
 
 	return status;
 }
-
 
 int zephir_call_zval_func_aparams(zval **return_value_ptr, zval *func_name,
 	zephir_fcall_cache_entry **cache_entry, int cache_slot,

--- a/ext/kernel/fcall.h
+++ b/ext/kernel/fcall.h
@@ -59,11 +59,11 @@ typedef enum _zephir_call_type {
  * @note If the call fails or an exception occurs, the memory frame is @em not restored.
  * In this case if @c return_value_ptr is not @c NULL, <tt>*return_value_ptr</tt> is set to @c NULL
  */
-#define ZEPHIR_CALL_FUNCTIONW(return_value_ptr, func_name, ...) \
+#define ZEPHIR_CALL_FUNCTIONW(return_value_ptr, func_name, cache, cache_slot, ...) \
 	do { \
 		zval *params_[] = {ZEPHIR_FETCH_VA_ARGS __VA_ARGS__}; \
 		if (__builtin_constant_p(func_name)) { \
-			if (cache) { \
+			if (cache && *cache) { \
 				ZEPHIR_LAST_CALL_STATUS = zephir_call_func_aparams_fast(return_value_ptr, cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 			} else { \
 				ZEPHIR_LAST_CALL_STATUS = zephir_call_func_aparams(return_value_ptr, func_name, sizeof(func_name)-1, cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
@@ -86,13 +86,12 @@ typedef enum _zephir_call_type {
 		zval *params_[] = {ZEPHIR_FETCH_VA_ARGS __VA_ARGS__}; \
 		ZEPHIR_OBSERVE_OR_NULLIFY_PPZV(return_value_ptr); \
 		if (__builtin_constant_p(func_name)) { \
-			if (cache) { \
-				ZEPHIR_LAST_CALL_STATUS = zephir_call_func_aparams_fast(return_value_ptr, cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
-			} else { \
+			if (!cache) { \
 				ZEPHIR_LAST_CALL_STATUS = zephir_call_func_aparams(return_value_ptr, func_name, sizeof(func_name)-1, cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			} else { \
+				ZEPHIR_LAST_CALL_STATUS = zephir_call_func_aparams_fast(return_value_ptr, cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 			} \
-		} \
-		else { \
+		} else { \
 			ZEPHIR_LAST_CALL_STATUS = zephir_call_func_aparams(return_value_ptr, func_name, strlen(func_name), cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 	} while (0)
@@ -150,7 +149,11 @@ typedef enum _zephir_call_type {
 		zval *params_[] = {ZEPHIR_FETCH_VA_ARGS __VA_ARGS__}; \
 		ZEPHIR_OBSERVE_OR_NULLIFY_PPZV(return_value_ptr); \
 		if (__builtin_constant_p(func_name)) { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_call_zval_func_aparams(return_value_ptr, func_name, cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			if (!cache || !*cache) { \
+				ZEPHIR_LAST_CALL_STATUS = zephir_call_zval_func_aparams(return_value_ptr, func_name, cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			} else { \
+				ZEPHIR_LAST_CALL_STATUS = zephir_call_func_aparams_fast(return_value_ptr, cache_entry, param_count, *params TSRMLS_CC); \
+			} \
 		} \
 		else { \
 			ZEPHIR_LAST_CALL_STATUS = zephir_call_zval_func_aparams(return_value_ptr, func_name, cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \

--- a/ext/kernel/fcall.h
+++ b/ext/kernel/fcall.h
@@ -63,9 +63,12 @@ typedef enum _zephir_call_type {
 	do { \
 		zval *params_[] = {ZEPHIR_FETCH_VA_ARGS __VA_ARGS__}; \
 		if (__builtin_constant_p(func_name)) { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_call_func_aparams(return_value_ptr, func_name, sizeof(func_name)-1, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
-		} \
-		else { \
+			if (cache) { \
+				ZEPHIR_LAST_CALL_STATUS = zephir_call_func_aparams_fast(return_value_ptr, cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			} else { \
+				ZEPHIR_LAST_CALL_STATUS = zephir_call_func_aparams(return_value_ptr, func_name, sizeof(func_name)-1, cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			} \
+		} else { \
 			ZEPHIR_LAST_CALL_STATUS = zephir_call_func_aparams(return_value_ptr, func_name, strlen(func_name), ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
 		} \
 	} while (0)
@@ -83,7 +86,11 @@ typedef enum _zephir_call_type {
 		zval *params_[] = {ZEPHIR_FETCH_VA_ARGS __VA_ARGS__}; \
 		ZEPHIR_OBSERVE_OR_NULLIFY_PPZV(return_value_ptr); \
 		if (__builtin_constant_p(func_name)) { \
-			ZEPHIR_LAST_CALL_STATUS = zephir_call_func_aparams(return_value_ptr, func_name, sizeof(func_name)-1, cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			if (cache) { \
+				ZEPHIR_LAST_CALL_STATUS = zephir_call_func_aparams_fast(return_value_ptr, cache, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			} else { \
+				ZEPHIR_LAST_CALL_STATUS = zephir_call_func_aparams(return_value_ptr, func_name, sizeof(func_name)-1, cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
+			} \
 		} \
 		else { \
 			ZEPHIR_LAST_CALL_STATUS = zephir_call_func_aparams(return_value_ptr, func_name, strlen(func_name), cache, cache_slot, ZEPHIR_CALL_NUM_PARAMS(params_), ZEPHIR_PASS_CALL_PARAMS(params_) TSRMLS_CC); \
@@ -524,6 +531,8 @@ typedef enum _zephir_call_type {
 int zephir_call_func_aparams(zval **return_value_ptr, const char *func_name, uint func_length,
 	zephir_fcall_cache_entry **cache_entry, int cache_slot,
 	uint param_count, zval **params TSRMLS_DC);
+
+int zephir_call_func_aparams_fast(zval **return_value_ptr, zephir_fcall_cache_entry **cache_entry, uint param_count, zval **params TSRMLS_DC);
 
 int zephir_call_zval_func_aparams(zval **return_value_ptr, zval *func_name,
 	zephir_fcall_cache_entry **cache_entry, int cache_slot,

--- a/parser/parser.lemon
+++ b/parser/parser.lemon
@@ -536,7 +536,7 @@ static json_object *xx_ret_type(int type)
 		default:
 			fprintf(stderr, "unknown type?\n");
 	}
-
+	return json_object_new_string("unknown");
 }
 
 static json_object *xx_ret_list(json_object *list_left, json_object *right_list)


### PR DESCRIPTION
This PR introduces a specialized function to call functions in the PHP userland removing many internal intermediate structures. `zephir_call_func_aparams_fast` is only used when an inline local cache is available for the method. This is when a function is called more than once in the same method or a function is called within a loop.

The following code:

``` php
public static function guid()
{
        return sprintf("%04X%04X-%04X-%04X-%04X-%04X%04X%04X", 
            rand(0, 65535), rand(0, 65535), 
            rand(0, 65535), rand(16384, 20479), 
            rand(32768, 49151), rand(0, 65535), 
            rand(0, 65535), rand(0, 65535));
}
```

Benchmark (executed 1'000.000 times):

``` php
v0.6.2 3289 milliseconds
v0.6.3 2149 milliseconds
65% improvement
```
