### PR TITLE
Implement arrays as default values of static properties

### DIFF
--- a/Library/ClassDefinition.php
+++ b/Library/ClassDefinition.php
@@ -782,7 +782,10 @@ class ClassDefinition
      */
     private function getInternalSignature(ClassMethod $method)
     {
-
+        if ($method->getName() == 'zephir_init_static_properties') {
+            $classDefinition = $method->getClassDefinition();
+            return 'void ' . $method->getName() . '_' . $classDefinition->getCNamespace() . '_' . $classDefinition->getName() . '(TSRMLS_D)';
+        }
         $signatureParameters = array();
         $parameters = $method->getParameters();
         if (is_object($parameters)) {
@@ -806,10 +809,10 @@ class ClassDefinition
         }
 
         if (count($signatureParameters)) {
-            return 'static void ' . $method->getInternalName() . '(int ht, zval *return_value, zval **return_value_ptr, zval *this_ptr, int return_value_used, ' . join(', ', $signatureParameters) . ' TSRMLS_DC) {';
+            return 'static void ' . $method->getInternalName() . '(int ht, zval *return_value, zval **return_value_ptr, zval *this_ptr, int return_value_used, ' . join(', ', $signatureParameters) . ' TSRMLS_DC)';
         }
 
-        return 'static void ' . $method->getInternalName() . '(int ht, zval *return_value, zval **return_value_ptr, zval *this_ptr, int return_value_used TSRMLS_DC) {';
+        return 'static void ' . $method->getInternalName() . '(int ht, zval *return_value, zval **return_value_ptr, zval *this_ptr, int return_value_used TSRMLS_DC)';
     }
 
     /**
@@ -1030,7 +1033,7 @@ class ClassDefinition
                 if (!$method->isInternal()) {
                     $codePrinter->output('PHP_METHOD(' . $this->getCNamespace() . '_' . $this->getName() . ', ' . $method->getName() . ') {');
                 } else {
-                    $codePrinter->output($this->getInternalSignature($method));
+                    $codePrinter->output($this->getInternalSignature($method) . ' {');
                 }
                 $codePrinter->outputBlankLine();
 
@@ -1073,6 +1076,8 @@ class ClassDefinition
                 foreach ($methods as $method) {
                     if (!$method->isInternal()) {
                         $codePrinter->output('PHP_METHOD(' . $this->getCNamespace() . '_' . $this->getName() . ', ' . $method->getName() . ');');
+                    } else {
+                        $codePrinter->output($this->getInternalSignature($method) . ';');
                     }
                 }
                 $codePrinter->outputBlankLine();

--- a/Library/ClassProperty.php
+++ b/Library/ClassProperty.php
@@ -21,6 +21,7 @@ namespace Zephir;
 
 use Zephir\Builder\StatementsBlockBuilder;
 use Zephir\Builder\Statements\LetStatementBuilder;
+use Zephir\Statements\LetStatement;
 
 /**
  * ClassProperty
@@ -247,11 +248,14 @@ class ClassProperty
 
             case 'array':
             case 'empty-array':
+                $methodName = '__construct';
+                $visibility = array('public');
                 if ($this->isStatic()) {
-                    throw new CompilerException('Cannot define static property with default value: ' . $this->defaultValue['type'], $this->original);
+                    $methodName = 'zephir_init_static_properties';
+                    $visibility = array('internal');
                 }
 
-                $constructMethod = $compilationContext->classDefinition->getMethod('__construct');
+                $constructMethod = $compilationContext->classDefinition->getMethod($methodName);
                 if ($constructMethod) {
                     $statementsBlock = $constructMethod->getStatementsBlock();
                     if ($statementsBlock) {
@@ -294,8 +298,8 @@ class ClassProperty
 
                     $compilationContext->classDefinition->getEventsManager()->dispatch('setMethod', array(new ClassMethod(
                         $compilationContext->classDefinition,
-                        array('public'),
-                        '__construct',
+                        $visibility,
+                        $methodName,
                         null,
                         $statementsBlock
                     ), null));
@@ -323,10 +327,21 @@ class ClassProperty
      */
     protected function getLetStatement()
     {
+        if (!$this->isStatic()) {
+            return new LetStatementBuilder(array(
+                'assign-type' => 'object-property',
+                'operator'    => 'assign',
+                'variable'    => 'this',
+                'property'    => $this->name,
+                'file'        => $this->original['default']['file'],
+                'line'        => $this->original['default']['line'],
+                'char'        => $this->original['default']['char'],
+            ), $this->original['default']);
+        }
         return new LetStatementBuilder(array(
-            'assign-type' => 'object-property',
+            'assign-type' => 'static-property',
             'operator'    => 'assign',
-            'variable'    => 'this',
+            'variable'    => '\\'.$this->classDefinition->getCompleteName(),
             'property'    => $this->name,
             'file'        => $this->original['default']['file'],
             'line'        => $this->original['default']['line'],

--- a/test/properties/staticpropertyarray.zep
+++ b/test/properties/staticpropertyarray.zep
@@ -1,0 +1,19 @@
+
+namespace Test\Properties;
+
+/**
+ * @link https://github.com/phalcon/zephir/issues/367
+ * @link https://github.com/phalcon/zephir/issues/188
+ */
+class StaticPropertyArray
+{
+	/**
+	 * This is a public property with an initial empty-array value
+	 */
+	public static someEmptyArray = [];
+
+	/**
+	 * This is a public property with an initial array value
+	 */
+	public static someArray = [1, 2, 3, 4];
+}

--- a/unit-tests/Extension/Properties/StaticPropertyArrayTest.php
+++ b/unit-tests/Extension/Properties/StaticPropertyArrayTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------------+
+ | Zephir Language                                                          |
+ +--------------------------------------------------------------------------+
+ | Copyright (c) 2013-2015 Zephir Team and contributors                     |
+ +--------------------------------------------------------------------------+
+ | This source file is subject the MIT license, that is bundled with        |
+ | this package in the file LICENSE, and is available through the           |
+ | world-wide-web at the following url:                                     |
+ | http://zephir-lang.com/license.html                                      |
+ |                                                                          |
+ | If you did not receive a copy of the MIT license and are unable          |
+ | to obtain it through the world-wide-web, please send a note to           |
+ | license@zephir-lang.com so we can mail you a copy immediately.           |
+ +--------------------------------------------------------------------------+
+*/
+
+namespace Extension\Properties;
+
+use Test\Properties\StaticPropertyArray;
+
+class StaticPropertyArrayTest extends \PHPUnit_Framework_TestCase
+{
+    public function testAssertations()
+    {
+        $this->assertSame(array(), StaticPropertyArray::$someEmptyArray);
+        $this->assertSame(array(1, 2, 3, 4), StaticPropertyArray::$someArray);
+    }
+}


### PR DESCRIPTION
This implements #367 and #188.

This is similarily implemented as for normal properties,
which simply use the "__construct" method to achieve
this property initialization.

For static properties instead we create a new initialization function,
which is executed on initialization (RINIT, Request Init), which
then simply initializes the properties.
