### PR TITLE
Improves performance of the getResolveParamsAsExp method

### DIFF
--- a/Library/Call.php
+++ b/Library/Call.php
@@ -249,7 +249,8 @@ class Call
                             throw new CompilerException('Named parameter "' . $parameter['name'] . '" is not a valid parameter name, available: ' . join(', ', array_keys($positionalParameters)), $parameter['parameter']);
                         }
                     }
-                    for ($i = 0; $i < count($parameters); $i++) {
+                    $parameters_count = count($parameters);
+                    for ($i = 0; $i < $parameters_count; $i++) {
                         if (!isset($orderedParameters[$i])) {
                             $orderedParameters[$i] = array('parameter' => array('type' => 'null'));
                         }


### PR DESCRIPTION
Due to the way for loops are implemented in php, the count function will run every iteration of the loop. Therefore, moving the count to a variable, calculated before the start of the loop, improves performance (less function calls).
