### PR TITLE
Fixes loose comparison

### DIFF
--- a/Library/Compiler.php
+++ b/Library/Compiler.php
@@ -825,7 +825,7 @@ class Compiler
         /**
          * Load function optimizers
          */
-        if (self::$loadedPrototypes == false) {
+        if (self::$loadedPrototypes === false) {
             FunctionCall::addOptimizerDir(ZEPHIRPATH . 'Library/Optimizers/FunctionCall');
 
             $optimizerDirs = $this->config->get('optimizer-dirs');


### PR DESCRIPTION
Strict comparison should be used for booleans,
If this is approved I can make a PR with all the other bool comparisons in the project.
