### PR TITLE
Correct str_replace using first argument an array

### DIFF
--- a/kernels/ZendEngine2/string.c
+++ b/kernels/ZendEngine2/string.c
@@ -532,7 +532,7 @@ void zephir_fast_str_replace(zval **return_value_ptr, zval *search, zval *replac
 		do {
 			zval *params[] = { search, replace, subject };
 			zval_ptr_dtor(return_value_ptr);
-			return_value_ptr = NULL;
+			*return_value_ptr = NULL;
 			zephir_call_func_aparams(return_value_ptr, "str_replace", sizeof("str_replace")-1, NULL, 0, 3, params TSRMLS_CC);
 			return;
 		} while(0);


### PR DESCRIPTION
Since v0.7.0 (work with this one), it's not possible to use the function

``` php
str_replace(Array, Array|String, String)
```

in zephir (see bug [#1055] for the latest one). If the first argument is an array in the function str_replace, the return was always NULL. The cause is the commit [c763915fc619151ca5498c9377f8df0da51f5536], solving a memory leak. I think, this is a C pointer error. This work correctly for me, in master after doing this modification).
