### PR TITLE
Fixed issue #1058

### DIFF
--- a/Library/Optimizers/FunctionCall/LdexpOptimizer.php
+++ b/Library/Optimizers/FunctionCall/LdexpOptimizer.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------------+
+ | Zephir Language                                                          |
+ +--------------------------------------------------------------------------+
+ | Copyright (c) 2013-2015 Zephir Team and contributors                     |
+ +--------------------------------------------------------------------------+
+ | This source file is subject the MIT license, that is bundled with        |
+ | this package in the file LICENSE, and is available through the           |
+ | world-wide-web at the following url:                                     |
+ | http://zephir-lang.com/license.html                                      |
+ |                                                                          |
+ | If you did not receive a copy of the MIT license and are unable          |
+ | to obtain it through the world-wide-web, please send a note to           |
+ | license@zephir-lang.com so we can mail you a copy immediately.           |
+ +--------------------------------------------------------------------------+
+*/
+
+namespace Zephir\Optimizers\FunctionCall;
+
+use Zephir\Call;
+use Zephir\CompilationContext;
+use Zephir\CompilerException;
+use Zephir\CompiledExpression;
+use Zephir\Expression;
+use Zephir\Optimizers\MathOptimizer;
+
+/**
+ * LdexpOptimizer
+ *
+ * Optimizes calls to 'ldexp' using internal function
+ */
+class LdexpOptimizer extends MathOptimizer
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function getFunctionName()
+    {
+        return 'ldexp';
+    }
+
+    /**
+     * @param array $expression
+     * @param Call $call
+     * @param CompilationContext $context
+     * @return bool|CompiledExpression|mixed
+     * @throws CompilerException
+     */
+    public function optimize(array $expression, Call $call, CompilationContext $context)
+    {
+        if (!isset($expression['parameters']) || count($expression['parameters']) != 2) {
+            throw new CompilerException(sprintf("'%s' requires two parameters", $this->getFunctionName()), $expression);
+        }
+
+        $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
+
+        $context->headersManager->add('kernel/math');
+        return new CompiledExpression(
+            'double',
+            'zephir_' . $this->getFunctionName() . '(' . $resolvedParams[0] . ', ' . $resolvedParams[1] . ' TSRMLS_CC)',
+            $expression
+        );
+    }
+}

--- a/Library/Optimizers/MathOptimizer.php
+++ b/Library/Optimizers/MathOptimizer.php
@@ -30,6 +30,11 @@ use Zephir\Expression;
  */
 abstract class MathOptimizer extends OptimizerAbstract
 {
+    /**
+     * Gets function name
+     *
+     * @return string
+     */
     abstract public function getFunctionName();
 
     /**

--- a/kernels/ZendEngine2/math.c
+++ b/kernels/ZendEngine2/math.c
@@ -254,3 +254,22 @@ long zephir_mt_rand(long min, long max TSRMLS_DC) {
 
 	return number;
 }
+
+double zephir_ldexp(zval *value, zval *expval TSRMLS_DC)
+{
+	int exp = (int) zephir_get_numberval(expval);
+
+	switch (Z_TYPE_P(value)) {
+		case IS_LONG:
+			return (double) ldexp(Z_LVAL_P(value), exp);
+		case IS_DOUBLE:
+			return (double) ldexp(Z_DVAL_P(value), exp);
+		case IS_ARRAY:
+		case IS_OBJECT:
+		case IS_RESOURCE:
+			zend_error(E_WARNING, "Unsupported operand types");
+			break;
+	}
+
+	return ldexp(zephir_get_numberval(value), exp);
+}

--- a/kernels/ZendEngine2/math.h
+++ b/kernels/ZendEngine2/math.h
@@ -38,4 +38,6 @@ void zephir_pow(zval *return_value, zval *op1, zval *op2 TSRMLS_DC);
 
 long zephir_mt_rand(long min, long max TSRMLS_DC);
 
+double zephir_ldexp(zval *value, zval *expval TSRMLS_DC);
+
 #endif

--- a/kernels/ZendEngine3/math.c
+++ b/kernels/ZendEngine3/math.c
@@ -207,3 +207,22 @@ long zephir_mt_rand(long min, long max)
 
 	return number;
 }
+
+double zephir_ldexp(zval *value, zval *expval TSRMLS_DC)
+{
+	int exp = (int) zephir_get_numberval(expval);
+
+	switch (Z_TYPE_P(value)) {
+		case IS_LONG:
+			return (double) ldexp(Z_LVAL_P(value), exp);
+		case IS_DOUBLE:
+			return (double) ldexp(Z_DVAL_P(value), exp);
+		case IS_ARRAY:
+		case IS_OBJECT:
+		case IS_RESOURCE:
+			zend_error(E_WARNING, "Unsupported operand types");
+			break;
+	}
+
+	return ldexp(zephir_get_numberval(value), exp);
+}

--- a/kernels/ZendEngine3/math.h
+++ b/kernels/ZendEngine3/math.h
@@ -35,4 +35,6 @@ long zephir_mt_rand(long min, long max);
 double zephir_ceil(zval *op1);
 void zephir_round(zval *return_value, zval *op1, zval *op2, zval *op3);
 
+double zephir_ldexp(zval *value, zval *expval TSRMLS_DC);
+
 #endif

--- a/test/optimizers/ldexp.zep
+++ b/test/optimizers/ldexp.zep
@@ -1,0 +1,52 @@
+
+namespace Test\Optimizers;
+
+class Ldexp
+{
+	public function testInt()
+	{
+		int x = 2;
+		int exponent = 3;
+
+		return ldexp(x, exponent);
+	}
+
+	public function testDoubleInt()
+	{
+		double x = 2.0;
+		int exponent = 3;
+
+		return ldexp(x, exponent);
+	}
+
+	public function testDouble()
+	{
+		double x = 2.0;
+		double exponent = 3.0;
+
+		return ldexp(x, exponent);
+	}
+
+	public function testVar()
+	{
+		var x = 2;
+		var exponent = 3;
+
+		return ldexp(x, exponent);
+	}
+
+	public function testIntValue1()
+	{
+		return ldexp(2, 3);
+	}
+
+	public function testIntParameter(int x, int exponent)
+	{
+		return ldexp(x, exponent);
+	}
+
+	public function testVarParameter(var x, var exponent)
+	{
+		return ldexp(x, exponent);
+	}
+}

--- a/unit-tests/Extension/Optimizers/MathTest.php
+++ b/unit-tests/Extension/Optimizers/MathTest.php
@@ -24,9 +24,23 @@ use Test\Optimizers\ASin;
 use Test\Optimizers\Cos;
 use Test\Optimizers\ACos;
 use Test\Optimizers\Tan;
+use Test\Optimizers\Ldexp;
 
 class MathTest extends \PHPUnit_Framework_TestCase
 {
+    public function testLdexp()
+    {
+        $t = new Ldexp();
+
+        $this->assertSame(16.0, $t->testInt());
+        $this->assertSame(16.0, $t->testVar());
+        $this->assertSame(16.0, $t->testIntValue1());
+        $this->assertSame(16.0, $t->testDoubleInt());
+        $this->assertSame(16.0, $t->testDouble());
+        $this->assertSame(524288.0, $t->testIntParameter(8, 16));
+        $this->assertSame(524288.0, $t->testvarParameter(8, 16));
+    }
+
     public function testSqrt()
     {
         $t = new Sqrt();


### PR DESCRIPTION
#### Description

The function **ldexp(double x, int exponent)** returns **x** multiplied by 2 raised to the power of **exponent**.
#### Declaration

Following is the declaration for ldexp() function.

``` zephir
ldexp(double x, int exponent) -> double
```

Zephir uses type casting.
#### Parameters
- **x** − This is the floating point value representing the significand.
- **exponent** − This is the value of the exponent.
#### Return Value

This function returns x \* 2 exp
#### Example

The following example shows the usage of ldexp() function.

**Zephir**

``` zephir
namespace Utils;

class Test
{
    public function foo(var x, var exponent)
    {
        return ldexp(x, exponent);
    }
}
```

**PHP**

``` php
use Utils\Test;

$test = new Test;
echo $test->foo(2, 3); //  16.0
```
