### PR TITLE
fix(parser): only include strndup, when required, openSUSE

### DIFF
--- a/parser/parser/base.c
+++ b/parser/parser/base.c
@@ -38,7 +38,7 @@ const xx_token_names xx_tokens[] =
 	{  0, NULL }
 };
 
-#ifndef HAVE_STRNDUP
+#if !defined HAVE_STRNDUP && !defined __USE_XOPEN2K8
 char *strndup(const char *s, size_t len)
 {
     if (s) {


### PR DESCRIPTION
openSUSE MACRO https://github.com/phalcon/zephir/issues/1142#issuecomment-167769011
