### PR TITLE
Fix fwrite() optimizer in php 7

### DIFF
--- a/Library/Optimizers/FunctionCall/FwriteOptimizer.php
+++ b/Library/Optimizers/FunctionCall/FwriteOptimizer.php
@@ -68,7 +68,8 @@ class FwriteOptimizer extends OptimizerAbstract
             if ($call->mustInitSymbolVariable()) {
                 $symbolVariable->initVariant($context);
             }
-            $context->codePrinter->output('zephir_fwrite(' . $symbolVariable->getName() . ', ' . $resolvedParams[0] . ', ' . $resolvedParams[1] . ' TSRMLS_CC);');
+            $symbol = $context->backend->getVariableCode($symbolVariable);
+            $context->codePrinter->output('zephir_fwrite(' . $symbol . ', ' . $resolvedParams[0] . ', ' . $resolvedParams[1] . ' TSRMLS_CC);');
             return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
         } else {
             $context->codePrinter->output('zephir_fwrite(NULL, ' . $resolvedParams[0] . ', ' . $resolvedParams[1] . ' TSRMLS_CC);');


### PR DESCRIPTION
Invalid first param type of zephir_fwrite(), zval \* required, but zval provided.
