### PR TITLE
Detect zephir command and set php/zephir options

### DIFF
--- a/bin/zephir
+++ b/bin/zephir
@@ -19,9 +19,17 @@ if [ -z "$ZEPHIRDIR" ]; then
   fi
 fi
 
-if [[ $1 && $2 && $3 && "$1"=="-c" ]]; then
-    php -d safe_mode=Off -d enable_dl=On -c $2 $ZEPHIRDIR/compiler.php ${*:3}
-else
-    php -d safe_mode=Off -d enable_dl=On $ZEPHIRDIR/compiler.php $*
-fi
+args[0]=$0
+args+=("$@")
+commands=(clean init builddev compile stubs fullclean version install build api help generate)
 
+k=1
+for ((i=1; i<=$#; i++)); do 
+    for j in "${commands[@]}"; do
+        if [[ "${args[${i}]}" == "$j" ]]; then
+            k=$i
+        fi
+    done
+done
+
+php ${*:1:$k-1} $ZEPHIRDIR/compiler.php ${*:$k}


### PR DESCRIPTION
Options before the zephir's command are set to php, after for the zephir:

``` sh
zephir
php ZEPHIRDIR/compiler.php

zephir init test
php ZEPHIRDIR/compiler.php init test

zephir -c php.ini build
php -c php.ini ZEPHIRDIR/compiler.php build

zephir -d safe_mode=Off -d enable_dl=On -d extension=zephir_parser.so generate --parser-compiled=yes
php -d safe_mode=Off -d enable_dl=On -d extension=zephir_parser.so ZEPHIRDIR/compiler.php generate --parser-compiled=yes
```
