### PR TITLE
Allow users to configure their phpize and php-config location from their projects

### DIFF
--- a/Library/Compiler.php
+++ b/Library/Compiler.php
@@ -300,7 +300,6 @@ class Compiler
         /* Check if we need to load the parser extension and also allow users to manage the zephir parser extension on their own (zephir won't handle updating)*/
         if ($parserExt && $parserExt !== true) {
             $cmd = PHP_BINARY . ' -dextension="'.$parserExt . '" ' . implode(' ', $_SERVER['argv']) . ' --parser-compiled';
-            echo $cmd;
             passthru($cmd, $exitCode);
             exit($exitCode);
         }

--- a/Library/Config.php
+++ b/Library/Config.php
@@ -94,6 +94,11 @@ class Config
         'verbose'     => false,
         'requires'    => array(
             'extensions'    => array()
+        ),
+        'environment'  => array(
+            "phpize" => "",
+            "php-config" => "",
+            "alwaysCompileParser" => false
         )
     );
 


### PR DESCRIPTION
allow users to add those options into their project/config.json file

```
"environment": {
        "phpize": "_PATH_TO_PHPIZE_", #ex /opt/php-5615/bin/phpize
        "php-config": "_PATH_TO_PHP-CONFIG", #ex /opt/php-5615/bin/php-config
        "alwaysCompileParser" : true 
}
```

the reason i added `alwaysCompileParser` is because i saw couple of issues about people trying php 7, then they go back to php5 and in this case compiling the parser throws errors. Enabling this should prevent any kind of errors of this kind.

also removed the `@unlink` stuff since i hate it :D
