### PR TITLE
Pull request for issue #1179 on phalcon/zephir: Use camelization for getter/setter shortcut function names

### DIFF
--- a/Library/CompilerFile.php
+++ b/Library/CompilerFile.php
@@ -341,7 +341,7 @@ class CompilerFile
                     $classDefinition->addMethod(new ClassMethod(
                         $classDefinition,
                         array('public'),
-                        'get' . ucfirst($name),
+                        'get' . Utils::camelize($name),
                         null,
                         new StatementsBlock(array(
                             array(
@@ -369,7 +369,7 @@ class CompilerFile
                     $classDefinition->addMethod(new ClassMethod(
                         $classDefinition,
                         array('public'),
-                        'set' . ucfirst($name),
+                        'set' . Utils::camelize($name),
                         new ClassMethodParameters(array(
                             array(
                                 'type' => 'parameter',


### PR DESCRIPTION
This change results in auto-generation of getter/setter function names using **camelization** of property name instead of first letter capitalization when processing getter/setter shortcut directives. Example: If property is

``` php
protected my_sample_property {
    get, set
};
```

then the auto-generated PHP setter/getter function names will now be generated as

``` php
getMySampleProperty()
setMySampleProperty()
```

which is more conventional, rather than

``` php
getMy_sample_property()
setMy_sample_property()
```
