### PR TITLE
Now, the developer can load the custom prototypes.

### DIFF
--- a/Library/Compiler.php
+++ b/Library/Compiler.php
@@ -973,6 +973,29 @@ class Compiler
                 }
             }
 
+            /**
+             * Load customer additional extension prototypes
+             */
+            $prototypeDirs = $this->config->get('prototype-dir');
+            if (is_array($prototypeDirs)) {
+                foreach ($prototypeDirs as $prototype => $prototypeDir) {
+                    /**
+                     * Check if the extension is installed
+                     */
+                    if (!extension_loaded($prototype)) {
+                        
+                        $prototypeRealpath = realpath($prototypeDir);
+                        if ($prototypeRealpath) {
+                            foreach (new \DirectoryIterator($prototypeRealpath) as $file) {
+                                if (!$file->isDir()) {
+                                    require $file->getRealPath();
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
             self::$loadedPrototypes = true;
         }
 

--- a/Library/Compiler.php
+++ b/Library/Compiler.php
@@ -982,7 +982,7 @@ class Compiler
                     /**
                      * Check if the extension is installed
                      */
-                    if (!extension_loaded($prototype)) {                      
+                    if (!extension_loaded($prototype)) {
                         $prototypeRealpath = realpath($prototypeDir);
                         if ($prototypeRealpath) {
                             foreach (new \DirectoryIterator($prototypeRealpath) as $file) {

--- a/Library/Compiler.php
+++ b/Library/Compiler.php
@@ -982,8 +982,7 @@ class Compiler
                     /**
                      * Check if the extension is installed
                      */
-                    if (!extension_loaded($prototype)) {
-                        
+                    if (!extension_loaded($prototype)) {                      
                         $prototypeRealpath = realpath($prototypeDir);
                         if ($prototypeRealpath) {
                             foreach (new \DirectoryIterator($prototypeRealpath) as $file) {


### PR DESCRIPTION
Recently, I in the development of a framework, using the new mongodb driver. The driver uses the namespace, file name cannot extend to name, on the "zephir/prototypes" doesn't work very well. Therefore I think of a better way to provide an option to let me decide which directory is loaded. By my own and maintain these, but not all in the zephir/prototypes".  
In the configuration file:

``` json
{
    "prototype-dir": {
        "mongodb": "prototypes/mongodb"
    }
}
```

If "mongodb extension" was not load, the file in "prototypes/mongodb" will be loaded.
