### PR TITLE
Delete symbol_table usage for zend_fcall_info strut (php 7.1.0-dev).

### DIFF
--- a/kernels/ZendEngine3/extended/fcall.c
+++ b/kernels/ZendEngine3/extended/fcall.c
@@ -1120,7 +1120,11 @@ int zephir_call_function_opt(zend_fcall_info *fci, zend_fcall_info_cache *fci_ca
 	if (func->type == ZEND_USER_FUNCTION) {
 		int call_via_handler = (func->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE) != 0;
 		EG(scope) = func->common.scope;
+#if PHP_VERSION_ID < 70100
+		call->symbol_table = fci->symbol_table;
+#else
 		call->symbol_table = NULL;
+#endif
 		if (UNEXPECTED(func->op_array.fn_flags & ZEND_ACC_CLOSURE)) {
 			ZEND_ASSERT(GC_TYPE((zend_object*)func->op_array.prototype) == IS_OBJECT);
 			GC_REFCOUNT((zend_object*)func->op_array.prototype)++;

--- a/kernels/ZendEngine3/extended/fcall.c
+++ b/kernels/ZendEngine3/extended/fcall.c
@@ -1120,7 +1120,7 @@ int zephir_call_function_opt(zend_fcall_info *fci, zend_fcall_info_cache *fci_ca
 	if (func->type == ZEND_USER_FUNCTION) {
 		int call_via_handler = (func->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE) != 0;
 		EG(scope) = func->common.scope;
-		call->symbol_table = fci->symbol_table;
+		call->symbol_table = NULL;
 		if (UNEXPECTED(func->op_array.fn_flags & ZEND_ACC_CLOSURE)) {
 			ZEND_ASSERT(GC_TYPE((zend_object*)func->op_array.prototype) == IS_OBJECT);
 			GC_REFCOUNT((zend_object*)func->op_array.prototype)++;

--- a/kernels/ZendEngine3/fcall.c
+++ b/kernels/ZendEngine3/fcall.c
@@ -420,7 +420,6 @@ int zephir_call_user_function(zval *object_pp, zend_class_entry *obj_ce, zephir_
 	fci.params         = NULL;
 	//fci.params: Passed as separate parameter to prevent the need to convert zval ** to zval *
 	fci.no_separation  = 1;
-	fci.symbol_table   = NULL;
 
 	fcic.initialized = 0;
 	fcic.function_handler = NULL;

--- a/kernels/ZendEngine3/fcall.c
+++ b/kernels/ZendEngine3/fcall.c
@@ -420,6 +420,9 @@ int zephir_call_user_function(zval *object_pp, zend_class_entry *obj_ce, zephir_
 	fci.params         = NULL;
 	//fci.params: Passed as separate parameter to prevent the need to convert zval ** to zval *
 	fci.no_separation  = 1;
+#if PHP_VERSION_ID < 70100
+	fci.symbol_table   = NULL;
+#endif
 
 	fcic.initialized = 0;
 	fcic.function_handler = NULL;


### PR DESCRIPTION
See commit in php 7 source / master of Dmitry Stogov dmitry@zend.com:
"PHP-7 doesn't support symbol_table substitution for functions".
Today it's an assert into zend_execute_API.c: line 855 into php 7.0.5 source.
