### PR TITLE
Force compile parser fix

### DIFF
--- a/Library/Compiler.php
+++ b/Library/Compiler.php
@@ -297,6 +297,7 @@ class Compiler
         $parserExt = $this->compileParser();
         /* Check if we need to load the parser extension and also allow users to manage the zephir parser extension on their own (zephir won't handle updating)*/
         if ($parserExt && $parserExt !== true) {
+            // exclude --parser-compiled argument, we'll specify it additionally
             $args = array_filter($_SERVER['argv'], function($arg) {
                 return 0 !== strpos($arg, "--parser-compiled");
             });

--- a/Library/Compiler.php
+++ b/Library/Compiler.php
@@ -247,7 +247,7 @@ class Compiler
 
                 chdir($oldCwd);
             } else {
-                if (!file_exists($currentDir . 'modules/zephir_parser.so')) {
+                if (!file_exists($currentDir . 'modules/zephir_parser.so') || ($this->parserCompiled === 'force')) {
                     $this->logger->output('zephir_parser extension not loaded, compiling it');
                     $oldCwd = getcwd();
                     chdir($currentDir);
@@ -297,7 +297,10 @@ class Compiler
         $parserExt = $this->compileParser();
         /* Check if we need to load the parser extension and also allow users to manage the zephir parser extension on their own (zephir won't handle updating)*/
         if ($parserExt && $parserExt !== true) {
-            $cmd = PHP_BINARY . ' -dextension="' . $parserExt . '" ' . implode(' ', $_SERVER['argv']) . ' --parser-compiled';
+            $args = array_filter($_SERVER['argv'], function($arg) {
+                return 0 !== strpos($arg, "--parser-compiled");
+            });
+            $cmd = PHP_BINARY . ' -dextension="' . $parserExt . '" ' . implode(' ', $args) . ' --parser-compiled';
             passthru($cmd, $exitCode);
             exit($exitCode);
         }

--- a/Library/Compiler.php
+++ b/Library/Compiler.php
@@ -298,7 +298,7 @@ class Compiler
         /* Check if we need to load the parser extension and also allow users to manage the zephir parser extension on their own (zephir won't handle updating)*/
         if ($parserExt && $parserExt !== true) {
             // exclude --parser-compiled argument, we'll specify it additionally
-            $args = array_filter($_SERVER['argv'], function($arg) {
+            $args = array_filter($_SERVER['argv'], function ($arg) {
                 return 0 !== strpos($arg, "--parser-compiled");
             });
             $cmd = PHP_BINARY . ' -dextension="' . $parserExt . '" ' . implode(' ', $args) . ' --parser-compiled';


### PR DESCRIPTION
Fixes issue with spawning PHP processes in a infinite loop when --parser-compiled=force is specified; also fixes parser recompilation being skipped even when --parser-compiled=force is specified.
