### PR TITLE
Added APC constants

### DIFF
--- a/prototypes/apc.php
+++ b/prototypes/apc.php
@@ -2,6 +2,31 @@
 
 if (!class_exists('APCIterator', false)) {
 
+// See: https://github.com/php/pecl-caching-apc/blob/master/apc_bin.h
+defined('APC_BIN_VERIFY_CRC32') || define('APC_BIN_VERIFY_CRC32', 1 << 1);
+defined('APC_BIN_VERIFY_MD5') || define('APC_BIN_VERIFY_MD5', 1 << 0);
+
+// See: https://github.com/php/pecl-caching-apc/blob/master/apc_iterator.h
+defined('APC_ITER_ALL') || define('APC_ITER_ALL', 0xffffffff);
+defined('APC_ITER_ATIME') || define('APC_ITER_ATIME', 1 << 11);
+defined('APC_ITER_CTIME') || define('APC_ITER_CTIME', 1 << 9);
+defined('APC_ITER_DEVICE') || define('APC_ITER_DEVICE', 1 << 3);
+defined('APC_ITER_DTIME') || define('APC_ITER_DTIME', 1 << 10);
+defined('APC_ITER_FILENAME') || define('APC_ITER_FILENAME', 1 << 2);
+defined('APC_ITER_INODE') || define('APC_ITER_INODE', 1 << 4);
+defined('APC_ITER_KEY') || define('APC_ITER_KEY', 1 << 1);
+defined('APC_ITER_MD5') || define('APC_ITER_MD5', 1 << 6);
+defined('APC_ITER_MEM_SIZE') || define('APC_ITER_MEM_SIZE', 1 << 13);
+defined('APC_ITER_MTIME') || define('APC_ITER_MTIME', 1 << 8);
+defined('APC_ITER_NONE') || define('APC_ITER_NONE', 0x00000000);
+defined('APC_ITER_NUM_HITS') || define('APC_ITER_NUM_HITS', 1 << 7);
+defined('APC_ITER_REFCOUNT') || define('APC_ITER_REFCOUNT', 1 << 12);
+defined('APC_ITER_TTL') || define('APC_ITER_TTL', 1 << 14);
+defined('APC_ITER_TYPE') || define('APC_ITER_TYPE', 1 << 0);
+defined('APC_ITER_VALUE') || define('APC_ITER_VALUE', 1 << 5);
+defined('APC_LIST_ACTIVE') || define('APC_LIST_ACTIVE', 0x1);
+defined('APC_LIST_DELETED') || define('APC_LIST_DELETED', 0x2);
+
 /**
  * Class APCIterator
  * @link http://www.php.net/manual/en/class.apciterator.php


### PR DESCRIPTION
Fixed notice:

```
PHP Notice:  Use of undefined constant APC_ITER_ALL - assumed 'APC_ITER_ALL' in /usr/share/zephir/Library/ClassDefinition.php on line 1743
PHP Stack trace:
PHP   1. {main}() /usr/share/zephir/compiler.php:0
PHP   2. Zephir\Bootstrap::boot() /usr/share/zephir/compiler.php:21
PHP   3. Zephir\Commands\CommandAbstract->execute() /usr/share/zephir/Library/Bootstrap.php:200
PHP   4. Zephir\Compiler->build() /usr/share/zephir/Library/Commands/CommandAbstract.php:108
PHP   5. Zephir\Compiler->install() /usr/share/zephir/Library/Compiler.php:1348
PHP   6. Zephir\Compiler->compile() /usr/share/zephir/Library/Compiler.php:1267
PHP   7. Zephir\Compiler->generate() /usr/share/zephir/Library/Compiler.php:1131
PHP   8. Zephir\CompilerFile->compile() /usr/share/zephir/Library/Compiler.php:1016
PHP   9. Zephir\CompilerFile->compileClass() /usr/share/zephir/Library/CompilerFile.php:857
PHP  10. Zephir\ClassDefinition->compile() /usr/share/zephir/Library/CompilerFile.php:202
PHP  11. Zephir\ClassMethod->compile() /usr/share/zephir/Library/ClassDefinition.php:1192
PHP  12. Zephir\StatementsBlock->compile() /usr/share/zephir/Library/ClassMethod.php:1703
PHP  13. Zephir\Statements\LetStatement->compile() /usr/share/zephir/Library/StatementsBlock.php:168
PHP  14. Zephir\Expression->compile() /usr/share/zephir/Library/Statements/LetStatement.php:133
PHP  15. Zephir\Operators\Other\NewInstanceOperator->compile() /usr/share/zephir/Library/Expression.php:608
PHP  16. Zephir\Compiler->getInternalClassDefinition() /usr/share/zephir/Library/Operators/Other/NewInstanceOperator.php:204
PHP  17. Zephir\ClassDefinition::buildFromReflection() /usr/share/zephir/Library/Compiler.php:521
PHP  18. ReflectionParameter->getDefaultValue() /usr/share/zephir/Library/ClassDefinition.php:1743
PHP Notice:  Use of undefined constant APC_LIST_ACTIVE - assumed 'APC_LIST_ACTIVE' in /usr/share/zephir/Library/ClassDefinition.php on line 1743
PHP Stack trace:
PHP   1. {main}() /usr/share/zephir/compiler.php:0
PHP   2. Zephir\Bootstrap::boot() /usr/share/zephir/compiler.php:21
PHP   3. Zephir\Commands\CommandAbstract->execute() /usr/share/zephir/Library/Bootstrap.php:200
PHP   4. Zephir\Compiler->build() /usr/share/zephir/Library/Commands/CommandAbstract.php:108
PHP   5. Zephir\Compiler->install() /usr/share/zephir/Library/Compiler.php:1348
PHP   6. Zephir\Compiler->compile() /usr/share/zephir/Library/Compiler.php:1267
PHP   7. Zephir\Compiler->generate() /usr/share/zephir/Library/Compiler.php:1131
PHP   8. Zephir\CompilerFile->compile() /usr/share/zephir/Library/Compiler.php:1016
PHP   9. Zephir\CompilerFile->compileClass() /usr/share/zephir/Library/CompilerFile.php:857
PHP  10. Zephir\ClassDefinition->compile() /usr/share/zephir/Library/CompilerFile.php:202
PHP  11. Zephir\ClassMethod->compile() /usr/share/zephir/Library/ClassDefinition.php:1192
PHP  12. Zephir\StatementsBlock->compile() /usr/share/zephir/Library/ClassMethod.php:1703
PHP  13. Zephir\Statements\LetStatement->compile() /usr/share/zephir/Library/StatementsBlock.php:168
PHP  14. Zephir\Expression->compile() /usr/share/zephir/Library/Statements/LetStatement.php:133
PHP  15. Zephir\Operators\Other\NewInstanceOperator->compile() /usr/share/zephir/Library/Expression.php:608
PHP  16. Zephir\Compiler->getInternalClassDefinition() /usr/share/zephir/Library/Operators/Other/NewInstanceOperator.php:204
PHP  17. Zephir\ClassDefinition::buildFromReflection() /usr/share/zephir/Library/Compiler.php:521
PHP  18. ReflectionParameter->getDefaultValue() /usr/share/zephir/Library/ClassDefinition.php:1743
```

See http://php.net/manual/en/apc.constants.php
