### PR TITLE
Fix risky unit tests

### DIFF
--- a/Library/Compiler.php
+++ b/Library/Compiler.php
@@ -1205,6 +1205,7 @@ class Compiler
                 $fixMarker = "/* zephir_phpize_fix */";
                 $configureFile = file_get_contents("ext/configure.js");
                 $configureFix = array("var PHP_ANALYZER = 'disabled';", "var PHP_PGO = 'no';", "var PHP_PGI = 'no';");
+                $hasChanged = false;
                 if (strpos($configureFile, $fixMarker) === false) {
                     $configureFile = $fixMarker . PHP_EOL . implode($configureFix, PHP_EOL) . PHP_EOL . $configureFile;
                     $hasChanged = true;
@@ -1226,7 +1227,6 @@ class Compiler
                 }
 
                 $this->logger->output('Preparing configuration file...');
-
                 exec('cd ext && configure --enable-' . $namespace);
             } else {
                 exec('cd ext && make clean && phpize --clean', $output, $exit);

--- a/Library/Loader.php
+++ b/Library/Loader.php
@@ -40,11 +40,15 @@ class Loader
      */
     public static function autoload($className)
     {
-        require __DIR__ .
+        $filename = __DIR__ .
             str_replace(
                 'Zephir' . DIRECTORY_SEPARATOR,
                 DIRECTORY_SEPARATOR,
                 str_replace('\\', DIRECTORY_SEPARATOR, $className)
             ) . '.php';
+
+        if (file_exists($filename)) {
+            require $filename;
+        }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,6 +3,7 @@
          backupGlobals="false"
          colors="true"
          bootstrap="./unit-tests/Bootstrap.php">
+
     <testsuites>
         <testsuite name="Extension Test Suite">
             <directory>./unit-tests/Extension/</directory>
@@ -11,4 +12,11 @@
             <directory>./unit-tests/Zephir/</directory>
         </testsuite>
     </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./Library</directory>
+        </whitelist>
+    </filter>
+
 </phpunit>

--- a/unit-tests/Extension/ExistsTest.php
+++ b/unit-tests/Extension/ExistsTest.php
@@ -19,7 +19,7 @@
 
 namespace Extension;
 
-class ExistsTEst extends \PHPUnit_Framework_TestCase
+class ExistsTest extends \PHPUnit_Framework_TestCase
 {
     public function testAssertations()
     {

--- a/unit-tests/Extension/ExitDieTest.php
+++ b/unit-tests/Extension/ExitDieTest.php
@@ -23,16 +23,12 @@ class ExitDieTest extends \PHPUnit_Framework_TestCase
 {
     public function testExitDie()
     {
-        /* Only available since PHP 5.4 */
-        if (defined('PHP_BINARY')) {
-            $phpBinary = constant('PHP_BINARY');
-            /* If we use phpdbg, you need to add options -qrr */
-            if (defined('PHP_SAPI') && constant('PHP_SAPI') == 'phpdbg') {
-                $phpBinary .= ' -qrr';
-            }
-        } else {
-            $phpBinary = PHP_BINDIR . DIRECTORY_SEPARATOR . 'php';
+        $phpBinary = constant('PHP_BINARY');
+        /* If we use phpdbg, you need to add options -qrr */
+        if (defined('PHP_SAPI') && constant('PHP_SAPI') == 'phpdbg') {
+            $phpBinary .= ' -qrr';
         }
+
         $testfile1 = __DIR__ .'/fixtures/exit.php';
         $return1 = `$phpBinary $testfile1`;
         $this->assertEquals("", trim($return1));

--- a/unit-tests/Extension/ExitDieTest.php
+++ b/unit-tests/Extension/ExitDieTest.php
@@ -23,9 +23,13 @@ class ExitDieTest extends \PHPUnit_Framework_TestCase
 {
     public function testExitDie()
     {
-        /* Only available since PHP 5.4*/
+        /* Only available since PHP 5.4 */
         if (defined('PHP_BINARY')) {
             $phpBinary = constant('PHP_BINARY');
+            /* If we use phpdbg, you need to add options -qrr */
+            if (defined('PHP_SAPI') && constant('PHP_SAPI') == 'phpdbg') {
+                $phpBinary .= ' -qrr';
+            }
         } else {
             $phpBinary = PHP_BINDIR . DIRECTORY_SEPARATOR . 'php';
         }

--- a/unit-tests/Extension/VarsTest.php
+++ b/unit-tests/Extension/VarsTest.php
@@ -29,7 +29,7 @@ class VarsTest extends \PHPUnit_Framework_TestCase
         $this->setOutputCallback(
             function ($output) {
                 /* To prevent differences between PHP version */
-                return str_replace(array(PHP_EOL, ' '), '', $output);
+                return str_replace(array("\n", ' '), '', $output);
             }
         );
 
@@ -52,8 +52,8 @@ class VarsTest extends \PHPUnit_Framework_TestCase
     public function testVarDumpWithTwoParams()
     {
         $this->expectOutputString(
-            'float(3.1)' . PHP_EOL .
-            'bool(true)' . PHP_EOL
+            'float(3.1)' . "\n" .
+            'bool(true)' . "\n"
         );
 
         $t = new \Test\Vars();
@@ -68,7 +68,7 @@ class VarsTest extends \PHPUnit_Framework_TestCase
     {
         $this->setOutputCallback(
             function ($output) {
-                return str_replace(array(PHP_EOL, ' '), '', $output);
+                return str_replace(array("\n", ' '), '', $output);
             }
         );
 
@@ -87,7 +87,7 @@ class VarsTest extends \PHPUnit_Framework_TestCase
     {
         $this->setOutputCallback(
             function ($output) {
-                return str_replace(array(PHP_EOL, ' '), '', $output);
+                return str_replace(array("\n", ' '), '', $output);
             }
         );
 
@@ -104,8 +104,8 @@ class VarsTest extends \PHPUnit_Framework_TestCase
         $t = new \Test\Vars();
 
         $this->expectOutputString(
-            'string(3) "foo"' . PHP_EOL .
-            'string(3) "bar"' . PHP_EOL .
+            'string(3) "foo"' . "\n" .
+            'string(3) "bar"' . "\n" .
             "'foo'" .
             "'bar'" .
             "'bar'"
@@ -119,7 +119,7 @@ class VarsTest extends \PHPUnit_Framework_TestCase
     public function testVarDumpAndCountOptimizer()
     {
         $this->expectOutputString(
-            'int(5)' . PHP_EOL .
+            'int(5)' . "\n" .
             '5'
         );
 
@@ -131,7 +131,7 @@ class VarsTest extends \PHPUnit_Framework_TestCase
     {
         $this->setOutputCallback(
             function ($output) {
-                return str_replace(array(PHP_EOL, ' '), '', $output);
+                return str_replace(array("\n", ' '), '', $output);
             }
         );
 
@@ -147,7 +147,7 @@ class VarsTest extends \PHPUnit_Framework_TestCase
     public function testIntVarDump()
     {
         $this->expectOutputString(
-            'int(1)' . PHP_EOL .
+            'int(1)' . "\n" .
             '1'
         );
 
@@ -159,12 +159,12 @@ class VarsTest extends \PHPUnit_Framework_TestCase
     {
         if (PHP_VERSION_ID < 70000) {
             $this->expectOutputString(
-                'float(1)' . PHP_EOL .
+                'float(1)' . "\n" .
                 '1'
             );
         } else {
             $this->expectOutputString(
-                'float(1)' . PHP_EOL .
+                'float(1)' . "\n" .
                 '1.0'
             );
         }
@@ -176,7 +176,7 @@ class VarsTest extends \PHPUnit_Framework_TestCase
     public function testBoolVarDump()
     {
         $this->expectOutputString(
-            'bool(true)' . PHP_EOL .
+            'bool(true)' . "\n" .
             'true'
         );
 

--- a/unit-tests/Extension/VarsTest.php
+++ b/unit-tests/Extension/VarsTest.php
@@ -157,10 +157,17 @@ class VarsTest extends \PHPUnit_Framework_TestCase
 
     public function testDoubleVarDump()
     {
-        $this->expectOutputString(
-            'float(1)' . PHP_EOL .
-            '1.0'
-        );
+        if (PHP_VERSION_ID < 70000) {
+            $this->expectOutputString(
+                'float(1)' . PHP_EOL .
+                '1'
+            );
+        } else {
+            $this->expectOutputString(
+                'float(1)' . PHP_EOL .
+                '1.0'
+            );
+        }
 
         $t = new \Test\Vars();
         $t->testDoubleVarDump();

--- a/unit-tests/Extension/VarsTest.php
+++ b/unit-tests/Extension/VarsTest.php
@@ -21,87 +21,159 @@ namespace Extension;
 
 class VarsTest extends \PHPUnit_Framework_TestCase
 {
-    public function testVarDump()
+    /**
+     * Test var_dump function (array and string).
+     */
+    public function testVarDumpArrayAndString()
     {
-        ob_start();
+        $this->setOutputCallback(
+            function ($output) {
+                /* To prevent differences between PHP version */
+                return str_replace(array(PHP_EOL, ' '), '', $output);
+            }
+        );
+
+        $this->expectOutputString(
+            'array(3){' .
+            '[0]=>int(1)' .
+            '[1]=>string(5)"world"' .
+            '[2]=>bool(false)}' .
+            'string(5)"hello"'
+        );
 
         $t = new \Test\Vars();
-        $t->testVarDump();
-        $t->testVarDump2param(3.1, true);
-        $t->testVarDump3param(3.1, true, array(1, 2, 3));
-        $t->testVarDump2param(3.1, true);
 
-        ob_clean();
+        $t->testVarDump();
+    }
+
+    /**
+     * Test var_dump function with two params.
+     */
+    public function testVarDumpWithTwoParams()
+    {
+        $this->expectOutputString(
+            'float(3.1)' . PHP_EOL .
+            'bool(true)' . PHP_EOL
+        );
+
+        $t = new \Test\Vars();
+
+        $t->testVarDump2param(3.1, true);
+    }
+
+    /**
+     * Test var_dump function with three params.
+     */
+    public function testVarDumpWithThreeParams()
+    {
+        $this->setOutputCallback(
+            function ($output) {
+                return str_replace(array(PHP_EOL, ' '), '', $output);
+            }
+        );
+
+        $this->expectOutputString(
+            'float(3.1)' .
+            'bool(true)' .
+            'array(3){[0]=>int(1)[1]=>int(2)[2]=>int(3)}'
+        );
+
+        $t = new \Test\Vars();
+
+        $t->testVarDump3param(3.1, true, array(1, 2, 3));
     }
 
     public function testVarExport()
     {
-        ob_start();
+        $this->setOutputCallback(
+            function ($output) {
+                return str_replace(array(PHP_EOL, ' '), '', $output);
+            }
+        );
+
+        $this->expectOutputString(
+            "array(0=>1,1=>'world',2=>false,)'hello'"
+        );
 
         $t = new \Test\Vars();
         $this->assertEquals($t->testVarExport(), "'hello'");
-
-        ob_clean();
     }
 
     public function test88Issue()
     {
-        ob_start();
-
         $t = new \Test\Vars();
-        $t->test88Issue('foo', 'bar');
-        $t->test88IssueParam2InitString('foo', 'bar');
 
-        ob_clean();
+        $this->expectOutputString(
+            'string(3) "foo"' . PHP_EOL .
+            'string(3) "bar"' . PHP_EOL .
+            "'foo'" .
+            "'bar'" .
+            "'bar'"
+        );
+
+        $t->test88Issue('foo', 'bar');
+
+        $t->test88IssueParam2InitString('foo', 'bar');
     }
 
     public function testVarDumpAndCountOptimizer()
     {
-        ob_start();
+        $this->expectOutputString(
+            'int(5)' . PHP_EOL .
+            '5'
+        );
 
         $t = new \Test\Vars();
         $t->testCountOptimizerVarDumpAndExport(array(1, 2, 3, 4, 5));
-
-        ob_clean();
     }
 
     public function testArrayTypeVarDumpAndExport()
     {
-        ob_start();
+        $this->setOutputCallback(
+            function ($output) {
+                return str_replace(array(PHP_EOL, ' '), '', $output);
+            }
+        );
+
+        $this->expectOutputString(
+            'array(3){[0]=>int(1)[1]=>int(2)[2]=>int(3)}' .
+            'array(0=>1,1=>2,2=>3,)'
+        );
 
         $t = new \Test\Vars();
         $t->testArrayTypeVarDumpAndExport(array(1, 2, 3));
-
-        ob_clean();
     }
 
     public function testIntVarDump()
     {
-        ob_start();
+        $this->expectOutputString(
+            'int(1)' . PHP_EOL .
+            '1'
+        );
 
         $t = new \Test\Vars();
         $t->testIntVarDump();
-
-        ob_clean();
     }
 
     public function testDoubleVarDump()
     {
-        ob_start();
+        $this->expectOutputString(
+            'float(1)' . PHP_EOL .
+            '1.0'
+        );
 
         $t = new \Test\Vars();
         $t->testDoubleVarDump();
-
-        ob_clean();
     }
 
     public function testBoolVarDump()
     {
-        ob_start();
+        $this->expectOutputString(
+            'bool(true)' . PHP_EOL .
+            'true'
+        );
 
         $t = new \Test\Vars();
         $t->testBoolVarDump();
-
-        ob_clean();
     }
 }

--- a/unit-tests/Zephir/Test/ConfigExceptionTest.php
+++ b/unit-tests/Zephir/Test/ConfigExceptionTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------------+
+ | Zephir Language                                                          |
+ +--------------------------------------------------------------------------+
+ | Copyright (c) 2013-2015 Zephir Team and contributors                     |
+ +--------------------------------------------------------------------------+
+ | This source file is subject the MIT license, that is bundled with        |
+ | this package in the file LICENSE, and is available through the           |
+ | world-wide-web at the following url:                                     |
+ | http://zephir-lang.com/license.html                                      |
+ |                                                                          |
+ | If you did not receive a copy of the MIT license and are unable          |
+ | to obtain it through the world-wide-web, please send a note to           |
+ | license@zephir-lang.com so we can mail you a copy immediately.           |
+ +--------------------------------------------------------------------------+
+*/
+
+namespace Zephir\Test;
+
+use Zephir\ConfigException;
+
+class ConfigExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Test __contruct method.
+     */
+    public function testConstruct()
+    {
+        $configException = new ConfigException('foo', 25);
+        $this->assertSame($configException->getCode(), 25);
+    }
+}

--- a/unit-tests/Zephir/Test/ConfigTest.php
+++ b/unit-tests/Zephir/Test/ConfigTest.php
@@ -92,7 +92,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $this->cleanTmpConfigFile();
     }
 
-    /** 
+    /**
      * Restore current directory, and clean config.json.
      */
     public function tearDown()

--- a/unit-tests/Zephir/Test/UtilsTest.php
+++ b/unit-tests/Zephir/Test/UtilsTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------------+
+ | Zephir Language                                                          |
+ +--------------------------------------------------------------------------+
+ | Copyright (c) 2013-2015 Zephir Team and contributors                     |
+ +--------------------------------------------------------------------------+
+ | This source file is subject the MIT license, that is bundled with        |
+ | this package in the file LICENSE, and is available through the           |
+ | world-wide-web at the following url:                                     |
+ | http://zephir-lang.com/license.html                                      |
+ |                                                                          |
+ | If you did not receive a copy of the MIT license and are unable          |
+ | to obtain it through the world-wide-web, please send a note to           |
+ | license@zephir-lang.com so we can mail you a copy immediately.           |
+ +--------------------------------------------------------------------------+
+*/
+
+namespace Zephir\Test;
+
+use Zephir\Utils;
+
+class UtilsTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Test escapeClassName method.
+     */
+    public function testEscapeClassName()
+    {
+        $classname = '\Bar\Foo';
+        $this->assertSame(
+            Utils::escapeClassName($classname),
+            '\\\\Bar\\\\Foo'
+        );
+    }
+
+    /**
+     * Test camelize method.
+     */
+    public function testCamelize()
+    {
+        $name = 'foo_Bar_Foo_bar';
+        $this->assertSame(
+            Utils::camelize($name),
+            'FooBarFooBar'
+        );
+    }
+}

--- a/unit-tests/Zephir/Test/_files/config.json
+++ b/unit-tests/Zephir/Test/_files/config.json
@@ -1,0 +1,1 @@
+bad file


### PR DESCRIPTION
- Migration to PHP Unit 5.4 and more by fixing Risky unit tests.
- Possibility to use the loader defined by Zephir without any warning.
- Activation of PHP Unit Coverage by adding filter section in phpunit.xml.dist
- Possiblity to use phpdbg to have the coverage
- Add some unit tests on ConfigException / Utils
