### PR TITLE
Fixed phpize and sudo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,13 +65,10 @@ after_success:
 after_failure:
  - ./unit-tests/ci/after_failure.sh
 
-after_script:
-  - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
-
 notifications:
   email:
     - andres@phalconphp.com
+    - serghei@phalconphp.com
 
 addons:
   apt:

--- a/templates/ZendEngine2/install
+++ b/templates/ZendEngine2/install
@@ -1,10 +1,20 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 export CC="gcc"
 export CFLAGS="-O2 -Wall -fvisibility=hidden -flto -DZEPHIR_RELEASE=1"
+
+phpize_bin=$(which phpize 2> /dev/null || which phpize5 2> /dev/null)
+
+if [ -z $(which sudo 2> /dev/null) ]; then
+    alias sudo=""
+fi
+
 if [ -f Makefile ]; then
 	sudo make --silent clean
-	sudo phpize --silent --clean
+	sudo ${phpize_bin} --silent --clean
 fi
-phpize --silent
+
+${phpize_bin} --silent
+
 ./configure --silent --enable-%PROJECT_LOWER%
 make --silent && sudo make --silent install

--- a/templates/ZendEngine3/install
+++ b/templates/ZendEngine3/install
@@ -1,10 +1,20 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 export CC="gcc"
 export CFLAGS="-O2 -Wall -fvisibility=hidden -flto -DZEPHIR_RELEASE=1"
+
+phpize_bin=$(which phpize 2> /dev/null)
+
+if [ -z $(which sudo 2> /dev/null) ]; then
+    alias sudo=""
+fi
+
 if [ -f Makefile ]; then
 	sudo make --silent clean
-	sudo phpize --silent --clean
+	sudo ${phpize_bin} --silent --clean
 fi
-phpize --silent
+
+${phpize_bin} --silent
+
 ./configure --silent --enable-%PROJECT_LOWER%
 make --silent && sudo make --silent install


### PR DESCRIPTION
1. In some cases `phpize` is called `phpize5`, besides in some cases it should be used as `/usr/bin/phpize` instead of only `phpize`.
2. In some systems (for example docker containers) there is no `sudo` by default.
3. Removed not needed ocular from Zephir build
