### PR TITLE
Adapted make to use in BSD systems

### DIFF
--- a/Library/Compiler.php
+++ b/Library/Compiler.php
@@ -270,7 +270,7 @@ class Compiler
                     $this->logger->output('Compiling the parser...');
 
                     exec(
-                        '(make --silent -j2 2> ./compile-errors.log 1> ./compile.log)',
+                        '(make -s -j2 2> ./compile-errors.log 1> ./compile.log)',
                         $output,
                         $exit
                     );
@@ -1259,7 +1259,7 @@ class Compiler
         } else {
             $this->preCompileHeaders();
             exec(
-                'cd ext && (make --silent -j2 2>' . $currentDir . '/compile-errors.log 1>' .
+                'cd ext && (make -s -j2 2>' . $currentDir . '/compile-errors.log 1>' .
                 $currentDir .
                 '/compile.log)',
                 $output,

--- a/templates/ZendEngine2/install
+++ b/templates/ZendEngine2/install
@@ -10,11 +10,11 @@ if [ -z $(which sudo 2> /dev/null) ]; then
 fi
 
 if [ -f Makefile ]; then
-	sudo make --silent clean
+	sudo make -s clean
 	sudo ${phpize_bin} --silent --clean
 fi
 
 ${phpize_bin} --silent
 
 ./configure --silent --enable-%PROJECT_LOWER%
-make --silent && sudo make --silent install
+make -s && sudo make -s install

--- a/templates/ZendEngine3/install
+++ b/templates/ZendEngine3/install
@@ -10,11 +10,11 @@ if [ -z $(which sudo 2> /dev/null) ]; then
 fi
 
 if [ -f Makefile ]; then
-	sudo make --silent clean
+	sudo make -s clean
 	sudo ${phpize_bin} --silent --clean
 fi
 
 ${phpize_bin} --silent
 
 ./configure --silent --enable-%PROJECT_LOWER%
-make --silent && sudo make --silent install
+make -s && sudo make -s install


### PR DESCRIPTION
Refs: #1289

**FreeBSD**
`man make`

```
-s       Do not echo any commands as they are executed.  Equivalent to
         specifying `@' before each command line in the makefile.
```

**Linux**
`man make`

```
-s, --silent, --quiet
Silent operation; do not print the commands as they are executed.
```
