### PR TITLE
Fixed phalcon usage as module in zephir

### DIFF
--- a/Library/Compiler.php
+++ b/Library/Compiler.php
@@ -387,16 +387,20 @@ class Compiler
         $filePath = $location . DIRECTORY_SEPARATOR .
                     strtolower(str_replace('\\', DIRECTORY_SEPARATOR, $className)) . '.zep';
 
-        if (!file_exists($filePath)) {
-            throw new CompilerException("Class '$className' must be located at '$filePath' but this file is missing");
-        }
-
         /**
          * Fix the class name
          */
         $className = join('\\', array_map(function ($i) {
             return ucfirst($i);
         }, explode('\\', $className)));
+
+        if (isset($this->files[$className])) {
+            return;
+        }
+
+        if (!file_exists($filePath)) {
+            throw new CompilerException("Class '$className' must be located at '$filePath' but this file is missing");
+        }
 
         $this->files[$className] = new CompilerFile($className, $filePath, $this->config, $this->logger);
         $this->files[$className]->setIsExternal(true);

--- a/Library/CompilerFile.php
+++ b/Library/CompilerFile.php
@@ -704,6 +704,17 @@ class CompilerFile
             }
         }
 
+        if ($compilationContext->classDefinition) {
+            if ($extendsClass = $compilationContext->classDefinition->getExtendsClass()) {
+                $compiler->isClass($extendsClass);
+            }
+            if ($interfaces = $compilationContext->classDefinition->getImplementedInterfaces()) {
+                foreach ($interfaces as $interface) {
+                    $compiler->isInterface($interface);
+                }
+            }
+        }
+
         $this->_ir = $ir;
     }
 

--- a/Library/Statements/ThrowStatement.php
+++ b/Library/Statements/ThrowStatement.php
@@ -59,7 +59,7 @@ class ThrowStatement extends StatementAbstract
                 if ($compilationContext->compiler->isClass($className)) {
                     $classDefinition = $compilationContext->compiler->getClassDefinition($className);
                     $message = $expr['parameters'][0]['parameter']['value'];
-                    $class = $classDefinition->getClassEntry();
+                    $class = $classDefinition->getClassEntry($compilationContext);
                     $this->throwStringException($codePrinter, $class, $message, $statement['expr']);
                     return;
                 } else {


### PR DESCRIPTION
Fixed usage the external zephir extensions.
Fixed getting/checking methods/properties/constants for the parent classes of external extensions.

fix https://github.com/phalcon/zephir/issues/304
fix https://github.com/phalcon/zephir/issues/1192
