### PR TITLE
Fixed PHP7 (ZendEngine3) zephir_array_isset_fetch when source and destination pointers are equal

### DIFF
--- a/kernels/ZendEngine3/array.c
+++ b/kernels/ZendEngine3/array.c
@@ -59,9 +59,9 @@ int zephir_array_isset_fetch(zval *fetched, const zval *arr, zval *index, int re
 	HashTable *h;
 	zval *result;
 
-	ZVAL_NULL(fetched);
-
 	if (Z_TYPE_P(arr) != IS_ARRAY) {
+		ZVAL_NULL(fetched);
+
 		return 0;
 	}
 
@@ -102,6 +102,9 @@ int zephir_array_isset_fetch(zval *fetched, const zval *arr, zval *index, int re
 		}
 		return 1;
 	}
+
+	ZVAL_NULL(fetched);
+
 	return 0;
 }
 

--- a/test/fetchtest.zep
+++ b/test/fetchtest.zep
@@ -16,22 +16,42 @@ class FetchTest
 		return fetch c, a[b];
 	}
 
-	public function testFetchArray2(var a, int b)
+	public function testFetchArray2(var a, var b)
+	{
+		return fetch a, a[b];
+	}
+
+	public function testFetchArray3(var a, int b)
 	{
 		var c;
 		return fetch c, a[b];
 	}
 
-	public function testFetchArray3(var a, string b)
+	public function testFetchArray4(var a, int b)
+	{
+		return fetch a, a[b];
+	}
+
+	public function testFetchArray5(var a, string b)
 	{
 		var c;
 		return fetch c, a[b];
+	}
+
+	public function testFetchArray6(var a, string b)
+	{
+		return fetch a, a[b];
 	}
 
 	public function testFetchObject1(var a, var b)
 	{
 		var c;
 		return fetch c, a->{b};
+	}
+
+	public function testFetchObject2(var a, var b)
+	{
+		return fetch a, a->{b};
 	}
 
 	public function testFetchPost(var b)


### PR DESCRIPTION
Description in #1308

Problem in Phalcon: https://github.com/phalcon/cphalcon/blob/c620825e105032cd3dc137e78fec93be85ff753e/phalcon/mvc/model/manager.zep#L545
