### PR TITLE
Avoid using "-a" or "-o" with "["

### DIFF
--- a/bin/zephir
+++ b/bin/zephir
@@ -19,7 +19,7 @@ if [ -z "$ZEPHIRDIR" ]; then
   fi
 fi
 
-if [ $1 -a $2 -a $3 -a $1 = "-c" ]; then
+if [ ! -z $1 ] && [ ! -z $2 ] && [ ! -z $3 ] && [ "$1" = "-c" ]; then
     php -d safe_mode=Off -d enable_dl=On -c $2 $ZEPHIRDIR/compiler.php ${*:3}
 else
     php -d safe_mode=Off -d enable_dl=On $ZEPHIRDIR/compiler.php $*


### PR DESCRIPTION
Since POSIX doesn't define the behavior of `[` with complex sets of tests, we should avoid using `-a` or `-o` with `[`.

Refs: [Conditional Blocks](http://mywiki.wooledge.org/BashGuide/TestsAndConditionals?highlight=%28conditional%29#Conditional_Blocks_.28if.2C_test_and_.5B.5B.29)
