### PR TITLE
Updating Compiler To Use Extension-Name For so file name.

### DIFF
--- a/Library/Compiler.php
+++ b/Library/Compiler.php
@@ -1354,7 +1354,9 @@ class Compiler
             $exit
         );
 
-        if (!file_exists("ext/modules/" . $namespace . ".so")) {
+        $fileName = $this->getConfig()->get('extension-name') ?: $namespace;
+
+        if (!file_exists("ext/modules/" . $fileName . ".so")) {
             throw new CompilerException(
                 "Internal extension compilation failed. Check compile-errors.log for more information"
             );


### PR DESCRIPTION
If you use the config option 'extension-name', the file created still uses the 'namespace' config option. This updates the compile to use the extension-name instead with a fallback to the namespace.

Note: Didn't see any tests for the compiler.
