### PR TITLE
Introduced HashEqualsOptimizer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ indent_style = space
 indent_size = 4
 
 [*.zep]
-indent_style = space
+indent_style = tab
 indent_size = 4
 
 [*.c]

--- a/Library/Optimizers/FunctionCall/HashEqualsOptimizer.php
+++ b/Library/Optimizers/FunctionCall/HashEqualsOptimizer.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------------+
+ | Zephir Language                                                          |
+ +--------------------------------------------------------------------------+
+ | Copyright (c) 2013-2016 Zephir Team and contributors                     |
+ +--------------------------------------------------------------------------+
+ | This source file is subject the MIT license, that is bundled with        |
+ | this package in the file LICENSE, and is available through the           |
+ | world-wide-web at the following url:                                     |
+ | http://zephir-lang.com/license.html                                      |
+ |                                                                          |
+ | If you did not receive a copy of the MIT license and are unable          |
+ | to obtain it through the world-wide-web, please send a note to           |
+ | license@zephir-lang.com so we can mail you a copy immediately.           |
+ +--------------------------------------------------------------------------+
+*/
+
+namespace Zephir\Optimizers\FunctionCall;
+
+use Zephir\Call;
+use Zephir\CompilationContext;
+use Zephir\CompilerException;
+use Zephir\CompiledExpression;
+use Zephir\Optimizers\OptimizerAbstract;
+
+/**
+ * HashEqualsOptimizer
+ *
+ * Optimizes calls to 'hash_equals' using internal function
+ */
+class HashEqualsOptimizer extends OptimizerAbstract
+{
+    /**
+     * @param array $expression
+     * @param Call $call
+     * @param CompilationContext $context
+     * @return bool|CompiledExpression|mixed
+     * @throws CompilerException
+     */
+    public function optimize(array $expression, Call $call, CompilationContext $context)
+    {
+        if (!isset($expression['parameters']) || count($expression['parameters']) != 2) {
+            throw new CompilerException("'hash_equals' requires two parameters", $expression);
+        }
+
+        /**
+         * Process the expected symbol to be returned
+         */
+        $call->processExpectedReturn($context);
+
+
+        $symbolVariable = $call->getSymbolVariable(true, $context);
+        if ($symbolVariable->isNotVariableAndString()) {
+            throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
+        }
+
+        $context->headersManager->add('kernel/string');
+
+        /**
+         * Process parameters
+         */
+        $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
+
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
+
+        return new CompiledExpression('bool', 'zephir_hash_equals(' . $resolvedParams[0] . ', ' . $resolvedParams[1] . ')', $expression);
+    }
+}

--- a/kernels/ZendEngine2/string.c
+++ b/kernels/ZendEngine2/string.c
@@ -1638,3 +1638,31 @@ void zephir_stripcslashes(zval *return_value, zval *str TSRMLS_DC)
 		zval_dtor(&copy);
 	}
 }
+
+/**
+ * Compares two strings using the same time whether they're equal or not.
+ * A difference in length will leak
+ */
+int zephir_hash_equals(const zval *known_zval, const zval *user_zval)
+{
+	char *known_str, *user_str;
+	int result = 0;
+	size_t j;
+
+	if (Z_TYPE_P(known_zval) != IS_STRING || Z_TYPE_P(user_zval) != IS_STRING) {
+		return 0;
+	}
+
+	if (Z_STRLEN_P(known_zval) != Z_STRLEN_P(user_zval)) {
+		return 0;
+	}
+
+	known_str = Z_STRVAL_P(known_zval);
+	user_str = Z_STRVAL_P(user_zval);
+
+	for (j = 0; j < Z_STRLEN_P(known_zval); j++) {
+		result |= known_str[j] ^ user_str[j];
+	}
+
+	return (int) (result == 0);
+}

--- a/kernels/ZendEngine2/string.h
+++ b/kernels/ZendEngine2/string.h
@@ -117,4 +117,6 @@ void zephir_stripcslashes(zval *return_value, zval *str TSRMLS_DC);
 		} \
 	} while (0)
 
+int zephir_hash_equals(const zval *known_zval, const zval *user_zval);
+
 #endif /* ZEPHIR_KERNEL_STRING_H */

--- a/kernels/ZendEngine3/string.c
+++ b/kernels/ZendEngine3/string.c
@@ -1346,3 +1346,31 @@ void zephir_stripcslashes(zval *return_value, zval *str)
 		zval_dtor(&copy);
 	}
 }
+
+/**
+ * Compares two strings using the same time whether they're equal or not.
+ * A difference in length will leak
+ */
+int zephir_hash_equals(const zval *known_zval, const zval *user_zval)
+{
+	char *known_str, *user_str;
+	int result = 0;
+	size_t j;
+
+	if (Z_TYPE_P(known_zval) != IS_STRING || Z_TYPE_P(user_zval) != IS_STRING) {
+		return 0;
+	}
+
+	if (Z_STRLEN_P(known_zval) != Z_STRLEN_P(user_zval)) {
+		return 0;
+	}
+
+	known_str = Z_STRVAL_P(known_zval);
+	user_str = Z_STRVAL_P(user_zval);
+
+	for (j = 0; j < Z_STRLEN_P(known_zval); j++) {
+		result |= known_str[j] ^ user_str[j];
+	}
+
+	return (int) (result == 0);
+}

--- a/kernels/ZendEngine3/string.h
+++ b/kernels/ZendEngine3/string.h
@@ -84,4 +84,6 @@ void zephir_unique_key(zval *return_value, const zval *prefix, zval *value);
 
 void zephir_append_printable_array(smart_str *implstr, const zval *value);
 
+int zephir_hash_equals(const zval *known_zval, const zval *user_zval);
+
 #endif /* ZEPHIR_KERNEL_STRING_H */

--- a/test/strings.zep
+++ b/test/strings.zep
@@ -107,33 +107,38 @@ class Strings
 		return stripcslashes(str);
 	}
 
-    public function testHardcodedMultilineString()
-    {
-        return "
+	public function testHashEquals(var str1, var str2) -> bool
+	{
+		return hash_equals(str1, str2);
+	}
+
+	public function testHardcodedMultilineString()
+	{
+		return "
             Hello world
         ";
-    }
+	}
 
-    public function testEchoMultilineString()
-    {
-        echo "
+	public function testEchoMultilineString()
+	{
+		echo "
             Hello world
         ";
-    }
+	}
 
-    public function testTrimMultilineString()
-    {
-        return trim("
+	public function testTrimMultilineString()
+	{
+		return trim("
             Hello world
         ");
-    }
+	}
 
-    public function testWellEscapedMultilineString()
-    {
-        return trim("
+	public function testWellEscapedMultilineString()
+	{
+		return trim("
             \\\"\}\$hello\$\\\"\'
         ");
-    }
+	}
 
 	public function testInternedString1()
 	{

--- a/unit-tests/Extension/StringTest.php
+++ b/unit-tests/Extension/StringTest.php
@@ -22,6 +22,35 @@ namespace Extension;
 class StringTest extends \PHPUnit_Framework_TestCase
 {
     /**
+     * @dataProvider providerHashEquals
+     * @param string $knownString
+     * @param string $userString
+     * @param string $expected
+     */
+    public function testHashEquals($knownString, $userString, $expected)
+    {
+        $t = new \Test\Strings();
+
+        $salt = '$2a$07$usesomesillystringforsalt$';
+        $knownString = crypt($knownString, $salt);
+        $userString = crypt($userString, $salt);
+
+        $this->assertSame($expected, $t->testHashEquals($knownString, $userString));
+    }
+
+    /**
+     * @dataProvider providerHashEqualsNonString
+     * @param string $knownString
+     * @param string $userString
+     */
+    public function testHashEqualsNonString($knownString, $userString)
+    {
+        $t = new \Test\Strings();
+
+        $this->assertFalse($t->testHashEquals($knownString, $userString));
+    }
+
+    /**
      * @dataProvider providerCamelize
      */
     public function testCamelize($actual, $expected, $delimiter)
@@ -198,6 +227,37 @@ class StringTest extends \PHPUnit_Framework_TestCase
 
         $escapedString = '\"\}\$hello\$\"\\\'';
         $this->assertSame($escapedString, $t->testWellEscapedMultilineString());
+    }
+
+    public function providerHashEquals()
+    {
+        return [
+            ['Phalcon',    'Phalcony',    false],
+            ['Phalcony',   'Phalcon',     false],
+            ['Phalcon',    'Phalcon',     true],
+            ['kristoffer', 'ingemansson', false],
+            ['kris',       'ingemansson', false],
+            ['Phalcon',    'phalcon',     false],
+            [' phalcon',   'phalcon',     false],
+            ['phalcon',    'phalcon',     true],
+            ['1234567890', '1234567890',  true],
+            ['',           'phalcon',     false],
+            ['phalcon',    '',            false],
+        ];
+    }
+
+    public function providerHashEqualsNonString()
+    {
+        return [
+            [null,       123,        false],
+            [123,        null,       false],
+            [123,        123,        false],
+            [123456,     123,        false],
+            [null,       'phalcon',  false],
+            ['phalcon',  null,       false],
+            [[],         false,      false],
+            [true,       [],         false],
+        ];
     }
 
     public function providerCamelize()


### PR DESCRIPTION
This PR introduces the `hash_equals` support/optimizer for PHP >= 5.4.
[Original function](http://php.net/manual/en/function.hash-equals.php) work only for for PHP >= 5.6.

Refs: https://github.com/phalcon/cphalcon/issues/12418