### PR TITLE
Test calling protected method

### DIFF
--- a/test/mcall.zep
+++ b/test/mcall.zep
@@ -256,6 +256,14 @@ class Mcall
 		return a->setCallable([this, "bb"]);
 	}
 
+	public function callProtectedFromOther()
+	{
+		var a;
+		let a = new Oo\OoOther();
+
+		return a->callProtected(this);
+	}
+
 	public function aa()
 	{
 		var a;

--- a/test/oo/ooother.zep
+++ b/test/oo/ooother.zep
@@ -1,0 +1,14 @@
+
+/**
+ * Class with calling proteced method
+ */
+
+namespace Test\Oo;
+
+class OoOther
+{
+	public function callProtected(var a)
+	{
+		return a->testMethod2();
+	}
+}

--- a/unit-tests/Extension/MCallTest.php
+++ b/unit-tests/Extension/MCallTest.php
@@ -21,6 +21,8 @@ namespace Extension;
 
 use Test\Mcall;
 use stdClass;
+use Throwable;
+use Exception;
 
 class MCallTest extends \PHPUnit_Framework_TestCase
 {
@@ -206,5 +208,21 @@ class MCallTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame('Test\Oo\Param', $this->getMethodFirstParameter()->getClass()->getName());
         $this->assertInstanceOf('Test\Oo\Param', $t->objectParamCastOoParam(new \Test\Oo\Param()));
+    }
+
+    public function testCallProtected()
+    {
+        $t = new Mcall();
+        $errorHappened = false;
+
+        try {
+            $t->callProtectedFromOther();
+        } catch (Throwable $t) {
+            $errorHappened = true;
+        } catch (Exception $e) {
+            $errorHappened = true;
+        }
+
+        $this->assertSame(true, $errorHappened);
     }
 }


### PR DESCRIPTION
On phalcon repo there is some weird code that protected method of some object is called without any problems from other object, on php 7.1 it's started to failing(**IT SHOULD ON ALL VERSIONS**) so this is testing this.