### PR TITLE
Fix a crash due to incorrect condition in `zephir_create_instance_params`

### DIFF
--- a/kernels/ZendEngine3/main.c
+++ b/kernels/ZendEngine3/main.c
@@ -368,6 +368,7 @@ void zephir_gettype(zval *return_value, zval *arg)
 					break;
 				}
 			}
+			/* no break */
 
 		default:
 			RETVAL_STRING("unknown type");

--- a/kernels/ZendEngine3/object.c
+++ b/kernels/ZendEngine3/object.c
@@ -1194,7 +1194,7 @@ int zephir_create_instance_params(zval *return_value, const zval *class_name, co
 			zval *item;
 			int i = 0;
 
-			if (likely(param_count) <= 10) {
+			if (EXPECTED(param_count <= 10)) {
 				params_ptr = static_params;
 			} else {
 				params_arr = emalloc(param_count * sizeof(zval*));
@@ -1211,7 +1211,7 @@ int zephir_create_instance_params(zval *return_value, const zval *class_name, co
 
 		outcome = zephir_call_class_method_aparams(NULL, ce, zephir_fcall_method, return_value, SL("__construct"), NULL, 0, param_count, params_ptr);
 
-		if (unlikely(params_arr != NULL)) {
+		if (UNEXPECTED(params_arr != NULL)) {
 			efree(params_arr);
 		}
 	}

--- a/test/instance.zep
+++ b/test/instance.zep
@@ -1,0 +1,47 @@
+
+/**
+ * Instance operations
+ */
+
+namespace Test;
+
+class Instance
+{
+	public function __construct(
+		<Arithmetic> a1,
+		<ArrayObject> a2,
+		<Assign> a3,
+		<Bitwise> a4,
+		<BranchPrediction> a5,
+		<Cast> a6,
+		<Cblock> a7,
+		<Chars> a8,
+		<Closures> a9,
+		<Compare> a10,
+		<Concat> a11
+	)
+	{
+
+	}
+
+	public static function testIssue1339()
+	{
+		var parameters;
+
+		let parameters = [
+			new Arithmetic(),
+			new ArrayObject(),
+			new Assign(),
+			new Bitwise(),
+			new BranchPrediction(),
+			new Cast(),
+			new Cblock(),
+			new Chars(),
+			new Closures(),
+			new Compare(),
+			new Concat()
+		];
+
+		return create_instance_params("Test\\Instance", parameters);
+	}
+}

--- a/unit-tests/Extension/InstanceTest.php
+++ b/unit-tests/Extension/InstanceTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------------+
+ | Zephir Language                                                          |
+ +--------------------------------------------------------------------------+
+ | Copyright (c) 2013-2017 Zephir Team and contributors                     |
+ +--------------------------------------------------------------------------+
+ | This source file is subject the MIT license, that is bundled with        |
+ | this package in the file LICENSE, and is available through the           |
+ | world-wide-web at the following url:                                     |
+ | http://zephir-lang.com/license.html                                      |
+ |                                                                          |
+ | If you did not receive a copy of the MIT license and are unable          |
+ | to obtain it through the world-wide-web, please send a note to           |
+ | license@zephir-lang.com so we can mail you a copy immediately.           |
+ +--------------------------------------------------------------------------+
+*/
+
+namespace Extension;
+
+use Test\Instance;
+
+class InstanceTest extends \PHPUnit_Framework_TestCase
+{
+    public function testIssue1339()
+    {
+        $t = Instance::testIssue1339();
+        $this->assertInstanceOf("Test\\Instance", $t);
+    }
+}


### PR DESCRIPTION
This fixes #1339, and includes the test case by @Jurigag from #1427 
