### PR TITLE
Fix promotion of chars

### DIFF
--- a/Library/Optimizers/FunctionCall/ZephirStringToHexOptimizer.php
+++ b/Library/Optimizers/FunctionCall/ZephirStringToHexOptimizer.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------------+
+ | Zephir Language                                                          |
+ +--------------------------------------------------------------------------+
+ | Copyright (c) 2013-2016 Zephir Team and contributors                     |
+ +--------------------------------------------------------------------------+
+ | This source file is subject the MIT license, that is bundled with        |
+ | this package in the file LICENSE, and is available through the           |
+ | world-wide-web at the following url:                                     |
+ | http://zephir-lang.com/license.html                                      |
+ |                                                                          |
+ | If you did not receive a copy of the MIT license and are unable          |
+ | to obtain it through the world-wide-web, please send a note to           |
+ | license@zephir-lang.com so we can mail you a copy immediately.           |
+ +--------------------------------------------------------------------------+
+*/
+
+namespace Zephir\Optimizers\FunctionCall;
+
+use Zephir\Call;
+use Zephir\CompilationContext;
+use Zephir\CompilerException;
+use Zephir\CompiledExpression;
+use Zephir\Optimizers\OptimizerAbstract;
+
+/**
+ * ZephirStringToHexOptimizer
+ *
+ * Optimizes calls to 'zephir_string_to_hex'
+ */
+class ZephirStringToHexOptimizer extends OptimizerAbstract
+{
+    /**
+     * @param array $expression
+     * @param Call $call
+     * @param CompilationContext $context
+     * @return bool|CompiledExpression|mixed
+     * @throws CompilerException
+     */
+    public function optimize(array $expression, Call $call, CompilationContext $context)
+    {
+        if (!isset($expression['parameters'])) {
+            return false;
+        }
+
+        if (count($expression['parameters']) > 1) {
+            return false;
+        }
+
+        /**
+         * Process the expected symbol to be returned
+         */
+        $call->processExpectedReturn($context);
+
+        $symbolVariable = $call->getSymbolVariable(true, $context);
+
+        if ($symbolVariable->isNotVariableAndString()) {
+            throw new CompilerException("Returned values by functions can only be assigned to variant variables", $expression);
+        }
+
+        $context->headersManager->add('kernel/string');
+
+        $symbolVariable->setDynamicTypes('string');
+
+        $resolvedParams = $call->getReadOnlyResolvedParams($expression['parameters'], $context, $expression);
+
+        if ($call->mustInitSymbolVariable()) {
+            $symbolVariable->initVariant($context);
+        }
+
+        $symbol = $context->backend->getVariableCode($symbolVariable);
+        $context->codePrinter->output('zephir_string_to_hex(' . $symbol . ', ' . $resolvedParams[0] . ');');
+
+        return new CompiledExpression('variable', $symbolVariable->getRealName(), $expression);
+    }
+}

--- a/Library/Types/CharType.php
+++ b/Library/Types/CharType.php
@@ -50,7 +50,7 @@ class CharType extends AbstractType
     {
         $exprBuilder = BuilderFactory::getInstance();
         $functionCall = $exprBuilder->statements()
-            ->functionCall('sprintf', array($exprBuilder->literal(Types::STRING, '%X'), $caller))
+            ->functionCall('zephir_string_to_hex', array($caller))
             ->setFile($expression['file'])
             ->setLine($expression['line'])
             ->setChar($expression['char']);

--- a/kernels/ZendEngine2/string.c
+++ b/kernels/ZendEngine2/string.c
@@ -1666,3 +1666,32 @@ int zephir_hash_equals(const zval *known_zval, const zval *user_zval)
 
 	return (int) (result == 0);
 }
+
+void zephir_string_to_hex(zval *return_value, zval *var)
+{
+	int use_copy = 0;
+	zval copy;
+	size_t i;
+	char *s;
+	char *res;
+
+	if (Z_TYPE_P(var) != IS_STRING) {
+		zend_make_printable_zval(var, &copy, &use_copy);
+		if (use_copy) {
+			var = &copy;
+		}
+	}
+
+	res = emalloc(2*Z_STRLEN_P(var) + 1);
+	s   = Z_STRVAL_P(var);
+	for (i=0; i<Z_STRLEN_P(var); ++i) {
+		sprintf(res + 2*i, "%hhX", s[i]);
+	}
+
+	res[2*Z_STRLEN_P(var)] = 0;
+	ZVAL_STRINGL(return_value, res, 2*Z_STRLEN_P(var), 0);
+
+	if (use_copy) {
+		zval_dtor(var);
+	}
+}

--- a/kernels/ZendEngine2/string.h
+++ b/kernels/ZendEngine2/string.h
@@ -119,4 +119,6 @@ void zephir_stripcslashes(zval *return_value, zval *str TSRMLS_DC);
 
 int zephir_hash_equals(const zval *known_zval, const zval *user_zval);
 
+void zephir_string_to_hex(zval *return_value, zval *var);
+
 #endif /* ZEPHIR_KERNEL_STRING_H */

--- a/kernels/ZendEngine3/string.c
+++ b/kernels/ZendEngine3/string.c
@@ -1375,3 +1375,34 @@ int zephir_hash_equals(const zval *known_zval, const zval *user_zval)
 
 	return (int) (result == 0);
 }
+
+void zephir_string_to_hex(zval *return_value, zval *var)
+{
+	int use_copy = 0;
+	zval copy;
+	size_t i;
+	char *s;
+	zend_string *res;
+
+	if (Z_TYPE_P(var) != IS_STRING) {
+		use_copy = zend_make_printable_zval(var, &copy);
+		if (use_copy) {
+			var = &copy;
+		}
+	}
+
+	res = zend_string_alloc(2*Z_STRLEN_P(var) + 1, 0);
+	s   = Z_STRVAL_P(var);
+	for (i=0; i<Z_STRLEN_P(var); ++i) {
+		sprintf(res->val + 2*i, "%hhX", s[i]);
+	}
+
+	res->val[2*Z_STRLEN_P(var)] = 0;
+	res->len = 2*Z_STRLEN_P(var);
+	zend_string_forget_hash_val(res);
+	ZVAL_STR(return_value, res);
+
+	if (use_copy) {
+		zval_dtor(var);
+	}
+}

--- a/kernels/ZendEngine3/string.h
+++ b/kernels/ZendEngine3/string.h
@@ -86,4 +86,6 @@ void zephir_append_printable_array(smart_str *implstr, const zval *value);
 
 int zephir_hash_equals(const zval *known_zval, const zval *user_zval);
 
+void zephir_string_to_hex(zval *return_value, zval *var);
+
 #endif /* ZEPHIR_KERNEL_STRING_H */

--- a/test/strings.zep
+++ b/test/strings.zep
@@ -149,4 +149,15 @@ class Strings
 	{
 		return ~" hello "->trim();
 	}
+
+	public function strToHex(string value) -> string
+	{
+		int i = 0;
+		string ret = "";
+		while (i < value->length()) {
+			let ret .= dechex(ord(value[i]));
+			let i++;
+		}
+		return ret;
+	}
 }

--- a/unit-tests/Extension/StringTest.php
+++ b/unit-tests/Extension/StringTest.php
@@ -229,6 +229,12 @@ class StringTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($escapedString, $t->testWellEscapedMultilineString());
     }
 
+    public function testStrToHex()
+    {
+        $t = new \Test\Strings();
+        $this->assertSame('746573742073656e74656e73652e2e2e', $t->strToHex("test sentense..."));
+    }
+
     public function providerHashEquals()
     {
         return [


### PR DESCRIPTION
See #1369 

Zend Engine does not have char type, and string characters accessed in a string by offset are also strings.

Zephir decided to introduce char type but promotes it to integer which is not compatible with PHP.

In this PR:
* chars are promoted to strings in `getReadOnlyResolvedParams()`;
* char->hex() is implemented via `zephir_string_to_hex()` builtin, as `sprintf("%X", "c")` returns 0 (`sprintf` relies on argument types).
