### PR TITLE
[Runtime] Support new LLVM backends on configuration

### DIFF
--- a/runtime/config.m4
+++ b/runtime/config.m4
@@ -10,8 +10,8 @@ if test "$PHP_ZEPHIR" = "yes"; then
 	zephir_sources="zephir.c kernel/main.c kernel/memory.c kernel/fcall.c kernel/exceptions.c kernel/operators.c kernel/string.c parser.c scanner.c builder.c utils.c classes.c blocks.c expr.c symtable.c variable.c errors.c fcall.c statements/echo.c statements/loop.c statements/let.c statements/if.c statements/while.c statements/declare.c statements/return.c statements/break.c operators/arithmetical.c operators/comparison.c optimizers/evalexpr.c"
 
 	dnl Link LLVM libraries:
-	LLVM_LDFLAGS=`llvm-config-3.3 --libs --ldflags core analysis executionengine jit interpreter native`
-	LLVM_CFLAGS=`llvm-config-3.3 --cflags`
+	LLVM_LDFLAGS=`llvm-config --libs --ldflags core analysis executionengine jit interpreter native`
+	LLVM_CFLAGS=`llvm-config --cflags`
 	LDFLAGS="$LDFLAGS -Wl,-rpath $LLVM_LDFLAGS"
 	CFLAGS="$CFLAGS -Wl,-rpath $LLVM_CFLAGS -O0 -g3 -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS"
 


### PR DESCRIPTION
Hey!

Looks likes this utils was renamed from `llvm-config-3.3` to `llvm-config` by default :atom: 

![image](https://cloud.githubusercontent.com/assets/572096/24576450/07213ca4-16f7-11e7-8af4-99ae061e957c.png)

For example

```
llvm-config --cflags
-I/usr/local/Cellar/llvm/4.0.0/include  -fPIC -Wall -W -Wno-unused-parameter -Wwrite-strings -Wmissing-field-initializers -pedantic -Wno-long-long -Wcovered-switch-default -Wdelete-non-virtual-dtor -Wstring-conversion -Werror=date-time -DNDEBUG -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
```

Thanks 😸 