### PR TITLE
git push in after_success only for phalcon/zephir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ after_success:
   - cp -a ext/test/. generated/$ZEPHIR_TARGET
   - git add -A generated/$ZEPHIR_TARGET
   - 'git commit -m "chore($ZEPHIR_TARGET): $TRAVIS_COMMIT: regenerate test sources [ci skip]" generated/$ZEPHIR_TARGET'
-  - if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$ZEPHIR_TARGET" != "legacy" ]]; then git fetch && git rebase --autostash FETCH_HEAD && git push; fi
+  - if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$ZEPHIR_TARGET" != "legacy" && "$TRAVIS_REPO_SLUG" == "phalcon/zephir" ]]; then git fetch && git rebase --autostash FETCH_HEAD && git push; fi
   - if [[ "$TRAVIS_PULL_REQUEST" == "true" ]]; then git log -1 -p; fi
 
 after_failure:


### PR DESCRIPTION
As discussed in Slack — when `git push` is invoked for a forked repository, it makes the Travis build time out.

This patch explicitly checks that we are on `phalcon/zephir`.

@sergeyklay see if we need a similar solution somewhere else.