### PR TITLE
Do not treat numeric strings starting with 0 as numbers

### DIFF
--- a/Library/Expression.php
+++ b/Library/Expression.php
@@ -316,10 +316,10 @@ class Expression
                 $v = $expression['value'];
                 if (!$this->_stringOperation) {
                     if (ctype_digit($v) && (strlen($v) == 1 || '0' != substr($v, 0, 1))) {
-                        return new CompiledExpression('int', $expression['value'], $expression);
+                        return new CompiledExpression('int', $v, $expression);
                     }
                 }
-                return new LiteralCompiledExpression('string', str_replace(PHP_EOL, '\\n', $expression['value']), $expression);
+                return new LiteralCompiledExpression('string', str_replace(PHP_EOL, '\\n', $v), $expression);
             case 'istring':
                 return new LiteralCompiledExpression('istring', str_replace(PHP_EOL, '\\n', $expression['value']), $expression);
 

--- a/Library/Expression.php
+++ b/Library/Expression.php
@@ -313,8 +313,9 @@ class Expression
                 return new LiteralCompiledExpression($type, $expression['value'], $expression);
 
             case 'string':
+                $v = $expression['value'];
                 if (!$this->_stringOperation) {
-                    if (ctype_digit($expression['value'])) {
+                    if (ctype_digit($v) && (strlen($v) == 1 || '0' != substr($v, 0, 1))) {
                         return new CompiledExpression('int', $expression['value'], $expression);
                     }
                 }

--- a/test/issue1521.zep
+++ b/test/issue1521.zep
@@ -7,7 +7,8 @@ class Issue1521
 	public function test()
 	{
 		let this->params = [
-			"merchantNumber":"0818217122"
+			"merchantNumber":"0818217122",
+			"zero":"0"
 		];
 
 		return this->params["merchantNumber"];

--- a/test/issue1521.zep
+++ b/test/issue1521.zep
@@ -11,6 +11,6 @@ class Issue1521
 			"zero":"0"
 		];
 
-		return this->params["merchantNumber"];
+		return this->params;
 	}
 }

--- a/test/issue1521.zep
+++ b/test/issue1521.zep
@@ -1,0 +1,15 @@
+namespace Test;
+
+class Issue1521
+{
+	public params;
+
+	public function test()
+	{
+		let this->params = [
+			"merchantNumber":"0818217122"
+		];
+
+		return this->params["merchantNumber"];
+	}
+}

--- a/unit-tests/Extension/Issue1521Test.php
+++ b/unit-tests/Extension/Issue1521Test.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------------+
+ | Zephir Language                                                          |
+ +--------------------------------------------------------------------------+
+ | Copyright (c) 2013-2017 Zephir Team and contributors                     |
+ +--------------------------------------------------------------------------+
+ | This source file is subject the MIT license, that is bundled with        |
+ | this package in the file LICENSE, and is available through the           |
+ | world-wide-web at the following url:                                     |
+ | http://zephir-lang.com/license.html                                      |
+ |                                                                          |
+ | If you did not receive a copy of the MIT license and are unable          |
+ | to obtain it through the world-wide-web, please send a note to           |
+ | license@zephir-lang.com so we can mail you a copy immediately.           |
+ +--------------------------------------------------------------------------+
+*/
+
+namespace Extension;
+
+class Issue1521Test extends \PHPUnit_Framework_TestCase
+{
+    public function testIssue1521()
+    {
+        $t      = new \Test\Issue1521();
+        $actual = $t->test();
+        $this->assertTrue(0 === $actual['zero']);
+        $this->assertTrue("0818217122" === $actual['merchantNumber']);
+    }
+}


### PR DESCRIPTION
If `"0123"` is treated like `0123`, the C compiler will think it is an octal number and will convert it to `83`.

Likewise, if such a string contains a non-octal digit, this will result in compilation error.

See #1521