### PR TITLE
Fix segfaults in Phalcon (ZE2)

### DIFF
--- a/Library/Backends/ZendEngine2/Backend.php
+++ b/Library/Backends/ZendEngine2/Backend.php
@@ -348,11 +348,6 @@ class Backend extends BaseBackend
 
         /* Initialize default values in dynamic variables */
         foreach ($variables as $variable) {
-            if (!$this->isZE3() && $variable->isComplex() && $variable->isLocalOnly() && $variable->mustInitNull()) {
-                $codePrinter->output('zephir_memory_observe_alt(&' . $variable->getName() . ' TSRMLS_CC);');
-                $compilationContext->symbolTable->mustGrownStack(true);
-            }
-
             /**
              * Initialize 'dynamic' variables with default values
              */

--- a/kernels/ZendEngine2/memory.h
+++ b/kernels/ZendEngine2/memory.h
@@ -81,11 +81,7 @@ void zephir_deinitialize_memory(TSRMLS_D);
 		ZVAL_NULL(&z);      \
 	} while (0)
 
-#define ZEPHIR_SINIT_NVAR(z) \
-	do {                     \
-		zval_dtor(&z);       \
-		INIT_PZVAL(&z);      \
-	} while (0)
+#define ZEPHIR_SINIT_NVAR(z) Z_SET_REFCOUNT_P(&z, 1)
 
 #define ZEPHIR_INIT_ZVAL_NREF(z) \
 	do {                         \


### PR DESCRIPTION
Revert 61c06a1fad2a93c71d5be3367297c813689ef523
Restore the definition of `ZEPHIR_SINIT_NVAR`