### PR TITLE
drop zend_error_noreturn usage

### DIFF
--- a/kernels/ZendEngine2/extended/fcall.c
+++ b/kernels/ZendEngine2/extended/fcall.c
@@ -272,7 +272,7 @@ int zephir_call_func_aparams_fast(zval **return_value_ptr, zephir_fcall_cache_en
 		ALLOC_INIT_ZVAL(*retval_ptr_ptr);
 
 		/* Not sure what should be done here if it's a static method */
-		zend_error_noreturn(E_ERROR, "Cannot call overloaded function for non-object");
+		zend_error(E_ERROR, "Cannot call overloaded function for non-object");
 
 		if (func->type == ZEND_OVERLOADED_FUNCTION_TEMPORARY) {
 			efree((char*)func->common.function_name);
@@ -1175,7 +1175,7 @@ int zephir_call_function_opt(zend_fcall_info *fci, zend_fcall_info_cache *fci_ca
 	fn_flags = EX(function_state).function->common.fn_flags;
 	if (fn_flags & (ZEND_ACC_ABSTRACT|ZEND_ACC_DEPRECATED)) {
 		if (fn_flags & ZEND_ACC_ABSTRACT) {
-			zend_error_noreturn(E_ERROR, "Cannot call abstract method %s::%s()", EX(function_state).function->common.scope->name, EX(function_state).function->common.function_name);
+			zend_error(E_ERROR, "Cannot call abstract method %s::%s()", EX(function_state).function->common.scope->name, EX(function_state).function->common.function_name);
 		}
 		if (fn_flags & ZEND_ACC_DEPRECATED) {
 			zend_error(E_DEPRECATED, "Function %s%s%s() is deprecated",
@@ -1341,7 +1341,7 @@ int zephir_call_function_opt(zend_fcall_info *fci, zend_fcall_info_cache *fci_ca
 		if (fci->object_ptr) {
 			Z_OBJ_HT_P(fci->object_ptr)->call_method(EX(function_state).function->common.function_name, fci->param_count, *fci->retval_ptr_ptr, fci->retval_ptr_ptr, fci->object_ptr, 1 TSRMLS_CC);
 		} else {
-			zend_error_noreturn(E_ERROR, "Cannot call overloaded function for non-object");
+			zend_error(E_ERROR, "Cannot call overloaded function for non-object");
 		}
 
 		if (EX(function_state).function->type == ZEND_OVERLOADED_FUNCTION_TEMPORARY) {

--- a/kernels/ZendEngine2/object.c
+++ b/kernels/ZendEngine2/object.c
@@ -1274,7 +1274,7 @@ static zval **zephir_std_get_static_property(zend_class_entry *ce, const char *p
 
 		if (UNEXPECTED(zend_hash_quick_find(&ce->properties_info, property_name, property_name_len + 1, hash_value, (void **) &temp_property_info)==FAILURE)) {
 			if (!silent) {
-				zend_error_noreturn(E_ERROR, "Access to undeclared static property: %s::$%s", ce->name, property_name);
+				zend_error(E_ERROR, "Access to undeclared static property: %s::$%s", ce->name, property_name);
 			}
 			return NULL;
 		}
@@ -1282,14 +1282,14 @@ static zval **zephir_std_get_static_property(zend_class_entry *ce, const char *p
 		#ifndef ZEPHIR_RELEASE
 		/*if (UNEXPECTED(!zend_verify_property_access(temp_property_info, ce TSRMLS_CC))) {
 			if (!silent) {
-				zend_error_noreturn(E_ERROR, "Cannot access %s property %s::$%s", zend_visibility_string(temp_property_info->flags), ce->name, property_name);
+				zend_error(E_ERROR, "Cannot access %s property %s::$%s", zend_visibility_string(temp_property_info->flags), ce->name, property_name);
 			}
 			return NULL;
 		}
 
 		if (UNEXPECTED((temp_property_info->flags & ZEND_ACC_STATIC) == 0)) {
 			if (!silent) {
-				zend_error_noreturn(E_ERROR, "Access to undeclared static property: %s::$%s", ce->name, property_name);
+				zend_error(E_ERROR, "Access to undeclared static property: %s::$%s", ce->name, property_name);
 			}
 			return NULL;
 		}*/
@@ -1307,7 +1307,7 @@ static zval **zephir_std_get_static_property(zend_class_entry *ce, const char *p
 
 	if (UNEXPECTED(CE_STATIC_MEMBERS(ce) == NULL) || UNEXPECTED(CE_STATIC_MEMBERS(ce)[temp_property_info->offset] == NULL)) {
 		if (!silent) {
-			zend_error_noreturn(E_ERROR, "Access to undeclared static property: %s::$%s", ce->name, property_name);
+			zend_error(E_ERROR, "Access to undeclared static property: %s::$%s", ce->name, property_name);
 		}
 		return NULL;
 	}

--- a/runtime/kernel/fcall.c
+++ b/runtime/kernel/fcall.c
@@ -796,7 +796,7 @@ int zephirt_call_function(zend_fcall_info *fci, zend_fcall_info_cache *fci_cache
 
 	#ifndef ZEPHIR_RELEASE
 	if (EX(function_state).function->common.fn_flags & ZEND_ACC_ABSTRACT) {
-		zend_error_noreturn(E_ERROR, "Cannot call abstract method %s::%s()", EX(function_state).function->common.scope->name, EX(function_state).function->common.function_name);
+		zend_error(E_ERROR, "Cannot call abstract method %s::%s()", EX(function_state).function->common.scope->name, EX(function_state).function->common.function_name);
 		return FAILURE;
 	}
 	#endif
@@ -962,7 +962,7 @@ int zephirt_call_function(zend_fcall_info *fci, zend_fcall_info_cache *fci_cache
 		if (fci->object_ptr) {
 			Z_OBJ_HT_P(fci->object_ptr)->call_method(EX(function_state).function->common.function_name, fci->param_count, *fci->retval_ptr_ptr, fci->retval_ptr_ptr, fci->object_ptr, 1 TSRMLS_CC);
 		} else {
-			zend_error_noreturn(E_ERROR, "Cannot call overloaded function for non-object");
+			zend_error(E_ERROR, "Cannot call overloaded function for non-object");
 			return FAILURE;
 		}
 

--- a/runtime/kernel/fcall.h
+++ b/runtime/kernel/fcall.h
@@ -655,10 +655,6 @@ int zephirt_call_function(zend_fcall_info *fci, zend_fcall_info_cache *fci_cache
 #define ZEPHIR_ZEND_CALL_FUNCTION_WRAPPER zend_call_function
 #endif
 
-#ifndef zend_error_noreturn
-#define zend_error_noreturn zend_error
-#endif
-
 #define zephirt_check_call_status() \
 	do \
 		if (ZEPHIR_LAST_CALL_STATUS == FAILURE) { \


### PR DESCRIPTION
See https://github.com/phalcon/cphalcon/issues/12909

Notice: **zend_error_noreturn** does exactly the same than **zend_error**, only exists to avoid compiler warnings

`
void zend_error_noreturn(int type, const char *format, ...) __attribute__ ((alias("zend_error"),noreturn));`