### PR TITLE
0.10.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ runtime/run-tests.php
 runtime/a.zep
 runtime/index.php
 runtime/parser.out
+
+coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,9 @@ cache:
     - $HOME/.ccache
     - $HOME/.composer/cache
 
+before_install:
+  - if [[ ! -z "${GH_TOKEN}" ]]; then composer config github-oauth.github.com ${GH_TOKEN}; echo "Configured Github token"; fi;
+
 install:
   - composer --prefer-source install
   - bash unit-tests/ci/install_zephir_parser.sh
@@ -67,6 +70,9 @@ script:
   - vendor/bin/phpcs --standard=PSR2 --report=emacs --extensions=php --warning-severity=0 Library/ unit-tests/Extension/ unit-tests/Zephir/
   - valgrind --read-var-info=yes --error-exitcode=1 --fullpath-after= --track-origins=yes --leak-check=full ./unit-tests/phpunit --not-exit -c phpunit.xml.dist --debug unit-tests/
   - $(phpenv which php) unit-tests/microbench.php
+
+after_success:
+  - if [[ ! -z "${CODECOV_TOKEN}" ]]; then bash <(curl -s https://codecov.io/bash); fi;
 
 after_failure:
   - ./unit-tests/ci/after_failure.sh

--- a/Library/Backends/ZendEngine3/Backend.php
+++ b/Library/Backends/ZendEngine3/Backend.php
@@ -623,7 +623,7 @@ class Backend extends BackendZendEngine2
         if ($value == 'null' || $value == 'true' || $value == 'false') {
             $varName = '__$' . $value;
             if (!$context->symbolTable->hasVariable($varName)) {
-                $tempVariable = new Variable('variable', $varName, $context->currentBranch, null);
+                $tempVariable = new Variable('variable', $varName, $context->currentBranch);
                 $context->symbolTable->addRawVariable($tempVariable);
             }
             $tempVariable = $context->symbolTable->getVariableForWrite($varName, $context);

--- a/Library/Bootstrap.php
+++ b/Library/Bootstrap.php
@@ -154,7 +154,7 @@ class Bootstrap
         };
 
         $message .= sprintf("at %s(%s)\n\n", $preparePaths($e->getFile()), $e->getLine());
-        $message .= sprintf("Trace:\n%s\n", $preparePaths($e->getTraceAsString()));
+        $message .= sprintf("Stack trace:\n%s\n", $preparePaths($e->getTraceAsString()));
 
         return $message;
     }

--- a/Library/Compiler.php
+++ b/Library/Compiler.php
@@ -31,7 +31,7 @@ use Zephir\FileSystem\HardDisk as FileSystem;
  */
 class Compiler
 {
-    const VERSION = '0.10.1';
+    const VERSION = '0.10.2';
 
     public $parserCompiled = false;
 

--- a/Library/Operators/Bitwise/BitwiseBaseOperator.php
+++ b/Library/Operators/Bitwise/BitwiseBaseOperator.php
@@ -101,8 +101,11 @@ class BitwiseBaseOperator extends BaseOperator
     }
 
     /**
+     * {@inheritdoc}
+     *
      * @param array $expression
      * @param CompilationContext $compilationContext
+     * @return bool|CompiledExpression
      */
     public function compile($expression, CompilationContext $compilationContext)
     {

--- a/Library/Operators/Other/ConcatOperator.php
+++ b/Library/Operators/Other/ConcatOperator.php
@@ -37,6 +37,7 @@ class ConcatOperator extends BaseOperator
      * @param array $expression
      * @param CompilationContext $compilationContext
      * @param boolean $isFullString
+     * @return array
      */
     private function _getOptimizedConcat($expression, CompilationContext $compilationContext, &$isFullString)
     {
@@ -128,10 +129,11 @@ class ConcatOperator extends BaseOperator
     }
 
     /**
-     * Performs concat compilation
+     * Performs concat compilation.
      *
-     * @param Expression $expression
+     * @param array $expression
      * @param CompilationContext $compilationContext
+     * @return CompiledExpression
      */
     public function compile($expression, CompilationContext $compilationContext)
     {

--- a/Library/Operators/Other/TypeHintOperator.php
+++ b/Library/Operators/Other/TypeHintOperator.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------------+
+ | Zephir                                                                   |
+ | Copyright (c) 2013-present Zephir (https://zephir-lang.com/)             |
+ |                                                                          |
+ | This source file is subject the MIT license, that is bundled with this   |
+ | package in the file LICENSE, and is available through the world-wide-web |
+ | at the following url: http://zephir-lang.com/license.html                |
+ +--------------------------------------------------------------------------+
+ */
+
+namespace Zephir\Operators\Other;
+
+use Zephir\Expression;
+use Zephir\CompiledExpression;
+use Zephir\CompilationContext;
+use Zephir\Operators\BaseOperator;
+use Zephir\Compiler\CompilerException;
+
+/**
+ * Zephir\Operators\Other\TypeHintOperator
+ *
+ * @package Zephir\Operators\Other
+ */
+class TypeHintOperator extends BaseOperator
+{
+    private $strict = false;
+
+    /**
+     * Sets if the type hint is strict or not.
+     *
+     * @param $strict
+     */
+    public function setStrict($strict)
+    {
+        $this->strict = (bool) $strict;
+    }
+
+    /**
+     * Performs type-hint compilation.
+     *
+     * @param array              $expression
+     * @param CompilationContext $compilationContext
+     * @return CompiledExpression
+     * @throws CompilerException
+     */
+    public function compile(array $expression, CompilationContext $compilationContext)
+    {
+        $expr = new Expression($expression['right']);
+        $expr->setReadOnly(true);
+        $resolved = $expr->compile($compilationContext);
+
+        if ($resolved->getType() != 'variable') {
+            throw new CompilerException('Type-Hints only can be applied to dynamic variables.', $expression);
+        }
+
+        $symbolVariable = $compilationContext->symbolTable->getVariableForRead(
+            $resolved->getCode(),
+            $compilationContext,
+            $expression
+        );
+
+        if (!$symbolVariable->isVariable()) {
+            throw new CompilerException('Type-Hints only can be applied to dynamic variables.', $expression);
+        }
+
+        $symbolVariable->setDynamicTypes('object');
+        $symbolVariable->setClassTypes($compilationContext->getFullName($expression['left']['value']));
+
+        return $resolved;
+    }
+}

--- a/Library/Statements/DeclareStatement.php
+++ b/Library/Statements/DeclareStatement.php
@@ -81,11 +81,7 @@ class DeclareStatement extends StatementAbstract
             /**
              * Variables are added to the symbol table
              */
-            if (isset($variable['expr'])) {
-                $symbolVariable = $symbolTable->addVariable($currentType, $varName, $compilationContext, $variable['expr']);
-            } else {
-                $symbolVariable = $symbolTable->addVariable($currentType, $varName, $compilationContext);
-            }
+            $symbolVariable = $symbolTable->addVariable($currentType, $varName, $compilationContext);
             $varName = $symbolVariable->getName();
 
             /**

--- a/Library/SymbolTable.php
+++ b/Library/SymbolTable.php
@@ -132,37 +132,36 @@ class SymbolTable
      * @param int $type
      * @param string $name
      * @param CompilationContext $compilationContext
-     * @param mixed $defaultValue
      * @return Variable
      */
-    public function addVariable($type, $name, CompilationContext $compilationContext, $defaultValue = null)
+    public function addVariable($type, $name, CompilationContext $compilationContext)
     {
         $currentBranch = $compilationContext->branchManager->getCurrentBranch();
         $branchId = $currentBranch->getUniqueId();
         if ($this->globalsManager->isSuperGlobal($name) || $type == 'zephir_fcall_cache_entry') {
             $branchId = 1;
         }
+
         $varName = $name;
         if ($branchId > 1 && $currentBranch->getType() != Branch::TYPE_ROOT) {
             $varName = $name . Variable::BRANCH_MAGIC . $branchId;
         }
 
-        $variable = new Variable($type, $varName, $compilationContext->currentBranch, $defaultValue);
-        if ($type == 'variable') {
-            if ($this->localContext) {
-                /**
-                 * Checks whether a variable can be optimized to be static or not
-                 */
-                if ($this->localContext->shouldBeLocal($name)) {
-                    $variable->setLocalOnly(true);
-                }
-            }
+        $variable = new Variable($type, $varName, $currentBranch);
+
+        /**
+         * Checks whether a variable can be optimized to be static or not
+         */
+        if ($type == 'variable' && $this->localContext && $this->localContext->shouldBeLocal($name)) {
+            $variable->setLocalOnly(true);
         }
 
         if (!isset($this->branchVariables[$branchId])) {
             $this->branchVariables[$branchId] = array();
         }
+
         $this->branchVariables[$branchId][$name] = $variable;
+
         return $variable;
     }
 

--- a/Library/Utils.php
+++ b/Library/Utils.php
@@ -2,27 +2,25 @@
 
 /*
  +--------------------------------------------------------------------------+
- | Zephir Language                                                          |
- +--------------------------------------------------------------------------+
- | Copyright (c) 2013-2017 Zephir Team and contributors                     |
- +--------------------------------------------------------------------------+
- | This source file is subject the MIT license, that is bundled with        |
- | this package in the file LICENSE, and is available through the           |
- | world-wide-web at the following url:                                     |
- | http://zephir-lang.com/license.html                                      |
+ | Zephir                                                                   |
+ | Copyright (c) 2013-present Zephir (https://zephir-lang.com/)             |
  |                                                                          |
- | If you did not receive a copy of the MIT license and are unable          |
- | to obtain it through the world-wide-web, please send a note to           |
- | license@zephir-lang.com so we can mail you a copy immediately.           |
+ | This source file is subject the MIT license, that is bundled with this   |
+ | package in the file LICENSE, and is available through the world-wide-web |
+ | at the following url: http://zephir-lang.com/license.html                |
  +--------------------------------------------------------------------------+
-*/
+ */
 
 namespace Zephir;
 
+use Zephir\Exception\InvalidArgumentException;
+
 /**
- * Utils
+ * Zephir\Utils
  *
- * Utility functions
+ * Utility functions.
+ *
+ * @package Zephir
  */
 class Utils
 {
@@ -146,33 +144,31 @@ class Utils
     public static function getFullName($className, $currentNamespace, AliasManager $aliasManager = null)
     {
         if (!is_string($className)) {
-            throw new \InvalidArgumentException('Class name must be a string ' . print_r($className, true));
-        }
-
-        if ($className[0] !== '\\') {
-            // If class/interface name not begin with \ maybe a alias or a sub-namespace
-            $firstSepPos = strpos($className, '\\');
-            if (false !== $firstSepPos) {
-                $baseName = substr($className, 0, $firstSepPos);
-                if ($aliasManager->isAlias($baseName)) {
-                    return $aliasManager->getAlias($baseName) . '\\' . substr($className, $firstSepPos + 1);
-                }
-            } else {
-                if ($aliasManager->isAlias($className)) {
-                    return $aliasManager->getAlias($className);
-                }
-            }
-
-            // Relative class/interface name
-            if ($currentNamespace) {
-                return $currentNamespace . '\\' . $className;
-            } else {
-                return $className;
-            }
+            throw new InvalidArgumentException('Class name must be a string ' . print_r($className, true));
         }
 
         // Absolute class/interface name
-        return substr($className, 1);
+        if ($className[0] === '\\') {
+            return substr($className, 1);
+        }
+
+        // If class/interface name not begin with \ maybe a alias or a sub-namespace
+        $firstSepPos = strpos($className, '\\');
+        if (false !== $firstSepPos) {
+            $baseName = substr($className, 0, $firstSepPos);
+            if ($aliasManager && $aliasManager->isAlias($baseName)) {
+                return $aliasManager->getAlias($baseName) . '\\' . substr($className, $firstSepPos + 1);
+            }
+        } elseif ($aliasManager && $aliasManager->isAlias($className)) {
+            return $aliasManager->getAlias($className);
+        }
+
+        // Relative class/interface name
+        if ($currentNamespace) {
+            return $currentNamespace . '\\' . $className;
+        }
+
+        return $className;
     }
 
     /**

--- a/Library/Variable.php
+++ b/Library/Variable.php
@@ -2,20 +2,14 @@
 
 /*
  +--------------------------------------------------------------------------+
- | Zephir Language                                                          |
- +--------------------------------------------------------------------------+
- | Copyright (c) 2013-2017 Zephir Team and contributors                     |
- +--------------------------------------------------------------------------+
- | This source file is subject the MIT license, that is bundled with        |
- | this package in the file LICENSE, and is available through the           |
- | world-wide-web at the following url:                                     |
- | https://zephir-lang.com/license.html                                     |
+ | Zephir                                                                   |
+ | Copyright (c) 2013-present Zephir (https://zephir-lang.com/)             |
  |                                                                          |
- | If you did not receive a copy of the MIT license and are unable          |
- | to obtain it through the world-wide-web, please send a note to           |
- | license@zephir-lang.com so we can mail you a copy immediately.           |
+ | This source file is subject the MIT license, that is bundled with this   |
+ | package in the file LICENSE, and is available through the world-wide-web |
+ | at the following url: http://zephir-lang.com/license.html                |
  +--------------------------------------------------------------------------+
-*/
+ */
 
 namespace Zephir;
 
@@ -175,10 +169,11 @@ class Variable
      * @param string $type
      * @param string $name
      * @param Branch $branch
-     * @param mixed $defaultInitValue
+     * @param mixed $defaultInitValue The default init value [optional].
      */
     public function __construct($type, $name, $branch, $defaultInitValue = null)
     {
+
         $this->globalsManager = new Globals();
 
         switch ($type) {
@@ -192,6 +187,8 @@ class Variable
         $this->type = $type;
         $this->name = $name;
         $this->branch = $branch;
+
+        $this->setDefaultInitValue($defaultInitValue);
     }
 
     /**
@@ -690,11 +687,11 @@ class Variable
     /**
      * Set if the variable must be initialized to null
      *
-     * @param boolean $mustInitNull
+     * @param mixed $mustInitNull
      */
     public function setMustInitNull($mustInitNull)
     {
-        $this->mustInitNull = (boolean) $mustInitNull;
+        $this->mustInitNull = (bool) $mustInitNull;
     }
 
     /**

--- a/Library/Variable.php
+++ b/Library/Variable.php
@@ -13,8 +13,8 @@
 
 namespace Zephir;
 
-use Zephir\Compiler\CompilerException;
 use Zephir\Variable\Globals;
+use Zephir\Compiler\CompilerException;
 
 /**
  * Variable
@@ -33,7 +33,7 @@ class Variable
      * Current dynamic type of the variable
      * @var array
      */
-    protected $dynamicTypes = array('unknown' => true);
+    protected $dynamicTypes = ['unknown' => true];
 
     /**
      * Variable's name
@@ -169,11 +169,9 @@ class Variable
      * @param string $type
      * @param string $name
      * @param Branch $branch
-     * @param mixed $defaultInitValue The default init value [optional].
      */
-    public function __construct($type, $name, $branch, $defaultInitValue = null)
+    public function __construct($type, $name, $branch)
     {
-
         $this->globalsManager = new Globals();
 
         switch ($type) {
@@ -187,8 +185,6 @@ class Variable
         $this->type = $type;
         $this->name = $name;
         $this->branch = $branch;
-
-        $this->setDefaultInitValue($defaultInitValue);
     }
 
     /**
@@ -695,7 +691,7 @@ class Variable
     }
 
     /**
-     * Sets the default init value
+     * Sets the default init value.
      *
      * @param mixed $value
      */

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@
 #---------------------------------#
 
 # version format
-version: 0.10.1-{build}
+version: 0.10.2-{build}
 
 # branches to build
 branches:

--- a/kernels/ZendEngine3/operators.c
+++ b/kernels/ZendEngine3/operators.c
@@ -507,6 +507,16 @@ int zephir_bitwise_or_function(zval *result, zval *op1, zval *op2)
 }
 
 /**
+ * Do bitwise_xor function keeping ref_count and is_ref
+ */
+int zephir_bitwise_xor_function(zval *result, zval *op1, zval *op2)
+{
+	int status;
+	status = bitwise_xor_function(result, op1, op2);
+	return status;
+}
+
+/**
  * Check if a zval is less/equal than other
  */
 int zephir_less_equal(zval *op1, zval *op2)

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -31,4 +31,7 @@
         <ini name="display_errors" value="on"/>
         <ini name="display_startup_errors" value="on"/>
     </php>
+    <logging>
+        <log type="coverage-clover" target="clover.xml"/>
+    </logging>
 </phpunit>

--- a/test/bitwise.zep
+++ b/test/bitwise.zep
@@ -948,4 +948,20 @@ class Bitwise
 	{
 		return a & ~b;
 	}
+
+	protected function getInt(int num) -> int
+	{
+		return num;
+	}
+
+	/**
+	 * @issue 1581
+	 */
+	public function testbitwiseXor()
+	{
+		var i = this->getInt(123),
+			j = this->getInt(321);
+
+		return i ^ j;
+	}
 }

--- a/unit-tests/Extension/BitwiseTest.php
+++ b/unit-tests/Extension/BitwiseTest.php
@@ -128,5 +128,11 @@ class BitwiseTest extends \PHPUnit_Framework_TestCase
         // Bitwise NOT
         $this->assertSame($t->testBitwiseNot(666), -667);
         $this->assertSame($t->testBitwiseAndNot(5, 4), 1);
+
+        /**
+         * Bitwise XOR
+         * @issue 1581
+         */
+        $this->assertSame(123 ^ 321, $t->testbitwiseXor());
     }
 }


### PR DESCRIPTION
## Added
* Introduced `Zephir\Operators\Other\TypeHintOperator`

## Fixed
* Removed `$defaultValue` from the `Zephir\Variable` constructor as not used anymore
* Improved `Utils::getFullName` to prevent calling `AliasManager::isAlias` on possibly NULL value
* ZE3: Fixed #1581 by adding missed `zephir_bitwise_xor_function`