### PR TITLE
Fix some testing settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -42,3 +42,7 @@ end_of_line              = lf
 indent_style             = space
 trim_trailing_whitespace = false
 insert_final_newline     = true
+
+[*.yml]
+indent_size              = 2
+indent_style             = space

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ dist: trusty
 sudo: false
 
 php:
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
+  - '5.5'
+  - '5.6'
+  - '7.0'
+  - '7.1'
+  - '7.2'
 
 git:
   depth: 1
@@ -51,13 +51,13 @@ matrix:
       php: nightly
       compiler: clang
     - env: CPPFLAGS=-DZEPHIR_RELEASE CC=gcc
-      php: 7.1
+      php: '7.1'
     - env: CPPFLAGS=-DZEPHIR_RELEASE CC=clang
-      php: 7.1
+      php: '7.1'
     - env: CPPFLAGS=-DZEPHIR_RELEASE CC=gcc
-      php: 7.2
+      php: '7.2'
     - env: CPPFLAGS=-DZEPHIR_RELEASE CC=clang
-      php: 7.2
+      php: '7.2'
 
 cache:
   apt: true
@@ -77,11 +77,6 @@ before_install:
 
 install:
   - composer install --prefer-source --no-suggest
-  - |
-        if [ "${PHP_MAJOR}.${PHP_MINOR}" != "5.5" ]; then
-            composer remove --dev phpunit/phpunit
-            composer require -q -n --dev --no-progress --prefer-dist --no-suggest "phpunit/phpunit:5.7.*"
-        fi
   - bash ./unit-tests/ci/install-re2c $RE2C_VERSION
   - bash ./unit-tests/ci/install_zephir_parser.sh
   - ./install
@@ -91,7 +86,15 @@ before_script:
   - $(phpenv which php) compiler.php generate -Wnonexistent-function -Wnonexistent-class -Wunused-variable
   - $(phpenv which php) compiler.php stubs
   - $(phpenv which php) compiler.php api
-  - (cd ext; $(phpenv which phpize) && ./configure --silent --with-php-config=$(phpenv which php-config) --enable-test && make -j"$(getconf _NPROCESSORS_ONLN)" && make --silent install && phpenv config-add ../unit-tests/ci/test.ini)
+  - |
+    (
+      set -e
+      cd ext
+      $(phpenv which phpize)
+      ./configure --silent --with-php-config=$(phpenv which php-config) --enable-test
+      make -j"$(getconf _NPROCESSORS_ONLN)"
+      make --silent install
+    )
   #- ls -1 `$(phpenv which php-config) --extension-dir`
   #- phpenv versions
   - ulimit -c unlimited || true
@@ -100,9 +103,15 @@ before_script:
   #- sudo chmod +s $(which gdb)
 
 script:
-  - echo 'variables_order=EGPCS' >> "$(phpenv root)/versions/$(phpenv version-name)/etc/php.ini"
+  - echo -e 'variables_order=EGPCS\nenable_dl=true' >> "$(phpenv root)/versions/$(phpenv version-name)/etc/php.ini"
   - vendor/bin/phpcs --standard=PSR2 --report=emacs --extensions=php --warning-severity=0 Library/ unit-tests/Extension/ unit-tests/Zephir/
-  - |
+  - | # Tests and coverage
+      ./unit-tests/phpunit \
+        --not-exit \
+        -c phpunit.xml.dist \
+        --debug \
+        unit-tests/
+  - | # Check for memory leaks
       valgrind \
         --read-var-info=yes \
         --error-exitcode=1 \
@@ -114,7 +123,7 @@ script:
         ./unit-tests/phpunit \
           --not-exit \
           -c phpunit.xml.dist \
-          --debug \
+          --no-coverage \
           unit-tests/
   - $(phpenv which php) unit-tests/microbench.php
 

--- a/Library/Optimizers/FunctionCall/IsPhpVersionOptimizer.php
+++ b/Library/Optimizers/FunctionCall/IsPhpVersionOptimizer.php
@@ -59,7 +59,7 @@ class IsPhpVersionOptimizer extends OptimizerAbstract
             throw new CompilerException("This function requires a scalar types parameter, $variableType given", $expression);
         }
 
-        preg_match('/^(?<major>\d+)(?:\.(?<minor>!?\d+))?(?:\.(?<patch>!?\d+))?$/', $expression['parameters'][0]['parameter']['value'], $matches);
+        preg_match('/^(?<major>\d+)(?:\.(?<minor>!?\d+))?(?:\.(?<patch>!?\d+))?(?:[^Ee0-9.]+.*)?$/', $expression['parameters'][0]['parameter']['value'], $matches);
         if (!count($matches)) {
             throw new CompilerException("Could not parse PHP version", $expression);
         }

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "ext-pdo": "*",
         "ext-pdo_sqlite": "*",
         "squizlabs/php_codesniffer": "^3.2",
-        "phpunit/phpunit": "^4.8"
+        "phpunit/phpunit": "^4.8|^5.7"
     },
     "autoload": {
         "psr-4": {

--- a/unit-tests/Extension/ExitDieTest.php
+++ b/unit-tests/Extension/ExitDieTest.php
@@ -23,6 +23,8 @@ class ExitDieTest extends \PHPUnit_Framework_TestCase
             $phpBinary .= ' -qrr';
         }
 
+        $phpBinary .= " -d 'enable_dl=true'";
+
         $testfile1 = __DIR__ .'/fixtures/exit.php';
         $return1 = `$phpBinary $testfile1`;
         $this->assertSame('', trim($return1));

--- a/unit-tests/Extension/Issue1404Test.php
+++ b/unit-tests/Extension/Issue1404Test.php
@@ -15,6 +15,12 @@ namespace Extension;
 
 use \Test\Issue1404;
 
+if (version_compare(PHP_VERSION, '5.6', '<')) {
+    require_once('Issue1404TestTrait55.php');
+} else {
+    require_once('Issue1404TestTrait56.php');
+}
+
 /**
  * Tests for Zephir function is_php_version(id)
  *
@@ -25,6 +31,8 @@ use \Test\Issue1404;
  */
 class Issue1404Test extends \PHPUnit_Framework_TestCase
 {
+    use Issue1404TestTrait;
+
     const PHP_RELEASES_LIMIT = 17;
     const PHP_MINOR_LIMIT = 3;
 
@@ -38,13 +46,6 @@ class Issue1404Test extends \PHPUnit_Framework_TestCase
     public function tearDown()
     {
         $this->test = null;
-    }
-
-    protected function onNotSuccessfulTest(\Exception $error)
-    {
-        $phpVer = "PHP_VERSION_ID:" . PHP_VERSION_ID . " (".PHP_MAJOR_VERSION .'.'.PHP_MINOR_VERSION.'.'.PHP_RELEASE_VERSION.')';
-        fwrite(STDOUT, $phpVer . "\nError: $error");
-        throw $error;
     }
 
     public function phpVersionProvider()
@@ -111,7 +112,7 @@ class Issue1404Test extends \PHPUnit_Framework_TestCase
      */
     private function isPhpVersion($version)
     {
-        preg_match('/^(?<major>\d+)(?:\.(?<minor>!?\d+))?(?:\.(?<patch>!?\d+))?$/', $version, $matches);
+        preg_match('/^(?<major>\d+)(?:\.(?<minor>!?\d+))?(?:\.(?<patch>!?\d+))?(?:[^Ee0-9.]+.*)?$/', $version, $matches);
         if (!count($matches)) {
             throw new \Exception("Could not parse PHP version");
         }

--- a/unit-tests/Extension/Issue1404TestTrait55.php
+++ b/unit-tests/Extension/Issue1404TestTrait55.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------------+
+ | Zephir                                                                   |
+ | Copyright (c) 2013-present Zephir Team (https://zephir-lang.com/)        |
+ |                                                                          |
+ | This source file is subject the MIT license, that is bundled with this   |
+ | package in the file LICENSE, and is available through the world-wide-web |
+ | at the following url: http://zephir-lang.com/license.html                |
+ +--------------------------------------------------------------------------+
+*/
+
+namespace Extension;
+
+/**
+ * Test trait for Zephir function is_php_version(id)
+ *
+ * @package  Extension
+ * @author   DanHunsaker <danhunsaker@gmail.com>
+ * @license  MIT http://zephir-lang.com/license.html
+ * @link     https://github.com/phalcon/zephir/issues/1404
+ */
+trait Issue1404TestTrait
+{
+    protected function onNotSuccessfulTest(\Exception $error)
+    {
+        $phpVer = "PHP_VERSION_ID:" . PHP_VERSION_ID . " (".PHP_MAJOR_VERSION .'.'.PHP_MINOR_VERSION.'.'.PHP_RELEASE_VERSION.')';
+        fwrite(STDOUT, "{$phpVer}\nError: {$error}");
+        throw $error;
+    }
+}

--- a/unit-tests/Extension/Issue1404TestTrait56.php
+++ b/unit-tests/Extension/Issue1404TestTrait56.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------------+
+ | Zephir                                                                   |
+ | Copyright (c) 2013-present Zephir Team (https://zephir-lang.com/)        |
+ |                                                                          |
+ | This source file is subject the MIT license, that is bundled with this   |
+ | package in the file LICENSE, and is available through the world-wide-web |
+ | at the following url: http://zephir-lang.com/license.html                |
+ +--------------------------------------------------------------------------+
+*/
+
+namespace Extension;
+
+/**
+ * Test trait for Zephir function is_php_version(id)
+ *
+ * @package  Extension
+ * @author   DanHunsaker <danhunsaker@gmail.com>
+ * @license  MIT http://zephir-lang.com/license.html
+ * @link     https://github.com/phalcon/zephir/issues/1404
+ */
+trait Issue1404TestTrait
+{
+    protected function onNotSuccessfulTest($error)
+    {
+        $phpVer = "PHP_VERSION_ID:" . PHP_VERSION_ID . " (".PHP_MAJOR_VERSION .'.'.PHP_MINOR_VERSION.'.'.PHP_RELEASE_VERSION.')';
+        fwrite(STDOUT, "{$phpVer}\nError: {$error}");
+        throw $error;
+    }
+}

--- a/unit-tests/Extension/fixtures/exit.php
+++ b/unit-tests/Extension/fixtures/exit.php
@@ -1,4 +1,8 @@
 <?php
 // unit-tests/Extension/fixtures/exit.php
+if (!extension_loaded('test') && ini_get('enable_dl') == '1') {
+    $prefix = (PHP_SHLIB_SUFFIX === 'dll') ? 'php_' : '';
+    dl($prefix . 'test.' . PHP_SHLIB_SUFFIX);
+}
 $t = new \Test\ExitDie();
 $t->testExit();

--- a/unit-tests/Extension/fixtures/exit_int.php
+++ b/unit-tests/Extension/fixtures/exit_int.php
@@ -1,5 +1,9 @@
 <?php
 // unit-tests/Extension/fixtures/exit_int.php
+if (!extension_loaded('test') && ini_get('enable_dl') == '1') {
+    $prefix = (PHP_SHLIB_SUFFIX === 'dll') ? 'php_' : '';
+    dl($prefix . 'test.' . PHP_SHLIB_SUFFIX);
+}
 $argv = $_SERVER['argv'];
 if (isset($argv[1])) {
     $t = new \Test\ExitDie();

--- a/unit-tests/Extension/fixtures/exit_string.php
+++ b/unit-tests/Extension/fixtures/exit_string.php
@@ -1,5 +1,9 @@
 <?php
 // unit-tests/Extension/fixtures/exit_string.php
+if (!extension_loaded('test') && ini_get('enable_dl') == '1') {
+    $prefix = (PHP_SHLIB_SUFFIX === 'dll') ? 'php_' : '';
+    dl($prefix . 'test.' . PHP_SHLIB_SUFFIX);
+}
 $argv = $_SERVER['argv'];
 if (isset($argv[1])) {
     $t = new \Test\ExitDie();

--- a/unit-tests/bootstrap.php
+++ b/unit-tests/bootstrap.php
@@ -28,3 +28,10 @@ defined('ZEPHIRPATH') || define('ZEPHIRPATH', dirname(__DIR__) . DIRECTORY_SEPAR
 if (!extension_loaded('phalcon')) {
     include_once ZEPHIRPATH . 'prototypes/phalcon.php';
 }
+
+if (!extension_loaded('test') && ini_get('enable_dl') == '1') {
+    $prefix = (PHP_SHLIB_SUFFIX === 'dll') ? 'php_' : '';
+    dl($prefix . 'test.' . PHP_SHLIB_SUFFIX);
+} else {
+    exit('"test" extension not loaded; cannot run tests without it');
+}

--- a/unit-tests/ci/after_failure.sh
+++ b/unit-tests/ci/after_failure.sh
@@ -2,7 +2,7 @@
 
 shopt -s nullglob
 export LC_ALL=C
-for i in core core.*; do
+for i in core*; do
 	if [ -f "$i" -a "$(file "$i" | grep -o 'core file')" ]; then
 		gdb -q $(phpenv which php) "$i" <<EOF
 set pagination 0

--- a/unit-tests/microbench.php
+++ b/unit-tests/microbench.php
@@ -13,6 +13,13 @@
 
 require __DIR__ . '/../bootstrap.php';
 
+if (!extension_loaded('test') && ini_get('enable_dl') == '1') {
+    $prefix = (PHP_SHLIB_SUFFIX === 'dll') ? 'php_' : '';
+    dl($prefix . 'test.' . PHP_SHLIB_SUFFIX);
+} else {
+    exit('"test" extension not loaded; cannot run tests without it');
+}
+
 $total = 0;
 
 function start_test()


### PR DESCRIPTION
Make tests more portable, so they can be run on users' systems as easily as on CI services.

- Load `test` module dynamically if it isn't globally installed.
- Use `composer.json` to indicate that PHPUnit 5.7 is acceptable when 4.8 isn't required, and allow Composer to determine which is appropriate.
- Fix `Issue1404Test.php` to use a regex that allows the version string to include distro data, and silently ignore it.

Also improve the way Travis tests are run:

- Run tests without Valgrind to get detailed output and code coverage without risking timeouts, then with Valgrind but no code coverage or detailed output to get memory leak information as well.