### PR TITLE
Allow extension to be loaded prior to the tests

### DIFF
--- a/unit-tests/Extension/fixtures/exit.php
+++ b/unit-tests/Extension/fixtures/exit.php
@@ -1,8 +1,12 @@
 <?php
 // unit-tests/Extension/fixtures/exit.php
-if (!extension_loaded('test') && ini_get('enable_dl') == '1') {
-    $prefix = (PHP_SHLIB_SUFFIX === 'dll') ? 'php_' : '';
-    dl($prefix . 'test.' . PHP_SHLIB_SUFFIX);
+if (!extension_loaded('test')) {
+    if (ini_get('enable_dl') == '1') {
+        $prefix = (PHP_SHLIB_SUFFIX === 'dll') ? 'php_' : '';
+        dl($prefix . 'test.' . PHP_SHLIB_SUFFIX);
+    } else {
+        exit('"test" extension not loaded; cannot run tests without it');
+    }
 }
 $t = new \Test\ExitDie();
 $t->testExit();

--- a/unit-tests/Extension/fixtures/exit_int.php
+++ b/unit-tests/Extension/fixtures/exit_int.php
@@ -1,8 +1,12 @@
 <?php
 // unit-tests/Extension/fixtures/exit_int.php
-if (!extension_loaded('test') && ini_get('enable_dl') == '1') {
-    $prefix = (PHP_SHLIB_SUFFIX === 'dll') ? 'php_' : '';
-    dl($prefix . 'test.' . PHP_SHLIB_SUFFIX);
+if (!extension_loaded('test')) {
+    if (ini_get('enable_dl') == '1') {
+        $prefix = (PHP_SHLIB_SUFFIX === 'dll') ? 'php_' : '';
+        dl($prefix . 'test.' . PHP_SHLIB_SUFFIX);
+    } else {
+        exit('"test" extension not loaded; cannot run tests without it');
+    }
 }
 $argv = $_SERVER['argv'];
 if (isset($argv[1])) {

--- a/unit-tests/Extension/fixtures/exit_string.php
+++ b/unit-tests/Extension/fixtures/exit_string.php
@@ -1,8 +1,12 @@
 <?php
 // unit-tests/Extension/fixtures/exit_string.php
-if (!extension_loaded('test') && ini_get('enable_dl') == '1') {
-    $prefix = (PHP_SHLIB_SUFFIX === 'dll') ? 'php_' : '';
-    dl($prefix . 'test.' . PHP_SHLIB_SUFFIX);
+if (!extension_loaded('test')) {
+    if (ini_get('enable_dl') == '1') {
+        $prefix = (PHP_SHLIB_SUFFIX === 'dll') ? 'php_' : '';
+        dl($prefix . 'test.' . PHP_SHLIB_SUFFIX);
+    } else {
+        exit('"test" extension not loaded; cannot run tests without it');
+    }
 }
 $argv = $_SERVER['argv'];
 if (isset($argv[1])) {

--- a/unit-tests/bootstrap.php
+++ b/unit-tests/bootstrap.php
@@ -29,9 +29,11 @@ if (!extension_loaded('phalcon')) {
     include_once ZEPHIRPATH . 'prototypes/phalcon.php';
 }
 
-if (!extension_loaded('test') && ini_get('enable_dl') == '1') {
-    $prefix = (PHP_SHLIB_SUFFIX === 'dll') ? 'php_' : '';
-    dl($prefix . 'test.' . PHP_SHLIB_SUFFIX);
-} else {
-    exit('"test" extension not loaded; cannot run tests without it');
+if (!extension_loaded('test')) {
+    if (ini_get('enable_dl') == '1') {
+        $prefix = (PHP_SHLIB_SUFFIX === 'dll') ? 'php_' : '';
+        dl($prefix . 'test.' . PHP_SHLIB_SUFFIX);
+    } else {
+        exit('"test" extension not loaded; cannot run tests without it');
+    }
 }

--- a/unit-tests/microbench.php
+++ b/unit-tests/microbench.php
@@ -13,11 +13,13 @@
 
 require __DIR__ . '/../bootstrap.php';
 
-if (!extension_loaded('test') && ini_get('enable_dl') == '1') {
-    $prefix = (PHP_SHLIB_SUFFIX === 'dll') ? 'php_' : '';
-    dl($prefix . 'test.' . PHP_SHLIB_SUFFIX);
-} else {
-    exit('"test" extension not loaded; cannot run tests without it');
+if (!extension_loaded('test')) {
+    if (ini_get('enable_dl') == '1') {
+        $prefix = (PHP_SHLIB_SUFFIX === 'dll') ? 'php_' : '';
+        dl($prefix . 'test.' . PHP_SHLIB_SUFFIX);
+    } else {
+        exit('"test" extension not loaded; cannot run tests without it');
+    }
 }
 
 $total = 0;


### PR DESCRIPTION
If `extension=test` (or `extension=php_test.dll`) is in the `php.ini`, or otherwise loaded prior to the tests themselves, the tests should be satisfied with that and continue on running. Unfortunately, I flubbed the logic there, and made it so the extension _had_ to be loaded by the tests themselves, or not at all.

So, uh, let's fix that!