### PR TITLE
0.10.11

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -42,3 +42,7 @@ end_of_line              = lf
 indent_style             = space
 trim_trailing_whitespace = false
 insert_final_newline     = true
+
+[*.yml]
+indent_size              = 2
+indent_style             = space

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ dist: trusty
 sudo: false
 
 php:
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
+  - '5.5'
+  - '5.6'
+  - '7.0'
+  - '7.1'
+  - '7.2'
 
 git:
   depth: 1
@@ -51,13 +51,13 @@ matrix:
       php: nightly
       compiler: clang
     - env: CPPFLAGS=-DZEPHIR_RELEASE CC=gcc
-      php: 7.1
+      php: '7.1'
     - env: CPPFLAGS=-DZEPHIR_RELEASE CC=clang
-      php: 7.1
+      php: '7.1'
     - env: CPPFLAGS=-DZEPHIR_RELEASE CC=gcc
-      php: 7.2
+      php: '7.2'
     - env: CPPFLAGS=-DZEPHIR_RELEASE CC=clang
-      php: 7.2
+      php: '7.2'
 
 cache:
   apt: true
@@ -77,11 +77,6 @@ before_install:
 
 install:
   - composer install --prefer-source --no-suggest
-  - |
-        if [ "${PHP_MAJOR}.${PHP_MINOR}" != "5.5" ]; then
-            composer remove --dev phpunit/phpunit
-            composer require -q -n --dev --no-progress --prefer-dist --no-suggest "phpunit/phpunit:5.7.*"
-        fi
   - bash ./unit-tests/ci/install-re2c $RE2C_VERSION
   - bash ./unit-tests/ci/install_zephir_parser.sh
   - ./install
@@ -91,7 +86,15 @@ before_script:
   - $(phpenv which php) compiler.php generate -Wnonexistent-function -Wnonexistent-class -Wunused-variable
   - $(phpenv which php) compiler.php stubs
   - $(phpenv which php) compiler.php api
-  - (cd ext; $(phpenv which phpize) && ./configure --silent --with-php-config=$(phpenv which php-config) --enable-test && make -j"$(getconf _NPROCESSORS_ONLN)" && make --silent install && phpenv config-add ../unit-tests/ci/test.ini)
+  - |
+    (
+      set -e
+      cd ext
+      $(phpenv which phpize)
+      ./configure --silent --with-php-config=$(phpenv which php-config) --enable-test
+      make -j"$(getconf _NPROCESSORS_ONLN)"
+      make --silent install
+    )
   #- ls -1 `$(phpenv which php-config) --extension-dir`
   #- phpenv versions
   - ulimit -c unlimited || true
@@ -100,9 +103,15 @@ before_script:
   #- sudo chmod +s $(which gdb)
 
 script:
-  - echo 'variables_order=EGPCS' >> "$(phpenv root)/versions/$(phpenv version-name)/etc/php.ini"
+  - echo -e 'variables_order=EGPCS\nenable_dl=true' >> "$(phpenv root)/versions/$(phpenv version-name)/etc/php.ini"
   - vendor/bin/phpcs --standard=PSR2 --report=emacs --extensions=php --warning-severity=0 Library/ unit-tests/Extension/ unit-tests/Zephir/
-  - |
+  - | # Tests and coverage
+      ./unit-tests/phpunit \
+        --not-exit \
+        -c phpunit.xml.dist \
+        --debug \
+        unit-tests/
+  - | # Check for memory leaks
       valgrind \
         --read-var-info=yes \
         --error-exitcode=1 \
@@ -114,7 +123,7 @@ script:
         ./unit-tests/phpunit \
           --not-exit \
           -c phpunit.xml.dist \
-          --debug \
+          --no-coverage \
           unit-tests/
   - $(phpenv which php) unit-tests/microbench.php
 

--- a/Library/Compiler.php
+++ b/Library/Compiler.php
@@ -31,7 +31,7 @@ use Zephir\FileSystem\HardDisk as FileSystem;
  */
 class Compiler
 {
-    const VERSION = '0.10.10';
+    const VERSION = '0.10.11';
 
     public $parserCompiled = false;
 

--- a/Library/Optimizers/FunctionCall/IsPhpVersionOptimizer.php
+++ b/Library/Optimizers/FunctionCall/IsPhpVersionOptimizer.php
@@ -59,7 +59,7 @@ class IsPhpVersionOptimizer extends OptimizerAbstract
             throw new CompilerException("This function requires a scalar types parameter, $variableType given", $expression);
         }
 
-        preg_match('/^(?<major>\d+)(?:\.(?<minor>!?\d+))?(?:\.(?<patch>!?\d+))?$/', $expression['parameters'][0]['parameter']['value'], $matches);
+        preg_match('/^(?<major>\d+)(?:\.(?<minor>!?\d+))?(?:\.(?<patch>!?\d+))?(?:[^Ee0-9.]+.*)?$/', $expression['parameters'][0]['parameter']['value'], $matches);
         if (!count($matches)) {
             throw new CompilerException("Could not parse PHP version", $expression);
         }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.10.10-{build}
+version: 0.10.11-{build}
 
 environment:
     matrix:

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "ext-pdo": "*",
         "ext-pdo_sqlite": "*",
         "squizlabs/php_codesniffer": "^3.2",
-        "phpunit/phpunit": "^4.8"
+        "phpunit/phpunit": "^4.8|^5.7"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -7,43 +7,45 @@
         "phalcon",
         "internals"
     ],
-    "homepage": "https://zephir-lang.com/",
+    "homepage": "https://zephir-lang.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Zephir Team",
             "email": "team@zephir-lang.com",
-            "homepage": "https://zephir-lang.com/"
+            "homepage": "https://zephir-lang.com"
         },
         {
             "name": "Contributors",
             "homepage": "https://github.com/phalcon/zephir/graphs/contributors"
         }
     ],
-    "support": {
-        "issues": "https://github.com/phalcon/zephir/issues?state=open",
-        "source": "https://github.com/phalcon/zephir",
-        "forum": "https://forum.zephir-lang.com/",
-        "docs": "https://docs.zephir-lang.com/"
-    },
     "require": {
         "php": ">=5.5",
-        "ext-json": "*",
-        "ext-hash": "*",
         "ext-ctype": "*",
+        "ext-hash": "*",
+        "ext-json": "*",
         "ext-xml": "*"
     },
     "require-dev": {
         "ext-gmp": "*",
         "ext-pdo": "*",
         "ext-pdo_sqlite": "*",
-        "squizlabs/php_codesniffer": "^3.2",
-        "phpunit/phpunit": "^4.8|^5.7"
+        "phpunit/phpunit": "^4.8 || ^5.7",
+        "squizlabs/php_codesniffer": "^3.2"
     },
     "autoload": {
         "psr-4": {
             "Zephir\\": "Library"
         }
     },
-    "bin": ["bin/zephir"]
+    "bin": [
+        "bin/zephir"
+    ],
+    "support": {
+        "issues": "https://github.com/phalcon/zephir/issues?state=open",
+        "forum": "https://forum.zephir-lang.com",
+        "source": "https://github.com/phalcon/zephir",
+        "docs": "https://docs.zephir-lang.com"
+    }
 }

--- a/kernels/ZendEngine2/operators.c
+++ b/kernels/ZendEngine2/operators.c
@@ -441,13 +441,15 @@ void zephir_cast(zval *result, zval *var, zend_uint type){
 long zephir_get_intval_ex(const zval *op) {
 
 	switch (Z_TYPE_P(op)) {
-        case IS_ARRAY:
-            return zend_hash_num_elements(Z_ARRVAL_P(op)) ? 1 : 0;
+		case IS_ARRAY:
+			return zend_hash_num_elements(Z_ARRVAL_P(op)) ? 1 : 0;
 
-	    case IS_CALLABLE:
-	    case IS_RESOURCE:
-	    case IS_OBJECT:
-	        return 1;
+		case IS_RESOURCE:
+			return zval_get_long(op);
+
+		case IS_CALLABLE:
+		case IS_OBJECT:
+			return 1;
 
 		case IS_LONG:
 			return Z_LVAL_P(op);

--- a/kernels/ZendEngine2/operators.c
+++ b/kernels/ZendEngine2/operators.c
@@ -445,7 +445,7 @@ long zephir_get_intval_ex(const zval *op) {
 			return zend_hash_num_elements(Z_ARRVAL_P(op)) ? 1 : 0;
 
 		case IS_RESOURCE:
-			return zval_get_long(op);
+			return (zend_long)Z_RES_HANDLE_P(op);
 
 		case IS_CALLABLE:
 		case IS_OBJECT:

--- a/kernels/ZendEngine2/operators.c
+++ b/kernels/ZendEngine2/operators.c
@@ -445,8 +445,6 @@ long zephir_get_intval_ex(const zval *op) {
 			return zend_hash_num_elements(Z_ARRVAL_P(op)) ? 1 : 0;
 
 		case IS_RESOURCE:
-			return (zend_long)Z_RES_HANDLE_P(op);
-
 		case IS_CALLABLE:
 		case IS_OBJECT:
 			return 1;

--- a/kernels/ZendEngine3/object.c
+++ b/kernels/ZendEngine3/object.c
@@ -724,7 +724,14 @@ int zephir_update_property_array_append(zval *object, char *property, unsigned i
 			array_init(&tmp);
 			separated = 1;
 		}
-		Z_DELREF(tmp);
+
+		if (Z_REFCOUNTED(tmp)) {
+			if (Z_REFCOUNT(tmp) > 1) {
+				if (!Z_ISREF(tmp)) {
+					Z_DELREF(tmp);
+				}
+			}
+		}
 	}
 
 	Z_TRY_ADDREF_P(value);
@@ -732,6 +739,14 @@ int zephir_update_property_array_append(zval *object, char *property, unsigned i
 
 	if (separated) {
 		zephir_update_property_zval(object, property, property_length, &tmp);
+	}
+
+	if (Z_REFCOUNTED(tmp)) {
+		if (Z_REFCOUNT(tmp) > 1) {
+			if (!Z_ISREF(tmp)) {
+				Z_DELREF(tmp);
+			}
+		}
 	}
 
 	return SUCCESS;

--- a/kernels/ZendEngine3/operators.c
+++ b/kernels/ZendEngine3/operators.c
@@ -287,13 +287,15 @@ void zephir_convert_to_object(zval *op)
 long zephir_get_intval_ex(const zval *op)
 {
 	switch (Z_TYPE_P(op)) {
-        case IS_ARRAY:
-            return zend_hash_num_elements(Z_ARRVAL_P(op)) ? 1 : 0;
+		case IS_ARRAY:
+			return zend_hash_num_elements(Z_ARRVAL_P(op)) ? 1 : 0;
 
-	    case IS_CALLABLE:
-	    case IS_RESOURCE:
-	    case IS_OBJECT:
-	        return 1;
+		case IS_RESOURCE:
+			return zval_get_long(op);
+
+		case IS_CALLABLE:
+		case IS_OBJECT:
+			return 1;
 
 		case IS_LONG:
 			return Z_LVAL_P(op);

--- a/kernels/ZendEngine3/operators.c
+++ b/kernels/ZendEngine3/operators.c
@@ -291,7 +291,7 @@ long zephir_get_intval_ex(const zval *op)
 			return zend_hash_num_elements(Z_ARRVAL_P(op)) ? 1 : 0;
 
 		case IS_RESOURCE:
-			return zval_get_long(op);
+			return (zend_long)Z_RES_HANDLE_P(op);
 
 		case IS_CALLABLE:
 		case IS_OBJECT:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,35 +3,42 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd"
          backupGlobals="false"
-         backupStaticAttributes="false"
          bootstrap="./unit-tests/bootstrap.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
          verbose="true"
 >
+
     <testsuites>
         <testsuite name="Extension Test Suite">
-            <directory suffix=".php">./unit-tests/Extension/</directory>
+            <directory suffix=".php">./unit-tests/Extension</directory>
         </testsuite>
         <testsuite name="Zephir Test Suite">
-            <directory suffix=".php">./unit-tests/Zephir/</directory>
+            <directory suffix=".php">./unit-tests/Zephir</directory>
         </testsuite>
     </testsuites>
+
     <filter>
         <whitelist>
             <directory suffix=".php">./Library</directory>
         </whitelist>
     </filter>
+
     <php>
         <ini name="date.timezone" value="UTC"/>
         <ini name="display_errors" value="on"/>
         <ini name="display_startup_errors" value="on"/>
     </php>
+
     <logging>
-        <log type="coverage-clover" target="clover.xml"/>
+        <log
+            type="coverage-text"
+            target="php://stdout"
+            lowUpperBound="60"
+            highLowerBound="90"/>
+
+        <log
+            type="coverage-clover"
+            target="./unit-tests/output/clover.xml"/>
     </logging>
+
 </phpunit>

--- a/test/cast.zep
+++ b/test/cast.zep
@@ -289,4 +289,26 @@ class Cast
 	{
 		return (object) "test string";
 	}
+
+	public function testCastStdinToInteger()
+	{
+		var handle;
+		let handle = STDIN;
+
+		return (int) handle;
+	}
+
+	public function testCastStdoutToInteger()
+	{
+		return (int) STDOUT;
+	}
+
+	public function testCastFileResourceToInteger(var fileName)
+	{
+		var id;
+
+		let id = (int) fileName;
+
+		return id;
+	}
 }

--- a/unit-tests/Extension/CastTest.php
+++ b/unit-tests/Extension/CastTest.php
@@ -17,91 +17,113 @@ use Test\Cast;
 
 class CastTest extends \PHPUnit_Framework_TestCase
 {
+    private $test;
+
+    public function setUp()
+    {
+        $this->test = new Cast();
+    }
+
+    public function tearDown()
+    {
+        $this->test = null;
+    }
+
     public function testIntCast()
     {
-        $t = new Cast();
-
         /**
          * Value
          */
 
-        $this->assertSame(5, $t->testIntCastFromFloat());
-        $this->assertSame(1, $t->testIntCastFromBooleanTrue());
-        $this->assertSame(0, $t->testIntCastFromBooleanFalse());
-        $this->assertSame(0, $t->testIntCastFromNull());
-        $this->assertSame(0, $t->testIntCastFromStringValue());
-        $this->assertSame(0, $t->testIntCastFromEmptyArray());
-        $this->assertSame(1, $t->testIntCastFromArray());
-        $this->assertSame(1, $t->testIntCastFromStdClass());
+        $this->assertSame(5, $this->test->testIntCastFromFloat());
+        $this->assertSame(1, $this->test->testIntCastFromBooleanTrue());
+        $this->assertSame(0, $this->test->testIntCastFromBooleanFalse());
+        $this->assertSame(0, $this->test->testIntCastFromNull());
+        $this->assertSame(0, $this->test->testIntCastFromStringValue());
+        $this->assertSame(0, $this->test->testIntCastFromEmptyArray());
+        $this->assertSame(1, $this->test->testIntCastFromArray());
+        $this->assertSame(1, $this->test->testIntCastFromStdClass());
 
 
         /**
          * Variable types
          */
 
-        $this->assertSame(5, $t->testIntCastFromVariableFloat());
-        $this->assertSame(1, $t->testIntCastFromVariableBooleanTrue());
-        $this->assertSame(0, $t->testIntCastFromVariableBooleanFalse());
-        $this->assertSame(0, $t->testIntCastFromVariableNull());
+        $this->assertSame(5, $this->test->testIntCastFromVariableFloat());
+        $this->assertSame(1, $this->test->testIntCastFromVariableBooleanTrue());
+        $this->assertSame(0, $this->test->testIntCastFromVariableBooleanFalse());
+        $this->assertSame(0, $this->test->testIntCastFromVariableNull());
 
-        $this->assertSame(0, $t->testIntCastFromVariableString());
-        $this->assertSame((int) "test", $t->testIntCastFromParameterString("test"));
-        $this->assertSame((int) "1", $t->testIntCastFromParameterString("1"));
-        $this->assertSame((int) "12345", $t->testIntCastFromParameterString("12345"));
-        $this->assertSame((int) "-1", $t->testIntCastFromParameterString("-1"));
-        $this->assertSame((int) "+5", $t->testIntCastFromParameterString("+5"));
+        $this->assertSame(0, $this->test->testIntCastFromVariableString());
+        $this->assertSame((int) "test", $this->test->testIntCastFromParameterString("test"));
+        $this->assertSame((int) "1", $this->test->testIntCastFromParameterString("1"));
+        $this->assertSame((int) "12345", $this->test->testIntCastFromParameterString("12345"));
+        $this->assertSame((int) "-1", $this->test->testIntCastFromParameterString("-1"));
+        $this->assertSame((int) "+5", $this->test->testIntCastFromParameterString("+5"));
 
-        $this->assertSame(0, $t->testIntCastFromVariableEmptyArray());
-        $this->assertSame(1, $t->testIntCastFromVariableArray());
-        $this->assertSame(1, $t->testIntCastFromVariableStdClass());
+        $this->assertSame(0, $this->test->testIntCastFromVariableEmptyArray());
+        $this->assertSame(1, $this->test->testIntCastFromVariableArray());
+        $this->assertSame(1, $this->test->testIntCastFromVariableStdClass());
     }
 
     public function testFloatCast()
     {
-        $t = new Cast();
+        $this->assertSame($this->test->testFloatCastFromFloat(), 5.0);
+        $this->assertSame($this->test->testFloatCastFromBooleanTrue(), 1.0);
+        $this->assertSame($this->test->testFloatCastFromBooleanFalse(), 0.0);
+        $this->assertSame($this->test->testFloatCastFromNull(), 0.0);
+        $this->assertSame($this->test->testFloatCastFromEmptyArray(), 0.0);
+        $this->assertSame($this->test->testFloatCastFromArray(), 1.0);
+        $this->assertSame($this->test->testFloatCastFromStdClass(), 1.0);
 
-        $this->assertSame($t->testFloatCastFromFloat(), 5.0);
-        $this->assertSame($t->testFloatCastFromBooleanTrue(), 1.0);
-        $this->assertSame($t->testFloatCastFromBooleanFalse(), 0.0);
-        $this->assertSame($t->testFloatCastFromNull(), 0.0);
-        $this->assertSame($t->testFloatCastFromEmptyArray(), 0.0);
-        $this->assertSame($t->testFloatCastFromArray(), 1.0);
-        $this->assertSame($t->testFloatCastFromStdClass(), 1.0);
-
-        $this->assertSame($t->testFloatCastFromVariableFloat(), 5.0);
-        $this->assertSame($t->testFloatCastFromVariableBooleanTrue(), 1.0);
-        $this->assertSame($t->testFloatCastFromVariableBooleanFalse(), 0.0);
-        $this->assertSame($t->testFloatCastFromVariableNull(), 0.0);
-        $this->assertSame($t->testFloatCastFromVariableEmptyArray(), 0.0);
-        $this->assertSame($t->testFloatCastFromVariableArray(), 1.0);
-        $this->assertSame($t->testFloatCastFromVariableStdClass(), 1.0);
+        $this->assertSame($this->test->testFloatCastFromVariableFloat(), 5.0);
+        $this->assertSame($this->test->testFloatCastFromVariableBooleanTrue(), 1.0);
+        $this->assertSame($this->test->testFloatCastFromVariableBooleanFalse(), 0.0);
+        $this->assertSame($this->test->testFloatCastFromVariableNull(), 0.0);
+        $this->assertSame($this->test->testFloatCastFromVariableEmptyArray(), 0.0);
+        $this->assertSame($this->test->testFloatCastFromVariableArray(), 1.0);
+        $this->assertSame($this->test->testFloatCastFromVariableStdClass(), 1.0);
     }
 
     public function testBooleanCast()
     {
-        $t = new Cast();
-
-        $this->assertTrue($t->testBooleanCastFromIntTrue1());
-        $this->assertTrue($t->testBooleanCastFromIntTrue2());
-        $this->assertFalse($t->testBooleanCastFromIntFalse());
-        $this->assertTrue($t->testBooleanCastFromObject());
-        $this->assertFalse($t->testBooleanCastFromEmptyArray());
-        $this->assertTrue($t->testBooleanCastFromArray());
-        $this->assertFalse($t->testBooleanCastFromNull());
+        $this->assertTrue($this->test->testBooleanCastFromIntTrue1());
+        $this->assertTrue($this->test->testBooleanCastFromIntTrue2());
+        $this->assertFalse($this->test->testBooleanCastFromIntFalse());
+        $this->assertTrue($this->test->testBooleanCastFromObject());
+        $this->assertFalse($this->test->testBooleanCastFromEmptyArray());
+        $this->assertTrue($this->test->testBooleanCastFromArray());
+        $this->assertFalse($this->test->testBooleanCastFromNull());
     }
 
     public function testObjectCast()
     {
-        $t = new Cast();
+        $this->assertEquals((object) 5, $this->test->testObjectCastFromInt());
+        $this->assertEquals((object) 5.0, $this->test->testObjectCastFromFloat());
+        $this->assertEquals((object) false, $this->test->testObjectCastFromFalse());
+        $this->assertEquals((object) true, $this->test->testObjectCastFromTrue());
+        $this->assertEquals((object) null, $this->test->testObjectCastFromNull());
+        $this->assertEquals((object) array(), $this->test->testObjectCastFromEmptyArray());
+        $this->assertEquals((object) array(1, 2, 3, 4), $this->test->testObjectCastFromArray());
+        $this->assertEquals((object) "", $this->test->testObjectCastFromEmptyString());
+        $this->assertEquals((object) "test string", $this->test->testObjectCastFromString());
+    }
 
-        $this->assertEquals((object) 5, $t->testObjectCastFromInt());
-        $this->assertEquals((object) 5.0, $t->testObjectCastFromFloat());
-        $this->assertEquals((object) false, $t->testObjectCastFromFalse());
-        $this->assertEquals((object) true, $t->testObjectCastFromTrue());
-        $this->assertEquals((object) null, $t->testObjectCastFromNull());
-        $this->assertEquals((object) array(), $t->testObjectCastFromEmptyArray());
-        $this->assertEquals((object) array(1, 2, 3, 4), $t->testObjectCastFromArray());
-        $this->assertEquals((object) "", $t->testObjectCastFromEmptyString());
-        $this->assertEquals((object) "test string", $t->testObjectCastFromString());
+    /**
+     * Test cases for Issue 1524
+     * Casting Resource to Integer must always return int value of Resource Id
+     *
+     * @author Alexander Andriiako <AlexNDR@phalconphp.com>
+     * @return void
+     */
+    public function testResourceCast()
+    {
+        $file = fopen(__DIR__ . '/php/exists.php', 'r');
+
+        $this->assertEquals((int) STDIN, $this->test->testCastStdinToInteger());
+        $this->assertEquals((int) STDOUT, $this->test->testCastStdoutToInteger());
+        $this->assertEquals((int) $file, $this->test->testCastFileResourceToInteger($file));
+
+        fclose($file);
     }
 }

--- a/unit-tests/Extension/CastTest.php
+++ b/unit-tests/Extension/CastTest.php
@@ -34,7 +34,6 @@ class CastTest extends \PHPUnit_Framework_TestCase
         /**
          * Value
          */
-
         $this->assertSame(5, $this->test->testIntCastFromFloat());
         $this->assertSame(1, $this->test->testIntCastFromBooleanTrue());
         $this->assertSame(0, $this->test->testIntCastFromBooleanFalse());
@@ -44,11 +43,9 @@ class CastTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(1, $this->test->testIntCastFromArray());
         $this->assertSame(1, $this->test->testIntCastFromStdClass());
 
-
         /**
          * Variable types
          */
-
         $this->assertSame(5, $this->test->testIntCastFromVariableFloat());
         $this->assertSame(1, $this->test->testIntCastFromVariableBooleanTrue());
         $this->assertSame(0, $this->test->testIntCastFromVariableBooleanFalse());
@@ -118,6 +115,12 @@ class CastTest extends \PHPUnit_Framework_TestCase
      */
     public function testResourceCast()
     {
+        if (version_compare(PHP_VERSION, '7.0.0', '<')) {
+            $this->markTestSkipped(
+                "Cast Resource to integer not implemented for ZendEngine 2."
+            );
+        }
+
         $file = fopen(__DIR__ . '/php/exists.php', 'r');
 
         $this->assertEquals((int) STDIN, $this->test->testCastStdinToInteger());

--- a/unit-tests/Extension/ExitDieTest.php
+++ b/unit-tests/Extension/ExitDieTest.php
@@ -23,6 +23,8 @@ class ExitDieTest extends \PHPUnit_Framework_TestCase
             $phpBinary .= ' -qrr';
         }
 
+        $phpBinary .= " -d 'enable_dl=true'";
+
         $testfile1 = __DIR__ .'/fixtures/exit.php';
         $return1 = `$phpBinary $testfile1`;
         $this->assertSame('', trim($return1));

--- a/unit-tests/Extension/Issue1404Test.php
+++ b/unit-tests/Extension/Issue1404Test.php
@@ -15,6 +15,12 @@ namespace Extension;
 
 use \Test\Issue1404;
 
+if (version_compare(PHP_VERSION, '5.6', '<')) {
+    require_once('Issue1404TestTrait55.php');
+} else {
+    require_once('Issue1404TestTrait56.php');
+}
+
 /**
  * Tests for Zephir function is_php_version(id)
  *
@@ -25,6 +31,8 @@ use \Test\Issue1404;
  */
 class Issue1404Test extends \PHPUnit_Framework_TestCase
 {
+    use Issue1404TestTrait;
+
     const PHP_RELEASES_LIMIT = 17;
     const PHP_MINOR_LIMIT = 3;
 
@@ -38,13 +46,6 @@ class Issue1404Test extends \PHPUnit_Framework_TestCase
     public function tearDown()
     {
         $this->test = null;
-    }
-
-    protected function onNotSuccessfulTest(\Exception $error)
-    {
-        $phpVer = "PHP_VERSION_ID:" . PHP_VERSION_ID . " (".PHP_MAJOR_VERSION .'.'.PHP_MINOR_VERSION.'.'.PHP_RELEASE_VERSION.')';
-        fwrite(STDOUT, $phpVer . "\nError: $error");
-        throw $error;
     }
 
     public function phpVersionProvider()
@@ -111,7 +112,7 @@ class Issue1404Test extends \PHPUnit_Framework_TestCase
      */
     private function isPhpVersion($version)
     {
-        preg_match('/^(?<major>\d+)(?:\.(?<minor>!?\d+))?(?:\.(?<patch>!?\d+))?$/', $version, $matches);
+        preg_match('/^(?<major>\d+)(?:\.(?<minor>!?\d+))?(?:\.(?<patch>!?\d+))?(?:[^Ee0-9.]+.*)?$/', $version, $matches);
         if (!count($matches)) {
             throw new \Exception("Could not parse PHP version");
         }

--- a/unit-tests/Extension/Issue1404TestTrait55.php
+++ b/unit-tests/Extension/Issue1404TestTrait55.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------------+
+ | Zephir                                                                   |
+ | Copyright (c) 2013-present Zephir Team (https://zephir-lang.com/)        |
+ |                                                                          |
+ | This source file is subject the MIT license, that is bundled with this   |
+ | package in the file LICENSE, and is available through the world-wide-web |
+ | at the following url: http://zephir-lang.com/license.html                |
+ +--------------------------------------------------------------------------+
+*/
+
+namespace Extension;
+
+/**
+ * Test trait for Zephir function is_php_version(id)
+ *
+ * @package  Extension
+ * @author   DanHunsaker <danhunsaker@gmail.com>
+ * @license  MIT http://zephir-lang.com/license.html
+ * @link     https://github.com/phalcon/zephir/issues/1404
+ */
+trait Issue1404TestTrait
+{
+    protected function onNotSuccessfulTest(\Exception $error)
+    {
+        $phpVer = "PHP_VERSION_ID:" . PHP_VERSION_ID . " (".PHP_MAJOR_VERSION .'.'.PHP_MINOR_VERSION.'.'.PHP_RELEASE_VERSION.')';
+        fwrite(STDOUT, "{$phpVer}\nError: {$error}");
+        throw $error;
+    }
+}

--- a/unit-tests/Extension/Issue1404TestTrait56.php
+++ b/unit-tests/Extension/Issue1404TestTrait56.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------------+
+ | Zephir                                                                   |
+ | Copyright (c) 2013-present Zephir Team (https://zephir-lang.com/)        |
+ |                                                                          |
+ | This source file is subject the MIT license, that is bundled with this   |
+ | package in the file LICENSE, and is available through the world-wide-web |
+ | at the following url: http://zephir-lang.com/license.html                |
+ +--------------------------------------------------------------------------+
+*/
+
+namespace Extension;
+
+/**
+ * Test trait for Zephir function is_php_version(id)
+ *
+ * @package  Extension
+ * @author   DanHunsaker <danhunsaker@gmail.com>
+ * @license  MIT http://zephir-lang.com/license.html
+ * @link     https://github.com/phalcon/zephir/issues/1404
+ */
+trait Issue1404TestTrait
+{
+    protected function onNotSuccessfulTest($error)
+    {
+        $phpVer = "PHP_VERSION_ID:" . PHP_VERSION_ID . " (".PHP_MAJOR_VERSION .'.'.PHP_MINOR_VERSION.'.'.PHP_RELEASE_VERSION.')';
+        fwrite(STDOUT, "{$phpVer}\nError: {$error}");
+        throw $error;
+    }
+}

--- a/unit-tests/Extension/fixtures/exit.php
+++ b/unit-tests/Extension/fixtures/exit.php
@@ -1,4 +1,8 @@
 <?php
 // unit-tests/Extension/fixtures/exit.php
+if (!extension_loaded('test') && ini_get('enable_dl') == '1') {
+    $prefix = (PHP_SHLIB_SUFFIX === 'dll') ? 'php_' : '';
+    dl($prefix . 'test.' . PHP_SHLIB_SUFFIX);
+}
 $t = new \Test\ExitDie();
 $t->testExit();

--- a/unit-tests/Extension/fixtures/exit.php
+++ b/unit-tests/Extension/fixtures/exit.php
@@ -1,8 +1,12 @@
 <?php
 // unit-tests/Extension/fixtures/exit.php
-if (!extension_loaded('test') && ini_get('enable_dl') == '1') {
-    $prefix = (PHP_SHLIB_SUFFIX === 'dll') ? 'php_' : '';
-    dl($prefix . 'test.' . PHP_SHLIB_SUFFIX);
+if (!extension_loaded('test')) {
+    if (ini_get('enable_dl') == '1') {
+        $prefix = (PHP_SHLIB_SUFFIX === 'dll') ? 'php_' : '';
+        dl($prefix . 'test.' . PHP_SHLIB_SUFFIX);
+    } else {
+        exit('"test" extension not loaded; cannot run tests without it');
+    }
 }
 $t = new \Test\ExitDie();
 $t->testExit();

--- a/unit-tests/Extension/fixtures/exit_int.php
+++ b/unit-tests/Extension/fixtures/exit_int.php
@@ -1,5 +1,9 @@
 <?php
 // unit-tests/Extension/fixtures/exit_int.php
+if (!extension_loaded('test') && ini_get('enable_dl') == '1') {
+    $prefix = (PHP_SHLIB_SUFFIX === 'dll') ? 'php_' : '';
+    dl($prefix . 'test.' . PHP_SHLIB_SUFFIX);
+}
 $argv = $_SERVER['argv'];
 if (isset($argv[1])) {
     $t = new \Test\ExitDie();

--- a/unit-tests/Extension/fixtures/exit_int.php
+++ b/unit-tests/Extension/fixtures/exit_int.php
@@ -1,8 +1,12 @@
 <?php
 // unit-tests/Extension/fixtures/exit_int.php
-if (!extension_loaded('test') && ini_get('enable_dl') == '1') {
-    $prefix = (PHP_SHLIB_SUFFIX === 'dll') ? 'php_' : '';
-    dl($prefix . 'test.' . PHP_SHLIB_SUFFIX);
+if (!extension_loaded('test')) {
+    if (ini_get('enable_dl') == '1') {
+        $prefix = (PHP_SHLIB_SUFFIX === 'dll') ? 'php_' : '';
+        dl($prefix . 'test.' . PHP_SHLIB_SUFFIX);
+    } else {
+        exit('"test" extension not loaded; cannot run tests without it');
+    }
 }
 $argv = $_SERVER['argv'];
 if (isset($argv[1])) {

--- a/unit-tests/Extension/fixtures/exit_string.php
+++ b/unit-tests/Extension/fixtures/exit_string.php
@@ -1,5 +1,9 @@
 <?php
 // unit-tests/Extension/fixtures/exit_string.php
+if (!extension_loaded('test') && ini_get('enable_dl') == '1') {
+    $prefix = (PHP_SHLIB_SUFFIX === 'dll') ? 'php_' : '';
+    dl($prefix . 'test.' . PHP_SHLIB_SUFFIX);
+}
 $argv = $_SERVER['argv'];
 if (isset($argv[1])) {
     $t = new \Test\ExitDie();

--- a/unit-tests/Extension/fixtures/exit_string.php
+++ b/unit-tests/Extension/fixtures/exit_string.php
@@ -1,8 +1,12 @@
 <?php
 // unit-tests/Extension/fixtures/exit_string.php
-if (!extension_loaded('test') && ini_get('enable_dl') == '1') {
-    $prefix = (PHP_SHLIB_SUFFIX === 'dll') ? 'php_' : '';
-    dl($prefix . 'test.' . PHP_SHLIB_SUFFIX);
+if (!extension_loaded('test')) {
+    if (ini_get('enable_dl') == '1') {
+        $prefix = (PHP_SHLIB_SUFFIX === 'dll') ? 'php_' : '';
+        dl($prefix . 'test.' . PHP_SHLIB_SUFFIX);
+    } else {
+        exit('"test" extension not loaded; cannot run tests without it');
+    }
 }
 $argv = $_SERVER['argv'];
 if (isset($argv[1])) {

--- a/unit-tests/bootstrap.php
+++ b/unit-tests/bootstrap.php
@@ -29,9 +29,11 @@ if (!extension_loaded('phalcon')) {
     include_once ZEPHIRPATH . 'prototypes/phalcon.php';
 }
 
-if (!extension_loaded('test') && ini_get('enable_dl') == '1') {
-    $prefix = (PHP_SHLIB_SUFFIX === 'dll') ? 'php_' : '';
-    dl($prefix . 'test.' . PHP_SHLIB_SUFFIX);
-} else {
-    exit('"test" extension not loaded; cannot run tests without it');
+if (!extension_loaded('test')) {
+    if (ini_get('enable_dl') == '1') {
+        $prefix = (PHP_SHLIB_SUFFIX === 'dll') ? 'php_' : '';
+        dl($prefix . 'test.' . PHP_SHLIB_SUFFIX);
+    } else {
+        exit('"test" extension not loaded; cannot run tests without it');
+    }
 }

--- a/unit-tests/bootstrap.php
+++ b/unit-tests/bootstrap.php
@@ -28,3 +28,10 @@ defined('ZEPHIRPATH') || define('ZEPHIRPATH', dirname(__DIR__) . DIRECTORY_SEPAR
 if (!extension_loaded('phalcon')) {
     include_once ZEPHIRPATH . 'prototypes/phalcon.php';
 }
+
+if (!extension_loaded('test') && ini_get('enable_dl') == '1') {
+    $prefix = (PHP_SHLIB_SUFFIX === 'dll') ? 'php_' : '';
+    dl($prefix . 'test.' . PHP_SHLIB_SUFFIX);
+} else {
+    exit('"test" extension not loaded; cannot run tests without it');
+}

--- a/unit-tests/ci/after_failure.sh
+++ b/unit-tests/ci/after_failure.sh
@@ -2,7 +2,7 @@
 
 shopt -s nullglob
 export LC_ALL=C
-for i in core core.*; do
+for i in core*; do
 	if [ -f "$i" -a "$(file "$i" | grep -o 'core file')" ]; then
 		gdb -q $(phpenv which php) "$i" <<EOF
 set pagination 0

--- a/unit-tests/microbench.php
+++ b/unit-tests/microbench.php
@@ -13,11 +13,13 @@
 
 require __DIR__ . '/../bootstrap.php';
 
-if (!extension_loaded('test') && ini_get('enable_dl') == '1') {
-    $prefix = (PHP_SHLIB_SUFFIX === 'dll') ? 'php_' : '';
-    dl($prefix . 'test.' . PHP_SHLIB_SUFFIX);
-} else {
-    exit('"test" extension not loaded; cannot run tests without it');
+if (!extension_loaded('test')) {
+    if (ini_get('enable_dl') == '1') {
+        $prefix = (PHP_SHLIB_SUFFIX === 'dll') ? 'php_' : '';
+        dl($prefix . 'test.' . PHP_SHLIB_SUFFIX);
+    } else {
+        exit('"test" extension not loaded; cannot run tests without it');
+    }
 }
 
 $total = 0;

--- a/unit-tests/microbench.php
+++ b/unit-tests/microbench.php
@@ -13,6 +13,13 @@
 
 require __DIR__ . '/../bootstrap.php';
 
+if (!extension_loaded('test') && ini_get('enable_dl') == '1') {
+    $prefix = (PHP_SHLIB_SUFFIX === 'dll') ? 'php_' : '';
+    dl($prefix . 'test.' . PHP_SHLIB_SUFFIX);
+} else {
+    exit('"test" extension not loaded; cannot run tests without it');
+}
+
 $total = 0;
 
 function start_test()


### PR DESCRIPTION
#### Added 
- Implementing correct casting resource to int (#1524)
- Allow extension to be loaded prior to the tests

#### Fixed
- Fixed [Copy-On-Write](https://en.wikipedia.org/wiki/Copy-on-write) violation for arrays/objects zvals
- Fix some testing settings