### PR TITLE
Removed no longer used optimizers

### DIFF
--- a/Library/SymbolTable.php
+++ b/Library/SymbolTable.php
@@ -287,18 +287,6 @@ class SymbolTable
         if (!$variable->isTemporal() && !$variable->getSkipVariant()) {
             if ($name != 'return_value' && $name != 'this') {
                 if (is_object($compilationContext) && is_object($compilationContext->branchManager)) {
-                    if ($compilationContext->config->get('check-invalid-reads', 'optimizations')) {
-                        switch ($variable->getType()) {
-                            case 'variable':
-                            case 'string':
-                            case 'array':
-                                if (!$variable->isLocalOnly()) {
-                                    $variable->setMustInitNull(true);
-                                    $compilationContext->codePrinter->output('ZEPHIR_CHECK_POINTER(' . $variable->getName() . ');');
-                                }
-                                break;
-                        }
-                    }
 
                     $initBranches = $variable->getInitBranches();
 

--- a/kernels/ZendEngine2/main.h
+++ b/kernels/ZendEngine2/main.h
@@ -548,8 +548,6 @@ int zephir_fetch_parameters(int num_args TSRMLS_DC, int required_args, int optio
 #define ZEPHIR_DEBUG_PARAMS_DUMMY , "", 0
 #endif
 
-#define ZEPHIR_CHECK_POINTER(v) if (!v) fprintf(stderr, "%s:%d\n", __PRETTY_FUNCTION__, __LINE__);
-
 int zephir_is_php_version(unsigned int id);
 
 void zephir_get_args(zval* return_value TSRMLS_DC);

--- a/kernels/ZendEngine3/main.h
+++ b/kernels/ZendEngine3/main.h
@@ -304,8 +304,6 @@ int zephir_declare_class_constant_double(zend_class_entry *ce, const char *name,
 int zephir_declare_class_constant_stringl(zend_class_entry *ce, const char *name, size_t name_length, const char *value, size_t value_length);
 int zephir_declare_class_constant_string(zend_class_entry *ce, const char *name, size_t name_length, const char *value);
 
-#define ZEPHIR_CHECK_POINTER(v)
-
 int zephir_is_php_version(unsigned int id);
 
 /** Method declaration for API generation */


### PR DESCRIPTION
- The `check-invalid-reads` no longer used and it was removed (https://github.com/phalcon/zephir-docs/issues/74)