### PR TITLE
Fix about HT_ASSERT_RC1

### DIFF
--- a/kernels/ZendEngine3/fcall.c
+++ b/kernels/ZendEngine3/fcall.c
@@ -421,6 +421,8 @@ int zephir_call_user_function(zval *object_pp, zend_class_entry *obj_ce, zephir_
 	}
 	else if (FAILURE == status || EG(exception)) {
 		ZVAL_NULL(retval_ptr);
+	} else if (Z_TYPE_P(retval_ptr) == IS_ARRAY) {
+		SEPARATE_ARRAY(retval_ptr);
 	}
 
 	return status;

--- a/kernels/ZendEngine3/object.c
+++ b/kernels/ZendEngine3/object.c
@@ -572,8 +572,6 @@ int zephir_update_property_zval(zval *object, const char *property_name, unsigne
 
 	if (Z_TYPE_P(value) == IS_ARRAY) {
 		SEPARATE_ARRAY(value);
-	} else {
-		Z_TRY_ADDREF_P(value);
 	}
 
 	/* write_property will add 1 to refcount, so no Z_TRY_ADDREF_P(value); is necessary */


### PR DESCRIPTION
Hello!

* Type: bug fix

In raising this pull request, I confirm the following:

- [x] I have checked that another pull request for this purpose does not exist

Small description of change:

Thanks

Zephir code:
```zephir
namespace Mytest;

class HeroAttr
{
    public id;
	public my_buffs = [];
	
	public function __construct(int id) {
	    let this->id = id;
	}
	
	public function add_my_buff(var buff) {
	    let this->my_buffs[] = buff;
	}
	
	public function get_my_buffs() {
	    return this->my_buffs;
	}
	
}

class Fight
{
	public heros_attr = [];
	
	public function __construct(var ids) {
		var id;
		for id in ids {
			var heroAttr;
			let heroAttr = new HeroAttr(id);
			let this->heros_attr["P1"][] = heroAttr;
		}
	}
	
	public function get_fight_ret()
	{
		var p = "P1", key = 0;
		this->add_buff(p, key);
	}

	public function add_buff(var p, var key) {
		var attached_buffs;
		let attached_buffs = this->heros_attr[p][key]->get_my_buffs();  // Add refcount

		this->heros_attr[p][key]->add_my_buff(33);
	}
}
```
PHP code:
```php
$fight_obj = new Mytest\Fight([33, 44, 55]);
$ret = $fight_obj->get_fight_ret();
```
