### PR TITLE
fix incorrect usage of zend_declare_class_constant_ex

### DIFF
--- a/kernels/ZendEngine3/main.c
+++ b/kernels/ZendEngine3/main.c
@@ -406,20 +406,10 @@ int zephir_declare_class_constant(zend_class_entry *ce, const char *name, size_t
 {
 #if PHP_VERSION_ID >= 70100
 	int ret;
-	zend_string *key;
 
-	if (ce->type == ZEND_INTERNAL_CLASS) {
-		key = zend_string_init_interned(name, name_length, 1);
-	} else {
-		key = zend_string_init(name, name_length, 0);
-	}
-
+	zend_string *key = zend_string_init(name, name_length, ce->type & ZEND_INTERNAL_CLASS);
 	ret = zend_declare_class_constant_ex(ce, key, value, ZEND_ACC_PUBLIC, NULL);
-	
-	if (ce->type != ZEND_INTERNAL_CLASS) {
-		zend_string_release(key);
-	}
-
+	zend_string_release(key);
 	return ret;
 #else
 	if (Z_CONSTANT_P(value)) {

--- a/kernels/ZendEngine3/main.c
+++ b/kernels/ZendEngine3/main.c
@@ -404,7 +404,24 @@ zend_class_entry* zephir_get_internal_ce(const char *class_name, unsigned int cl
 /* Declare constants */
 int zephir_declare_class_constant(zend_class_entry *ce, const char *name, size_t name_length, zval *value)
 {
-#if PHP_VERSION_ID >= 70100
+#if PHP_VERSION_ID >= 70200
+	int ret;
+	zend_string *key;
+
+	if (ce->type == ZEND_INTERNAL_CLASS) {
+		key = zend_string_init_interned(name, name_length, 1);
+	} else {
+		key = zend_string_init(name, name_length, 0);
+	}
+
+	zend_declare_class_constant_ex(ce, key, value, ZEND_ACC_PUBLIC, NULL);
+
+	if (ce->type != ZEND_INTERNAL_CLASS) {
+		zend_string_release(key);
+	}
+
+	return ret;
+#elif PHP_VERSION_ID >= 70100
 	int ret;
 
 	zend_string *key = zend_string_init(name, name_length, ce->type & ZEND_INTERNAL_CLASS);

--- a/kernels/ZendEngine3/main.c
+++ b/kernels/ZendEngine3/main.c
@@ -406,10 +406,20 @@ int zephir_declare_class_constant(zend_class_entry *ce, const char *name, size_t
 {
 #if PHP_VERSION_ID >= 70100
 	int ret;
+	zend_string *key;
 
-	zend_string *key = zend_string_init(name, name_length, ce->type & ZEND_INTERNAL_CLASS);
+	if (ce->type == ZEND_INTERNAL_CLASS) {
+		key = zend_string_init_interned(name, name_length, 1);
+	} else {
+		key = zend_string_init(name, name_length, 0);
+	}
+
 	ret = zend_declare_class_constant_ex(ce, key, value, ZEND_ACC_PUBLIC, NULL);
-	zend_string_release(key);
+	
+	if (ce->type != ZEND_INTERNAL_CLASS) {
+		zend_string_release(key);
+	}
+
 	return ret;
 #else
 	if (Z_CONSTANT_P(value)) {


### PR DESCRIPTION
https://github.com/phalcon/cphalcon/issues/14160
https://bugs.php.net/bug.php?id=78121

Hello!

This fixes https://github.com/phalcon/cphalcon/issues/14160, author attribution is for @krakjoe in the commit.

I haven't touched the changelog yet as I'm not sure what the target version would be? Surely a bugfix release and not the next major version?

PR is editable.