### PR TITLE
fix phalcon/cphalcon#14160 incorrect usage of zend_declare_class_constant in 7.2+

### DIFF
--- a/ext/kernel/main.c
+++ b/ext/kernel/main.c
@@ -404,7 +404,24 @@ zend_class_entry* zephir_get_internal_ce(const char *class_name, unsigned int cl
 /* Declare constants */
 int zephir_declare_class_constant(zend_class_entry *ce, const char *name, size_t name_length, zval *value)
 {
-#if PHP_VERSION_ID >= 70100
+#if PHP_VERSION_ID >= 70200
+	int ret;
+	zend_string *key;
+
+	if (ce->type == ZEND_INTERNAL_CLASS) {
+		key = zend_string_init_interned(name, name_length, 1);
+	} else {
+		key = zend_string_init(name, name_length, 0);
+	}
+
+	zend_declare_class_constant_ex(ce, key, value, ZEND_ACC_PUBLIC, NULL);
+
+	if (ce->type != ZEND_INTERNAL_CLASS) {
+		zend_string_release(key);
+	}
+
+	return ret;
+#elif PHP_VERSION_ID >= 70100
 	int ret;
 
 	zend_string *key = zend_string_init(name, name_length, ce->type & ZEND_INTERNAL_CLASS);


### PR DESCRIPTION
see phalcon/cphalcon#14160