### PR TITLE
Fix #1885: Check return value before creating dynamic class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Fixed segfault when auto-loading class with syntax error
+  [#1885](https://github.com/phalcon/zephir/issues/1885)
 
 ## [0.12.0] - 2019-06-20
 ### Added

--- a/Library/Operators/Other/NewInstanceOperator.php
+++ b/Library/Operators/Other/NewInstanceOperator.php
@@ -135,6 +135,12 @@ class NewInstanceOperator extends BaseOperator
                     $classNameToFetch = 'Z_STRVAL_P('.$safeSymbol.'), Z_STRLEN_P('.$safeSymbol.')';
                     $zendClassEntry = $compilationContext->cacheManager->getClassEntryCache()->get($classNameToFetch, true, $compilationContext);
                     $classEntry = $zendClassEntry->getName();
+
+                    $compilationContext->codePrinter->output('if(!'.$classEntry.') {');
+                    $compilationContext->codePrinter->increaseLevel();
+                    $compilationContext->codePrinter->output('RETURN_MM_NULL();');
+                    $compilationContext->codePrinter->decreaseLevel();
+                    $compilationContext->codePrinter->output('}');
                 } else {
                     if (!class_exists($className, false)) {
                         $compilationContext->logger->warning(

--- a/test/operator.zep
+++ b/test/operator.zep
@@ -45,4 +45,10 @@ class Operator
 			varFalse !== var1
 	  	];
     }
+
+    public function testNewInstanceOperator(className)
+    {
+        return new {className}();
+    }
+
 }

--- a/unit-tests/Extension/NewInstanceOperatorTest.php
+++ b/unit-tests/Extension/NewInstanceOperatorTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Zephir.
+ *
+ * (c) Zephir Team <team@zephir-lang.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Extension;
+
+use PHPUnit\Framework\TestCase;
+
+class NewInstanceOperatorTest extends TestCase
+{
+
+    protected $autoloadMap = [
+        'Fixture\ParseErrorClass' => ZEPHIRPATH.'/unit-tests/fixtures/class-parse-error.php',
+        'Fixture\EmptyClass' => ZEPHIRPATH.'/unit-tests/fixtures/class-empty.php'
+    ];
+
+    public function setUp()
+    {
+        spl_autoload_register([$this, 'autoload']);
+    }
+
+    public function tearDown()
+    {
+        spl_autoload_unregister([$this, 'autoload']);
+    }
+
+    public function autoload($className)
+    {
+        if(isset($this->autoloadMap[$className])) {
+            include $this->autoloadMap[$className];
+        }
+    }
+
+    public function testThrowableException()
+    {
+        $this->expectException(\ParseError::class);
+
+        $t = new \Test\Operator();
+        $obj = $t->testNewInstanceOperator('Fixture\ParseErrorClass');
+    }
+
+    public function testNewInstance()
+    {
+        $t = new \Test\Operator();
+        $object = $t->testNewInstanceOperator('Fixture\EmptyClass');
+
+        $this->assertInstanceOf('Fixture\EmptyClass', $object);
+    }
+
+}

--- a/unit-tests/Extension/NewInstanceOperatorTest.php
+++ b/unit-tests/Extension/NewInstanceOperatorTest.php
@@ -15,7 +15,6 @@ use PHPUnit\Framework\TestCase;
 
 class NewInstanceOperatorTest extends TestCase
 {
-
     protected $autoloadMap = [
         'Fixture\ParseErrorClass' => ZEPHIRPATH.'/unit-tests/fixtures/class-parse-error.php',
         'Fixture\EmptyClass' => ZEPHIRPATH.'/unit-tests/fixtures/class-empty.php'
@@ -33,7 +32,7 @@ class NewInstanceOperatorTest extends TestCase
 
     public function autoload($className)
     {
-        if(isset($this->autoloadMap[$className])) {
+        if (isset($this->autoloadMap[$className])) {
             include $this->autoloadMap[$className];
         }
     }
@@ -53,5 +52,4 @@ class NewInstanceOperatorTest extends TestCase
 
         $this->assertInstanceOf('Fixture\EmptyClass', $object);
     }
-
 }

--- a/unit-tests/fixtures/class-empty.php
+++ b/unit-tests/fixtures/class-empty.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * This file is part of the Zephir.
+ *
+ * (c) Zephir Team <team@zephir-lang.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Fixture;
+
+class EmptyClass
+{
+
+}

--- a/unit-tests/fixtures/class-empty.php
+++ b/unit-tests/fixtures/class-empty.php
@@ -13,5 +13,4 @@ namespace Fixture;
 
 class EmptyClass
 {
-
 }

--- a/unit-tests/fixtures/class-parse-error.php
+++ b/unit-tests/fixtures/class-parse-error.php
@@ -13,13 +13,13 @@ namespace Fixture;
 
 class ParseErrorClass
 {
-
-    public function __construct() {
+    public function __construct()
+    {
 
     }
 
-    public function syntaxError() {
+    public function syntaxError()
+    {
         echo ';
     }
-
 }

--- a/unit-tests/fixtures/class-parse-error.php
+++ b/unit-tests/fixtures/class-parse-error.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * This file is part of the Zephir.
+ *
+ * (c) Zephir Team <team@zephir-lang.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Fixture;
+
+class ParseErrorClass
+{
+
+    public function __construct() {
+
+    }
+
+    public function syntaxError() {
+        echo ';
+    }
+
+}


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #1885

In raising this pull request, I confirm the following:

- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I updated the CHANGELOG

Small description of change:
Code to check the `$classEntry` value before calling the method `Zephir\BaseBackend::initObject()` inside of `Zephir\Operators\Other\NewInstanceOperator`.

Without this check, it's possible that `NULL` could be passed through and end up causing a segment fault. Happens when auto-loading a class with a syntax error.

Thanks
