### PR TITLE
Updated kernel require

### DIFF
--- a/.ci/travis.ini
+++ b/.ci/travis.ini
@@ -12,5 +12,4 @@ variables_order=EGPCS
 enable_dl=1
 
 ; See: https://github.com/phalcon/zephir/issues/1713
-allow_url_include=1
 allow_url_fopen=1

--- a/Library/CompilerFile.php
+++ b/Library/CompilerFile.php
@@ -973,7 +973,7 @@ final class CompilerFile implements FileInterface
         }
 
         if (\count($this->headerCBlocks) > 0) {
-            $code .= implode($this->headerCBlocks, PHP_EOL).PHP_EOL;
+            $code .= implode(PHP_EOL, $this->headerCBlocks).PHP_EOL;
         }
 
         /*

--- a/ext/kernel/require.c
+++ b/ext/kernel/require.c
@@ -45,13 +45,19 @@ int zephir_require_ret(zval *return_value_ptr, const char *require_path)
 	}
 #endif
 
-	file_handle.filename = require_path;
 #if PHP_VERSION_ID < 70400
+	file_handle.filename = require_path;
 	file_handle.free_filename = 0;
-#endif
 	file_handle.type = ZEND_HANDLE_FILENAME;
 	file_handle.opened_path = NULL;
 	file_handle.handle.fp = NULL;
+#else
+	ret = php_stream_open_for_zend_ex(require_path, &file_handle, USE_PATH|STREAM_OPEN_FOR_INCLUDE);
+
+	if (ret != SUCCESS) {
+		return FAILURE;
+	}
+#endif
 
 	new_op_array = zend_compile_file(&file_handle, ZEND_REQUIRE);
 	if (new_op_array) {

--- a/kernels/ZendEngine3/require.c
+++ b/kernels/ZendEngine3/require.c
@@ -45,13 +45,19 @@ int zephir_require_ret(zval *return_value_ptr, const char *require_path)
 	}
 #endif
 
-	file_handle.filename = require_path;
 #if PHP_VERSION_ID < 70400
+	file_handle.filename = require_path;
 	file_handle.free_filename = 0;
-#endif
 	file_handle.type = ZEND_HANDLE_FILENAME;
 	file_handle.opened_path = NULL;
 	file_handle.handle.fp = NULL;
+#else
+	ret = php_stream_open_for_zend_ex(require_path, &file_handle, USE_PATH|STREAM_OPEN_FOR_INCLUDE);
+
+	if (ret != SUCCESS) {
+		return FAILURE;
+	}
+#endif
 
 	new_op_array = zend_compile_file(&file_handle, ZEND_REQUIRE);
 	if (new_op_array) {

--- a/templates/Api/themes/zephir/partials/class/method-summary.phtml
+++ b/templates/Api/themes/zephir/partials/class/method-summary.phtml
@@ -7,7 +7,7 @@ $allTypes = [];
 $_lClasses = $method->getReturnClassTypes();
 
 foreach ($_lClasses as $c) {
-    if ($c{0} == "\\") {
+    if ('\\' == $c[0]) {
         $allTypes[] = substr($c,1);
     } else {
         $_lFullClassName = $classNamespace . "\\" . $c;

--- a/unit-tests/Extension/RequiresTest.php
+++ b/unit-tests/Extension/RequiresTest.php
@@ -36,12 +36,6 @@ class RequiresTest extends TestCase
      */
     public function shouldRequireUsingNewSymbolTable()
     {
-        if (\PHP_VERSION_ID >= 70400) {
-            $this->markTestSkipped(
-                'Does not ready for PHP >= 70400'
-            );
-        }
-
         $r = new Requires();
 
         $this->assertSame(
@@ -56,12 +50,6 @@ class RequiresTest extends TestCase
      */
     public function shouldRenderTemplate()
     {
-        if (\PHP_VERSION_ID >= 70400) {
-            $this->markTestSkipped(
-                'Does not ready for PHP >= 70400'
-            );
-        }
-
         $r = new Requires();
         $a = 1;
 


### PR DESCRIPTION
Hello!

* Type: bug fix | code quality

In raising this pull request, I confirm the following:

- [x] I have checked that another pull request for this purpose does not exist

Does `ob_clean` needs to be replaced with `ob_start`?

```zep
class External3
{
	protected someVariable;

	public function req(var path, var requires) -> void
	{
		ob_clean(); // <-- This postion
		require path;
		requires->setContent(ob_get_contents());
	}
}
```
