### PR TITLE
add static property reference test case

### DIFF
--- a/test/properties/staticpropertyreference.zep
+++ b/test/properties/staticpropertyreference.zep
@@ -1,0 +1,19 @@
+
+namespace Test\Properties;
+
+/**
+ * @link https://github.com/phalcon/zephir/issues/367
+ * @link https://github.com/phalcon/zephir/issues/188
+ */
+class StaticPropertyReference
+{
+	/**
+	 * This is a public property that will be referenced by variable
+	 */
+	public static reference;
+
+	public static function setValue(val)
+	{
+		let self::reference = val;
+	}
+}

--- a/unit-tests/Extension/Properties/StaticPropertyReferenceTest.php
+++ b/unit-tests/Extension/Properties/StaticPropertyReferenceTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Zephir.
+ *
+ * (c) Zephir Team <team@zephir-lang.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Extension\Properties;
+
+use PHPUnit\Framework\TestCase;
+
+class StaticPropertiyReferenceTest extends TestCase
+{
+    public function testAssertations()
+    {
+        $value = &\Test\Properties\StaticPropertyReference::$reference;
+
+        $value = 'test1';
+        $this->assertSame(\Test\Properties\StaticPropertyReference::$reference, $value);
+
+        \Test\Properties\StaticPropertyReference::$reference = 'test2';
+        $this->assertSame(\Test\Properties\StaticPropertyReference::$reference, $value);
+
+        \Test\Properties\StaticPropertyReference::setValue('test3');
+        $this->assertSame(\Test\Properties\StaticPropertyReference::$reference, $value);
+    }
+}


### PR DESCRIPTION
This test case is used to test static property reference of class. Currently, the version of php7.2 and below has not passed the test.