### PR TITLE
Fix typo in 'install' file

### DIFF
--- a/templates/ZendEngine3/install
+++ b/templates/ZendEngine3/install
@@ -39,7 +39,7 @@ ZEPHIR_LDFLAGS=""
 test -n "$CFLAGS" && ZEPHIR_CFLAGS="CFLAGS=\"$CFLAGS\""
 test -n "$LDFLAGS" && ZEPHIR_LDFLAGS="LDFLAGS=\"$LDFLAGS\""
 
-/configure --silent --enable-%PROJECT_LOWER% "$ZEPHIR_CFLAGS" "$ZEPHIR_LDFLAGS"
+./configure --silent --enable-%PROJECT_LOWER% "$ZEPHIR_CFLAGS" "$ZEPHIR_LDFLAGS"
 
 make -s
 $sudo make -s install


### PR DESCRIPTION
Hello!

* Type: documentation
* Link to issue:

In raising this pull request, I confirm the following:

- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I updated the CHANGELOG

Small description of the change:
Fix typo in the install file.

This commit will fix this issue: `./install: line 42: /configure: No such file or directory`

Thanks