### PR TITLE
Fixed IDE stubs generation

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -29,6 +29,7 @@ $finder = PhpCsFixer\Finder::create()
         'ext',
         'ide',
         'templates/ZendEngine3',
+        'unit-tests/fixtures/stubs/issue1922',
     ]);
 
 return PhpCsFixer\Config::create()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Do not regenerate C-code before stubs generation. Now users should explicitly
+  generate C-code if needed arises before stubs generation.
+
+### Fixed
+- Fixed IDE stubs generation to properly generate return type hint for `var | null`
+  [#1922](https://github.com/phalcon/zephir/issues/1922)
+
 ### Fixed
 ## [0.12.4] - 2019-09-22
 - Fixed install template

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-### Changed
-- Do not regenerate C-code before stubs generation. Now users should explicitly
-  generate C-code if needed arises before stubs generation.
-
 ### Fixed
 - Fixed IDE stubs generation to properly generate return type hint for `var | null`
   [#1922](https://github.com/phalcon/zephir/issues/1922)

--- a/Library/Compiler.php
+++ b/Library/Compiler.php
@@ -808,7 +808,7 @@ final class Compiler
         $this->fcallManager->genFcallCode();
 
         if ($this->config->get('stubs-run-after-generate', 'stubs')) {
-            $this->stubs();
+            $this->stubs($fromGenerate);
         }
 
         return $needConfigure;
@@ -951,13 +951,30 @@ final class Compiler
 
     /**
      * Generate IDE stubs.
+     *
+     * @param bool $fromGenerate
+     *
+     * @throws Exception
      */
-    public function stubs()
+    public function stubs(bool $fromGenerate = false)
     {
+        if (!$fromGenerate) {
+            $this->generate();
+        }
+
         $this->logger->info('Generating stubs...');
 
-        $stubsGenerator = new Stubs\Generator($this->files, $this->config);
-        $stubsGenerator->generate();
+        $stubsGenerator = new Stubs\Generator($this->files);
+
+        $path = $this->config->get('path', 'stubs');
+        $path = str_replace('%version%', $this->config->get('version'), $path);
+        $path = str_replace('%namespace%', ucfirst($this->config->get('namespace')), $path);
+
+        $stubsGenerator->generate(
+            $this->config->get('namespace'),
+            $path,
+            $this->config->get('indent', 'extra')
+        );
     }
 
     /**

--- a/Library/Compiler.php
+++ b/Library/Compiler.php
@@ -808,7 +808,7 @@ final class Compiler
         $this->fcallManager->genFcallCode();
 
         if ($this->config->get('stubs-run-after-generate', 'stubs')) {
-            $this->stubs($fromGenerate);
+            $this->stubs();
         }
 
         return $needConfigure;
@@ -951,25 +951,13 @@ final class Compiler
 
     /**
      * Generate IDE stubs.
-     *
-     * @param bool $fromGenerate
-     *
-     * @throws Exception
      */
-    public function stubs($fromGenerate = false)
+    public function stubs()
     {
-        if (!$fromGenerate) {
-            $this->generate();
-        }
-
         $this->logger->info('Generating stubs...');
+
         $stubsGenerator = new Stubs\Generator($this->files, $this->config);
-
-        $path = $this->config->get('path', 'stubs');
-        $path = str_replace('%version%', $this->config->get('version'), $path);
-        $path = str_replace('%namespace%', ucfirst($this->config->get('namespace')), $path);
-
-        $stubsGenerator->generate($path);
+        $stubsGenerator->generate();
     }
 
     /**

--- a/Library/Console/Command/GenerateCommand.php
+++ b/Library/Console/Command/GenerateCommand.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Zephir\Compiler;
 use Zephir\Exception;
-use Zephir\Exception\CompilerException;
+use Zephir\Exception\ExceptionInterface;
 use Zephir\Exception\InvalidArgumentException;
 
 /**
@@ -66,7 +66,7 @@ final class GenerateCommand extends Command
             );
 
             return 1;
-        } catch (CompilerException $e) {
+        } catch (ExceptionInterface $e) {
             $io->getErrorStyle()->error($e->getMessage());
 
             return 1;

--- a/Library/Console/Command/StubsCommand.php
+++ b/Library/Console/Command/StubsCommand.php
@@ -15,7 +15,9 @@ use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Zephir\Compiler;
+use Zephir\Exception\ExceptionInterface;
 
 /**
  * Zephir\Console\Command\StubsCommand.
@@ -46,8 +48,16 @@ final class StubsCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        // TODO: Move all the stuff from the compiler
-        $this->compiler->stubs();
+        $io = new SymfonyStyle($input, $output);
+
+        try {
+            // TODO: Move all the stuff from the compiler
+            $this->compiler->stubs();
+        } catch (ExceptionInterface $e) {
+            $io->getErrorStyle()->error($e->getMessage());
+
+            return 1;
+        }
 
         return 0;
     }

--- a/Library/Operators/Other/IssetOperator.php
+++ b/Library/Operators/Other/IssetOperator.php
@@ -152,8 +152,6 @@ class IssetOperator extends BaseOperator
                 break;
 
             case 'property-string-access':
-                return new CompiledExpression('bool', '(0 == 0)', $left);
-
             case 'static-property-access':
                 return new CompiledExpression('bool', '(0 == 0)', $left);
 

--- a/Library/Stubs/Generator.php
+++ b/Library/Stubs/Generator.php
@@ -16,7 +16,6 @@ use Zephir\ClassDefinition;
 use Zephir\ClassMethod;
 use Zephir\ClassProperty;
 use Zephir\CompilerFile;
-use Zephir\Config;
 use Zephir\Exception;
 
 /**
@@ -42,44 +41,31 @@ class Generator
     protected $files;
 
     /**
-     * @var Config
-     */
-    protected $config;
-
-    /**
      * @param CompilerFile[] $files
-     * @param Config         $config
      */
-    public function __construct(array $files, Config $config)
+    public function __construct(array $files)
     {
         $this->files = $files;
-        $this->config = $config;
     }
 
     /**
      * Generates stubs.
      *
+     * @param string $namespace
+     * @param string $path
+     * @param string $indent
+     *
      * @throws Exception\LogicException
      */
-    public function generate()
+    public function generate(string $namespace, string $path, string $indent)
     {
-        $path = $this->config->get('path', 'stubs');
         if (empty($path)) {
             throw new Exception\LogicException(
-                'The configuration parameter stubs.path is empty or not provided'
+                'The stubs path must not be empty.'
             );
         }
 
-        $path = str_replace('%version%', $this->config->get('version'), $path);
-        $path = str_replace('%namespace%', ucfirst($this->config->get('namespace')), $path);
-
-        if ('tabs' === $this->config->get('indent', 'extra')) {
-            $indent = "\t";
-        } else {
-            $indent = '    ';
-        }
-
-        $namespace = $this->config->get('namespace');
+        $indent = 'tabs' === $indent ? "\t" : '    ';
 
         foreach ($this->files as $file) {
             $class = $file->getClassDefinition();

--- a/Library/Stubs/Generator.php
+++ b/Library/Stubs/Generator.php
@@ -137,7 +137,10 @@ EOF;
             $extendsClassDefinition = $class->getExtendsClassDefinition();
             if (!$extendsClassDefinition) {
                 throw new Exception\RuntimeException(
-                    'Class "'.$class->getName().'" does not have a extendsClassDefinition'
+                    sprintf(
+                        'Class "%s" does not have a extendsClassDefinition',
+                        $class->getName()
+                    )
                 );
             }
 
@@ -410,8 +413,11 @@ EOF;
                 break;
 
             default:
-                throw new Exception\NotImplementedException(
-                    'Stubs - value with type: '.$parameter['default']['type'].' is not supported'
+                throw new Exception\LogicException(
+                    sprintf(
+                        'Stubs - value with type: %s is not supported',
+                        $parameter['default']['type']
+                    )
                 );
                 break;
         }

--- a/unit-tests/fixtures/devmode/.gitignore
+++ b/unit-tests/fixtures/devmode/.gitignore
@@ -1,0 +1,2 @@
+/.zephir
+/ext

--- a/unit-tests/fixtures/lifecycle/.gitignore
+++ b/unit-tests/fixtures/lifecycle/.gitignore
@@ -1,0 +1,2 @@
+/.zephir
+/ext

--- a/unit-tests/fixtures/protodir/.gitignore
+++ b/unit-tests/fixtures/protodir/.gitignore
@@ -1,0 +1,2 @@
+/.zephir
+/ext

--- a/unit-tests/fixtures/stubs/.gitignore
+++ b/unit-tests/fixtures/stubs/.gitignore
@@ -1,0 +1,3 @@
+/.zephir
+/ide
+/ext

--- a/unit-tests/fixtures/stubs/.gitignore
+++ b/unit-tests/fixtures/stubs/.gitignore
@@ -1,3 +1,3 @@
-/.zephir
-/ide
-/ext
+.zephir
+ide
+ext

--- a/unit-tests/fixtures/stubs/issue1922/config.json
+++ b/unit-tests/fixtures/stubs/issue1922/config.json
@@ -10,6 +10,6 @@
     },
     "stubs": {
         "path": "ide\/%version%\/%namespace%\/",
-        "stubs-run-after-generate": true
+        "stubs-run-after-generate": false
     }
 }

--- a/unit-tests/fixtures/stubs/issue1922/config.json
+++ b/unit-tests/fixtures/stubs/issue1922/config.json
@@ -1,0 +1,15 @@
+{
+    "namespace": "stubs",
+    "name": "stubs",
+    "description": "",
+    "author": "",
+    "version": "0.0.1",
+    "verbose": false,
+    "requires": {
+        "extensions": []
+    },
+    "stubs": {
+        "path": "ide\/%version%\/%namespace%\/",
+        "stubs-run-after-generate": true
+    }
+}

--- a/unit-tests/fixtures/stubs/issue1922/expected/Test.zep.php
+++ b/unit-tests/fixtures/stubs/issue1922/expected/Test.zep.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Stubs;
+
+
+class Test
+{
+
+    /**
+     * @param string $key
+     * @return mixed|null
+     */
+    public function getVar(string $key) {}
+
+}

--- a/unit-tests/fixtures/stubs/issue1922/stubs/test.zep
+++ b/unit-tests/fixtures/stubs/issue1922/stubs/test.zep
@@ -1,0 +1,9 @@
+namespace Stubs;
+
+class Test
+{
+    public function getVar(string! key) -> var | null
+    {
+        return null;
+    }
+}

--- a/unit-tests/sharness/t0005-stubs.sh
+++ b/unit-tests/sharness/t0005-stubs.sh
@@ -9,6 +9,7 @@ source ./setup.sh
 test_expect_success "Should fail when there are no required modules" "
   cd $FIXTURESDIR/stubs/issue1922 &&
   zephirc generate --no-ansi 2>&1 >/dev/null &&
+  zephirc stubs --no-ansi 2>&1 >/dev/null &&
   test_cmp expected/Test.zep.php ide/0.0.1/Stubs/Test.zep.php
 "
 

--- a/unit-tests/sharness/t0005-stubs.sh
+++ b/unit-tests/sharness/t0005-stubs.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC2034
+test_description="Test generate IDE stubs"
+
+source ./setup.sh
+
+# See: https://github.com/phalcon/zephir/issues/1922
+test_expect_success "Should fail when there are no required modules" "
+  cd $FIXTURESDIR/stubs/issue1922 &&
+  zephirc generate --no-ansi 2>&1 >/dev/null &&
+  test_cmp expected/Test.zep.php ide/0.0.1/Stubs/Test.zep.php
+"
+
+test_done


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #1922

In raising this pull request, I confirm the following:

- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I updated the CHANGELOG

Fixed IDE stubs generation to properly generate return type hint for `var | null`.

Thanks
