### PR TITLE
Fixed invalid ZEPHIR_METHOD_GLOBALS_PTR call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+## [0.12.6] - 2019-10-03
+### Fixed
+- Fixed regression introduced in `0.12.5` for those users who doesn't use
+  bundled `ext/json/php_json.h` [#1940](https://github.com/phalcon/zephir/issues/1940) 
+
 ## [0.12.5] - 2019-10-02
 ### Changed
 - Update `zend_update_static_property` to be compatible with PHP >= 7.3
@@ -242,7 +247,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed casting resource to int (only ZendEngine 3)
   [#1524](https://github.com/phalcon/zephir/issues/1524)
 
-[Unreleased]: https://github.com/phalcon/zephir/compare/0.12.5...HEAD
+[Unreleased]: https://github.com/phalcon/zephir/compare/0.12.6...HEAD
+[0.12.6]: https://github.com/phalcon/zephir/compare/0.12.5...0.12.6
 [0.12.5]: https://github.com/phalcon/zephir/compare/0.12.4...0.12.5
 [0.12.4]: https://github.com/phalcon/zephir/compare/0.12.3...0.12.4
 [0.12.3]: https://github.com/phalcon/zephir/compare/0.12.2...0.12.3

--- a/kernels/ZendEngine3/string.c
+++ b/kernels/ZendEngine3/string.c
@@ -402,10 +402,8 @@ static void zephir_append_printable_zval(smart_str *implstr, zval *tmp)
 
 void zephir_append_printable_array(smart_str *implstr, const zval *value)
 {
-
-	zval           *tmp;
-	zend_array     *arr;
-	unsigned int numelems, i = 0;
+	zend_array *arr;
+	unsigned int numelems;
 
 	arr = Z_ARRVAL_P(value);
 	numelems = zend_hash_num_elements(arr);
@@ -413,6 +411,8 @@ void zephir_append_printable_array(smart_str *implstr, const zval *value)
 	smart_str_appendc(implstr, '[');
 
 	if (numelems > 0) {
+		zval *tmp;
+		unsigned int i = 0;
 
 		ZEND_HASH_FOREACH_VAL(arr, tmp) {
 
@@ -1191,7 +1191,7 @@ int zephir_json_encode(zval *return_value, zval *v, int opts)
 	zval zopts;
 	zval *params[2];
 
-	ZEPHIR_INIT_VAR(&zopts);
+	ZEPHIR_NULL(&zopts);
 	ZVAL_LONG(&zopts, opts);
 
 	params[0] = v;
@@ -1205,7 +1205,7 @@ int zephir_json_decode(zval *return_value, zval *v, zend_bool assoc)
 	zval zassoc;
 	zval *params[2];
 
-	ZEPHIR_INIT_VAR(&zassoc);
+	ZEPHIR_NULL(&zassoc);
 	ZVAL_BOOL(&zassoc, assoc);
 
 	params[0] = v;
@@ -1222,10 +1222,9 @@ void zephir_md5(zval *return_value, zval *str)
 	unsigned char digest[16];
 	char hexdigest[33];
 	zval copy;
-	int use_copy = 0;
 
 	if (Z_TYPE_P(str) != IS_STRING) {
-		use_copy = zend_make_printable_zval(str, &copy);
+		int use_copy = zend_make_printable_zval(str, &copy);
 		if (use_copy) {
 			str = &copy;
 		}
@@ -1274,7 +1273,6 @@ void zephir_crc32(zval *return_value, zval *str)
 void zephir_ucfirst(zval *return_value, zval *s)
 {
 	zval copy;
-	char *c;
 	int use_copy = 0;
 
 	if (UNEXPECTED(Z_TYPE_P(s) != IS_STRING)) {
@@ -1286,8 +1284,8 @@ void zephir_ucfirst(zval *return_value, zval *s)
 
 	if (!Z_STRLEN_P(s)) {
 		ZVAL_EMPTY_STRING(return_value);
-	}
-	else {
+	} else {
+		char *c;
 		ZVAL_STRINGL(return_value, Z_STRVAL_P(s), Z_STRLEN_P(s));
 		c = Z_STRVAL_P(return_value);
 		*c = toupper((unsigned char)*c);
@@ -1407,7 +1405,7 @@ void zephir_string_to_hex(zval *return_value, zval *var)
 	res = zend_string_alloc(2*Z_STRLEN_P(var) + 1, 0);
 	s   = Z_STRVAL_P(var);
 	for (i=0; i<Z_STRLEN_P(var); ++i) {
-		sprintf(res->val + 2*i, "%hhX", s[i]);
+		sprintf(res->val + 2*i, "%hhX", (unsigned char) s[i]);
 	}
 
 	res->val[2*Z_STRLEN_P(var)] = 0;


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/zephir/issues/1940

In raising this pull request, I confirm the following:

- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I updated the CHANGELOG

Fixed invalid `zephir_json_encode` and `zephir_json_decode` call or those users who doesn't use
bundled `ext/json/php_json.h` 

Thanks
