### PR TITLE
Do not convert NULL and UNDEF to array

### DIFF
--- a/kernels/ZendEngine3/operators.h
+++ b/kernels/ZendEngine3/operators.h
@@ -222,6 +222,9 @@ long zephir_safe_mod_double_zval(double op1, zval *op2);
 	{ \
 		if (Z_TYPE_P(passValue) == IS_ARRAY) { \
 			ZEPHIR_CPY_WRT(returnValue, passValue); \
+		} else if (Z_ISNULL_P(passValue) || Z_ISUNDEF_P(passValue)) { \
+			ZEPHIR_INIT_NVAR(returnValue); \
+			array_init_size(returnValue, 0); \
 		} else { \
 			convert_to_array(passValue); \
 			ZEPHIR_CPY_WRT(returnValue, passValue); \


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/zephir/issues/1941
* Introduced: https://github.com/phalcon/zephir/commit/a6c9d0c9e4bad09920c8a6fe4e56815e76a1b85c

In raising this pull request, I confirm the following:

- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I updated the CHANGELOG

Converting `IS_UNDEF` to array leads to segmentation fault.

Thanks
