### PR TITLE
Disable regression changes

### DIFF
--- a/kernels/ZendEngine3/object.c
+++ b/kernels/ZendEngine3/object.c
@@ -1023,24 +1023,27 @@ int zephir_read_static_property_ce(zval *result, zend_class_entry *ce, const cha
 
 int zephir_update_static_property_ce(zend_class_entry *ce, const char *property_name, uint32_t property_length, zval *value)
 {
-#if PHP_VERSION_ID < 70300
-	zval *property, garbage;
-	property = zend_read_static_property(ce, property_name, property_length, (zend_bool)ZEND_FETCH_CLASS_SILENT);
-	if (property) {
-		if (Z_ISREF_P(property)) {
-			ZVAL_DEREF(property);
-		}
-		if (Z_ISREF_P(value)) {
-			ZVAL_DEREF(value);
-		}
-		ZVAL_COPY_VALUE(&garbage, property);
-		ZVAL_COPY(property, value);
-		zval_ptr_dtor(&garbage);
-		return 1;
-	}
-#else
-	zend_update_static_property(ce, property_name, property_length, value);
-#endif
+// Disabled due to:
+// https://github.com/phalcon/zephir/issues/1941#issuecomment-538654340
+//
+//#if PHP_VERSION_ID < 70300
+//	zval *property, garbage;
+//	property = zend_read_static_property(ce, property_name, property_length, (zend_bool)ZEND_FETCH_CLASS_SILENT);
+//	if (property) {
+//		if (Z_ISREF_P(property)) {
+//			ZVAL_DEREF(property);
+//		}
+//		if (Z_ISREF_P(value)) {
+//			ZVAL_DEREF(value);
+//		}
+//		ZVAL_COPY_VALUE(&garbage, property);
+//		ZVAL_COPY(property, value);
+//		zval_ptr_dtor(&garbage);
+//		return 1;
+//	}
+//#else
+	return zend_update_static_property(ce, property_name, property_length, value);
+//#endif
 }
 
 /*

--- a/unit-tests/Extension/Properties/StaticPublicPropertiesTest.php
+++ b/unit-tests/Extension/Properties/StaticPublicPropertiesTest.php
@@ -33,6 +33,8 @@ class StaticPublicPropertiesTest extends TestCase
         $this->assertSame(\Test\Properties\StaticPublicProperties::$someString, $value);
         \Test\Properties\StaticPublicProperties::$someString = 'test2';
         $this->assertSame(\Test\Properties\StaticPublicProperties::$someString, $value);
+        // Disabled due to:
+        // https://github.com/phalcon/zephir/issues/1941#issuecomment-538654340
         \Test\Properties\StaticPublicProperties::setSomeString('test3');
         $this->assertSame(\Test\Properties\StaticPublicProperties::$someString, $value);
     }

--- a/unit-tests/Extension/Properties/StaticPublicPropertiesTest.php
+++ b/unit-tests/Extension/Properties/StaticPublicPropertiesTest.php
@@ -35,7 +35,7 @@ class StaticPublicPropertiesTest extends TestCase
         $this->assertSame(\Test\Properties\StaticPublicProperties::$someString, $value);
         // Disabled due to:
         // https://github.com/phalcon/zephir/issues/1941#issuecomment-538654340
-        \Test\Properties\StaticPublicProperties::setSomeString('test3');
-        $this->assertSame(\Test\Properties\StaticPublicProperties::$someString, $value);
+        // \Test\Properties\StaticPublicProperties::setSomeString('test3');
+        // $this->assertSame(\Test\Properties\StaticPublicProperties::$someString, $value);
     }
 }


### PR DESCRIPTION
Changes introduced in the https://github.com/phalcon/zephir/commit/11dc1d4634b2d74599c53147b3733b829257c3a4 completely broke Phalcon just by one line PHP script:
```php
<?php
$di = new Phalcon\Di;
```

Refs:

- https://github.com/phalcon/zephir/issues/1904
- https://github.com/phalcon/zephir/issues/1941#issuecomment-538654340
- https://github.com/phalcon/zephir/commit/11dc1d4634b2d74599c53147b3733b829257c3a4

/cc @dreamsxin