### PR TITLE
Warn if timecop is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed IDE stubs generation for classes that extends base classes
   [#1907](https://github.com/phalcon/zephir/issues/1907)
 
+#### Changed
+- Added warning during the code generation if the timecop extension was detected
+  [#1950](https://github.com/phalcon/zephir/issues/1950)
+
 ### Removed
 - Removed no longer used `zephir_dtor` macro
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   [#1907](https://github.com/phalcon/zephir/issues/1907)
 
 #### Changed
-- Added warning during the code generation if the timecop extension was detected
+- Print warning during the code generation if the `timecop` extension was detected
   [#1950](https://github.com/phalcon/zephir/issues/1950)
 
 ### Removed

--- a/Library/Console/Command/GenerateCommand.php
+++ b/Library/Console/Command/GenerateCommand.php
@@ -52,6 +52,20 @@ final class GenerateCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
 
+        if (\extension_loaded('timecop') && 1 == ini_get('timecop.func_override')) {
+            $io->getErrorStyle()->warning(<<<MSG
+The timecop extension was detected. It is recommended to disable
+it from the launcher during the code generation to avoid potential
+issues.
+
+For more see:
+
+- https://github.com/phalcon/zephir/issues/1950
+- https://github.com/phalcon/cphalcon/issues/13117
+MSG
+            );
+        }
+
         try {
             // TODO: Move all the stuff from the compiler
             $this->compiler->generate(true);

--- a/ext/kernel/fcall.c
+++ b/ext/kernel/fcall.c
@@ -474,7 +474,7 @@ int zephir_call_zval_func_aparams(zval *return_value_ptr, zval *func_name,
 	status = zephir_call_user_function(NULL, NULL, zephir_fcall_function, func_name, rvp, cache_entry, cache_slot, param_count, params);
 
 	if (status == FAILURE && !EG(exception)) {
-		zephir_throw_exception_format(spl_ce_RuntimeException, "Call to undefined function %s()", Z_TYPE_P(func_name) ? Z_STRVAL_P(func_name) : "undefined");
+		zephir_throw_exception_format(spl_ce_RuntimeException, "Call to undefined function %s()", Z_TYPE_P(func_name) == IS_STRING ? Z_STRVAL_P(func_name) : "undefined");
 	} else if (EG(exception)) {
 		status = FAILURE;
 	}

--- a/ext/kernel/main.c
+++ b/ext/kernel/main.c
@@ -100,8 +100,7 @@ int zephir_get_global(zval *arr, const char *global, unsigned int global_length)
 		if ((gv = zend_hash_find_ind(&EG(symbol_table), str)) != NULL) {
 			ZVAL_DEREF(gv);
 			if (Z_TYPE_P(gv) == IS_ARRAY) {
-				ZVAL_DUP(arr, gv);
-				zend_hash_update(&EG(symbol_table), str, arr);
+				ZVAL_COPY_VALUE(arr, gv);
 				zend_string_release(str);
 				return SUCCESS;
 			}

--- a/ext/kernel/memory.c
+++ b/ext/kernel/memory.c
@@ -50,15 +50,13 @@ static zend_always_inline zend_execute_data* find_symbol_table(zend_execute_data
  */
 void ZEPHIR_FASTCALL zephir_memory_grow_stack(zephir_method_globals *g, const char *func)
 {
-	zephir_memory_entry *entry;
 	if (g->active_memory == NULL) {
 		zephir_memory_entry *active_memory;
-		size_t i;
 
 		active_memory = (zephir_memory_entry *) pecalloc(1, sizeof(zephir_memory_entry), 0);
 
-		active_memory->addresses       = pecalloc(24, sizeof(zval*), 0);
-		active_memory->capacity        = 24;
+		active_memory->addresses = pecalloc(24, sizeof(zval*), 0);
+		active_memory->capacity  = 24;
 
 		g->active_memory = active_memory;
 	}
@@ -74,7 +72,7 @@ void ZEPHIR_FASTCALL zephir_memory_grow_stack(zephir_method_globals *g, const ch
 void ZEPHIR_FASTCALL zephir_memory_restore_stack(zephir_method_globals *g, const char *func)
 {
 	size_t i;
-	zephir_memory_entry *prev, *active_memory;
+	zephir_memory_entry *active_memory;
 	zephir_symbol_table *active_symbol_table;
 	zval *ptr;
 #ifndef ZEPHIR_RELEASE
@@ -200,7 +198,6 @@ void zephir_initialize_memory(zend_zephir_globals_def *zephir_globals_ptr)
  */
 void zephir_deinitialize_memory()
 {
-	size_t i;
 	zend_zephir_globals_def *zephir_globals_ptr = ZEPHIR_VGLOBAL;
 
 	if (zephir_globals_ptr->initialized != 1) {

--- a/ext/kernel/object.c
+++ b/ext/kernel/object.c
@@ -1023,24 +1023,27 @@ int zephir_read_static_property_ce(zval *result, zend_class_entry *ce, const cha
 
 int zephir_update_static_property_ce(zend_class_entry *ce, const char *property_name, uint32_t property_length, zval *value)
 {
-#if PHP_VERSION_ID < 70300
-	zval *property, garbage;
-	property = zend_read_static_property(ce, property_name, property_length, (zend_bool)ZEND_FETCH_CLASS_SILENT);
-	if (property) {
-		if (Z_ISREF_P(property)) {
-			ZVAL_DEREF(property);
-		}
-		if (Z_ISREF_P(value)) {
-			ZVAL_DEREF(value);
-		}
-		ZVAL_COPY_VALUE(&garbage, property);
-		ZVAL_COPY(property, value);
-		zval_ptr_dtor(&garbage);
-		return 1;
-	}
-#else
-	zend_update_static_property(ce, property_name, property_length, value);
-#endif
+// Disabled due to:
+// https://github.com/phalcon/zephir/issues/1941#issuecomment-538654340
+//
+//#if PHP_VERSION_ID < 70300
+//	zval *property, garbage;
+//	property = zend_read_static_property(ce, property_name, property_length, (zend_bool)ZEND_FETCH_CLASS_SILENT);
+//	if (property) {
+//		if (Z_ISREF_P(property)) {
+//			ZVAL_DEREF(property);
+//		}
+//		if (Z_ISREF_P(value)) {
+//			ZVAL_DEREF(value);
+//		}
+//		ZVAL_COPY_VALUE(&garbage, property);
+//		ZVAL_COPY(property, value);
+//		zval_ptr_dtor(&garbage);
+//		return 1;
+//	}
+//#else
+	return zend_update_static_property(ce, property_name, property_length, value);
+//#endif
 }
 
 /*

--- a/ext/kernel/operators.h
+++ b/ext/kernel/operators.h
@@ -222,6 +222,9 @@ long zephir_safe_mod_double_zval(double op1, zval *op2);
 	{ \
 		if (Z_TYPE_P(passValue) == IS_ARRAY) { \
 			ZEPHIR_CPY_WRT(returnValue, passValue); \
+		} else if (Z_ISNULL_P(passValue) || Z_ISUNDEF_P(passValue)) { \
+			ZEPHIR_INIT_NVAR(returnValue); \
+			array_init_size(returnValue, 0); \
 		} else { \
 			convert_to_array(passValue); \
 			ZEPHIR_CPY_WRT(returnValue, passValue); \

--- a/ext/test/assign.zep.c
+++ b/ext/test/assign.zep.c
@@ -1063,6 +1063,7 @@ PHP_METHOD(Test_Assign, testPropertyArray1) {
 	ZVAL_LONG(&_1, 'A');
 	zephir_update_property_array_append(this_ptr, SL("myArray"), &_1);
 	ZEPHIR_INIT_ZVAL_NREF(_1);
+	ZEPHIR_INIT_VAR(&_1);
 	ZVAL_STRING(&_1, "hello");
 	zephir_update_property_array_append(this_ptr, SL("myArray"), &_1);
 	ZEPHIR_INIT_VAR(&_2);

--- a/ext/test/properties/propertyupdate.zep.c
+++ b/ext/test/properties/propertyupdate.zep.c
@@ -29,14 +29,18 @@ ZEPHIR_INIT_CLASS(Test_Properties_PropertyUpdate) {
 PHP_METHOD(Test_Properties_PropertyUpdate, update1) {
 
 	zval _0;
+	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
 	zval *this_ptr = getThis();
 
 	ZVAL_UNDEF(&_0);
 
+	ZEPHIR_MM_GROW();
 
 	ZEPHIR_INIT_ZVAL_NREF(_0);
+	ZEPHIR_INIT_VAR(&_0);
 	ZVAL_STRING(&_0, "aaa");
 	zephir_update_property_array_append(this_ptr, SL("p1"), &_0);
+	ZEPHIR_MM_RESTORE();
 
 }
 


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #1950

In raising this pull request, I confirm the following:

- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I updated the CHANGELOG

Print warning during the code generation if the `timecop` extension was detected.

Thanks
