### PR TITLE
Bugfix | 1495 regexp escape string

### DIFF
--- a/Library/Statements/Let/Variable.php
+++ b/Library/Statements/Let/Variable.php
@@ -11,6 +11,7 @@
 
 namespace Zephir\Statements\Let;
 
+use function Zephir\add_slashes;
 use Zephir\CodePrinter;
 use Zephir\CompilationContext;
 use Zephir\CompiledExpression;
@@ -1095,7 +1096,7 @@ class Variable
                     case 'assign':
                         $symbolVariable->initVariant($compilationContext);
                         $symbolVariable->setDynamicTypes('string');
-                        $compilationContext->backend->assignString($symbolVariable, $resolvedExpr->getCode(), $compilationContext);
+                        $compilationContext->backend->assignString($symbolVariable, add_slashes($resolvedExpr->getCode()), $compilationContext);
                         break;
 
                     case 'concat-assign':

--- a/unit-tests/Zephir/Test/Backends/ZendEngine3/BackendTest.php
+++ b/unit-tests/Zephir/Test/Backends/ZendEngine3/BackendTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Zephir.
+ *
+ * (c) Zephir Team <team@zephir-lang.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Zephir\Test\Backends\ZendEngine3;
+
+use PHPUnit\Framework\TestCase;
+use Zephir\Backends\ZendEngine3\Backend;
+use Zephir\CompilationContext;
+use Zephir\Config;
+use Zephir\Variable;
+
+class BackendTest extends TestCase
+{
+    public function stringDataProvider()
+    {
+        return [
+            'regexp1' => ['/(\w+)\s*=\s*(\[[^\]]*\]|\"[^\"]*\"|[^,)]*)\s*(?:,|$)/', '/(\\w+)\\s*=\\s*(\\[[^\\]]*\\]|\"[^\"]*\"|[^,)]*)\\s*(?:,|$)/'],
+            'regexp2' => ['/@(\w+)(?:\s*(?:\(\s*)?(.*?)(?:\s*\))?)??\s*(?:\n|\*\/)/', '/@(\\w+)(?:\\s*(?:\\(\\s*)?(.*?)(?:\\s*\\))?)??\\s*(?:\n|\\*\\/)/'],
+            'simple string' => ['zephir', 'zephir'],
+            'string with slashed' => ['\\Zephir', '\Zephir'],
+            'string with \n' => ['\\Zephir\n', '\Zephir\\n'],
+            'string with \null' => ['\\null', '\null'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider stringDataProvider
+     */
+    public function shouldEscapeStringWithRegexp(string $testString, string $expectedString)
+    {
+        $backend = new Backend(new Config(), null, null);
+        $variable = new Variable('variable', 'name');
+        $context = new CompilationContext();
+
+        $actual = $backend->assignString($variable, $testString, $context, false);
+        $expected = 'ZVAL_STRING(&name, "'.$expectedString.'");';
+
+        $this->assertSame($expected, $actual);
+    }
+}


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: [1495](https://github.com/phalcon/zephir/issues/1495)

In raising this pull request, I confirm the following:

- [X] I have checked that another pull request for this purpose does not exist
- [X] I wrote some tests for this PR
- [ ] I updated the CHANGELOG

- Added slashes for regex string when generate C-code
- Added tests

Thanks