### PR TITLE
Fix #1986 | Aliases in use statements for stubs generartion

### DIFF
--- a/Library/AliasManager.php
+++ b/Library/AliasManager.php
@@ -69,9 +69,9 @@ final class AliasManager
     }
 
     /**
-     * Returns Alias by Namespace.
+     * Returns alias by namespace.
      *
-     * @param string $namespace - FQN Class name
+     * @param string $namespace - fully qualified class name
      */
     public function getAliasForNamespace(string $namespace): string
     {
@@ -85,7 +85,7 @@ final class AliasManager
     }
 
     /**
-     * Check if Namespace use an Aliasing in use statement.
+     * Check if namespace use an aliasing in use statement.
      *
      * ex: use Events\ManagerInterface as EventsManagerInterface;
      *
@@ -93,7 +93,7 @@ final class AliasManager
      *
      * @return bool
      */
-    public function hasUseStatementAliased(string $alias): bool
+    public function isUseStatementAliased(string $alias): bool
     {
         if ($this->isAlias($alias)) {
             return $alias !== $this->implicitAlias($this->getAlias($alias));
@@ -103,9 +103,9 @@ final class AliasManager
     }
 
     /**
-     * Check if Namespace has explicit Alias in `use` declaration.
+     * Check if namespace has explicit alias in `use` declaration.
      *
-     * @param string $namespace - FQN Class name
+     * @param string $namespace - fully qualified class name
      *
      * @return bool
      */
@@ -119,7 +119,7 @@ final class AliasManager
     /**
      * Extract implicit alias from use statement.
      *
-     * @param string $namespace - FQN or simple Class name from use statement
+     * @param string $namespace - FQCN or simple class name from use statement
      *
      * @return string
      */

--- a/Library/AliasManager.php
+++ b/Library/AliasManager.php
@@ -75,7 +75,7 @@ final class AliasManager
      */
     public function getAliasForNamespace(string $namespace): string
     {
-        $keys = array_keys($this->aliases, $namespace);
+        $keys = array_keys($this->aliases, trim($namespace, '\\'));
 
         if (1 === \count($keys)) {
             return $keys[0];

--- a/Library/AliasManager.php
+++ b/Library/AliasManager.php
@@ -41,7 +41,7 @@ final class AliasManager
      *
      * @return bool
      */
-    public function isAlias($alias)
+    public function isAlias(string $alias): bool
     {
         return isset($this->aliases[$alias]);
     }
@@ -53,7 +53,7 @@ final class AliasManager
      *
      * @return string
      */
-    public function getAlias($alias)
+    public function getAlias(string $alias): bool
     {
         return $this->aliases[$alias];
     }
@@ -69,11 +69,12 @@ final class AliasManager
     }
 
     /**
-     * Check if Namespace use an Aliasing in use statement
+     * Check if Namespace use an Aliasing in use statement.
      *
      * ex: use Events\ManagerInterface as EventsManagerInterface;
      *
      * @param string $alias
+     *
      * @return bool
      */
     public function hasUseStatementAliased(string $alias): bool
@@ -86,7 +87,7 @@ final class AliasManager
     }
 
     /**
-     * Extract implicit alias from use statement
+     * Extract implicit alias from use statement.
      *
      * @param string $namespace - FQN or simple Class name from use statement
      *

--- a/Library/AliasManager.php
+++ b/Library/AliasManager.php
@@ -28,13 +28,9 @@ final class AliasManager
     public function add(array $useStatement)
     {
         foreach ($useStatement['aliases'] as $alias) {
-            if (isset($alias['alias'])) {
-                $this->aliases[$alias['alias']] = $alias['name'];
-            } else {
-                $parts = explode('\\', $alias['name']);
-                $implicitAlias = $parts[\count($parts) - 1];
-                $this->aliases[$implicitAlias] = $alias['name'];
-            }
+            $implicitAlias = $alias['alias'] ?? $this->implicitAlias($alias['name']);
+
+            $this->aliases[$implicitAlias] = $alias['name'];
         }
     }
 
@@ -70,5 +66,36 @@ final class AliasManager
     public function getAliases(): array
     {
         return $this->aliases;
+    }
+
+    /**
+     * Check if Implicit Alias declared as Alias
+     *
+     * ex: use Events\ManagerInterface as EventsManagerInterface;
+     * @param string $alias
+     */
+    public function hasImplicitAliasUsedAsAlias(string $alias): bool
+    {
+        if ($this->isAlias($alias)) {
+            $implicitAlias = $this->implicitAlias($this->aliases[$alias]);
+
+            return $this->getAlias($alias) === $implicitAlias;
+        }
+
+        return false;
+    }
+
+    /**
+     * Extract implicit alias from use statement
+     *
+     * @param string $useStatement - FQN or simple Class name from use statement
+     *
+     * @return string
+     */
+    private function implicitAlias(string $useStatement): string
+    {
+        $parts = explode('\\', $useStatement);
+
+        return $parts[\count($parts) - 1];
     }
 }

--- a/Library/AliasManager.php
+++ b/Library/AliasManager.php
@@ -53,7 +53,7 @@ final class AliasManager
      *
      * @return string
      */
-    public function getAlias(string $alias): bool
+    public function getAlias(string $alias): string
     {
         return $this->aliases[$alias];
     }

--- a/Library/AliasManager.php
+++ b/Library/AliasManager.php
@@ -69,6 +69,22 @@ final class AliasManager
     }
 
     /**
+     * Returns Alias by Namespace.
+     *
+     * @param string $namespace - FQN Class name
+     */
+    public function getAliasForNamespace(string $namespace): string
+    {
+        $keys = array_keys($this->aliases, $namespace);
+
+        if (1 === \count($keys)) {
+            return $keys[0];
+        }
+
+        return $namespace;
+    }
+
+    /**
      * Check if Namespace use an Aliasing in use statement.
      *
      * ex: use Events\ManagerInterface as EventsManagerInterface;
@@ -84,6 +100,20 @@ final class AliasManager
         }
 
         return false;
+    }
+
+    /**
+     * Check if Namespace has explicit Alias in `use` declaration.
+     *
+     * @param string $namespace - FQN Class name
+     *
+     * @return bool
+     */
+    public function isNamespaceAliased(string $namespace): bool
+    {
+        $extractAlias = $this->implicitAlias($namespace);
+
+        return !isset($this->aliases[$extractAlias]);
     }
 
     /**

--- a/Library/AliasManager.php
+++ b/Library/AliasManager.php
@@ -69,17 +69,17 @@ final class AliasManager
     }
 
     /**
-     * Check if Implicit Alias declared as Alias
+     * Check if Namespace use an Aliasing in use statement
      *
      * ex: use Events\ManagerInterface as EventsManagerInterface;
+     *
      * @param string $alias
+     * @return bool
      */
-    public function hasImplicitAliasUsedAsAlias(string $alias): bool
+    public function hasUseStatementAliased(string $alias): bool
     {
         if ($this->isAlias($alias)) {
-            $implicitAlias = $this->implicitAlias($this->aliases[$alias]);
-
-            return $this->getAlias($alias) === $implicitAlias;
+            return $alias !== $this->implicitAlias($this->getAlias($alias));
         }
 
         return false;
@@ -88,13 +88,13 @@ final class AliasManager
     /**
      * Extract implicit alias from use statement
      *
-     * @param string $useStatement - FQN or simple Class name from use statement
+     * @param string $namespace - FQN or simple Class name from use statement
      *
      * @return string
      */
-    private function implicitAlias(string $useStatement): string
+    private function implicitAlias(string $namespace): string
     {
-        $parts = explode('\\', $useStatement);
+        $parts = explode('\\', $namespace);
 
         return $parts[\count($parts) - 1];
     }

--- a/Library/Stubs/Generator.php
+++ b/Library/Stubs/Generator.php
@@ -156,7 +156,7 @@ class Generator
                 $interfaces[$key] = '\\'.trim($interface, '\\');
 
                 if ($aliasManager->isNamespaceAliased($interface)) {
-                    $interfaces[$key] = $aliasManager->getAliasForNamespace(trim($interface, '\\'));
+                    $interfaces[$key] = $aliasManager->getAliasForNamespace($interface);
                 }
             }
 

--- a/Library/Stubs/Generator.php
+++ b/Library/Stubs/Generator.php
@@ -112,7 +112,7 @@ class Generator
             $source .= PHP_EOL;
 
             foreach ($aliases as $alias => $fqn) {
-                $isAliased = $aliasManager->hasUseStatementAliased($alias);
+                $isAliased = $aliasManager->isUseStatementAliased($alias);
                 $asAlias = $isAliased ? ' as '.$alias : '';
                 $source .= 'use '.$fqn.$asAlias.';'.PHP_EOL;
             }

--- a/Library/Stubs/Generator.php
+++ b/Library/Stubs/Generator.php
@@ -104,12 +104,17 @@ class Generator
         $source = '<?php'.PHP_EOL.PHP_EOL;
         $source .= "namespace {$class->getNamespace()};".PHP_EOL;
 
-        $aliases = $class->getAliasManager()->getAliases();
+        /** @var Zephir\AliasManager $aliasManager */
+        $aliasManager = $class->getAliasManager();
+        $aliases = $aliasManager->getAliases();
+
         if (!empty($aliases)) {
             $source .= PHP_EOL;
 
             foreach ($aliases as $alias => $fqn) {
-                $source .= 'use '.$fqn.';'.PHP_EOL;
+                $isAliased = $aliasManager->hasUseStatementAliased($alias);
+                $asAlias = $isAliased ? ' as '.$alias : '';
+                $source .= 'use '.$fqn.$asAlias.';'.PHP_EOL;
             }
         }
 
@@ -140,16 +145,20 @@ class Generator
                 );
             }
 
-            $hasAliasForExtends = $class->getAliasManager()->isAlias($extendsClassDefinition->getShortName());
+            $hasAliasForExtends = $aliasManager->isAlias($extendsClassDefinition->getShortName());
 
             $source .= ' extends '.($hasAliasForExtends || $extendsClassDefinition->isBundled() ? '' : '\\');
             $source .= $hasAliasForExtends ? $extendsClassDefinition->getShortName() : $extendsClassDefinition->getCompleteName();
         }
 
-        if ($implementedInterfaces = $class->getImplementedInterfaces()) {
-            $interfaces = array_map(function ($val) {
-                return '\\'.trim($val, '\\');
-            }, $implementedInterfaces);
+        if ($interfaces = $class->getImplementedInterfaces()) {
+            foreach ($interfaces as $key => $interface) {
+                $interfaces[$key] = '\\'.trim($interface, '\\');
+
+                if ($aliasManager->isNamespaceAliased($interface)) {
+                    $interfaces[$key] = $aliasManager->getAliasForNamespace(trim($interface, '\\'));
+                }
+            }
 
             $keyword = 'interface' == $class->getType() ? ' extends ' : ' implements ';
             $source .= $keyword.implode(', ', $interfaces);

--- a/Library/Stubs/MethodDocBlock.php
+++ b/Library/Stubs/MethodDocBlock.php
@@ -202,7 +202,7 @@ class MethodDocBlock extends DocBlock
         if (!isset($this->predefinedParams['return'])) {
             list($type, $description) = $this->return;
 
-            $return = $type.' '.$description;
+            $return = $this->aliasManager->getAliasForNamespace($type).' '.$description;
             $this->lines[] = '@return '.trim($return, ' ');
         }
     }

--- a/unit-tests/Zephir/Test/AliasManagerTest.php
+++ b/unit-tests/Zephir/Test/AliasManagerTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Zephir.
+ *
+ * (c) Zephir Team <team@zephir-lang.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zephir\Test;
+
+use PHPUnit\Framework\TestCase;
+use Zephir\AliasManager;
+
+class AliasManagerTest extends TestCase
+{
+    /** @var \Zephir\AliasManager */
+    private $testAliasMgr;
+
+    public function setUp()
+    {
+        $this->testAliasMgr = new AliasManager();
+    }
+
+    public function aliasDataProvider(): array
+    {
+        return [
+            'with Alias' => [
+                // Actual
+                [
+                    'name' => 'Bug\\Events\\ManagerInterface',
+                    'alias' => 'EventsManagerInterface',
+                ],
+                // Expected
+                [
+                    'EventsManagerInterface' => 'Bug\\Events\\ManagerInterface',
+                ],
+            ],
+            'without Alias' => [
+                // Actual
+                [
+                    'name' => 'Throwable',
+                    'alias' => 'Throwable',
+                ],
+                // Expected
+                [
+                    'Throwable' => 'Throwable',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider aliasDataProvider
+     */
+    public function shouldProperAddStatements(array $useStatements, array $expected)
+    {
+        $this->testAliasMgr->add([
+            'aliases' => [$useStatements],
+        ]);
+
+        $alias = $useStatements['alias'];
+        $namespace = $useStatements['name'];
+
+        $this->assertTrue($this->testAliasMgr->isAlias($alias));
+        $this->assertSame($this->testAliasMgr->getAliases(), $expected);
+        $this->assertSame($this->testAliasMgr->getAlias($alias), $namespace);
+    }
+}

--- a/unit-tests/Zephir/Test/AliasManagerTest.php
+++ b/unit-tests/Zephir/Test/AliasManagerTest.php
@@ -80,4 +80,39 @@ class AliasManagerTest extends TestCase
         $this->assertSame($this->testAliasMgr->getAliases(), $expected);
         $this->assertSame($this->testAliasMgr->getAlias($alias), $namespace);
     }
+
+    public function statementDataProvider(): array
+    {
+        return [
+            'with aliased statement' => [
+                [
+                    'name' => 'Bug\\Events\\ManagerInterface',
+                    'alias' => 'EventsManagerInterface',
+                ], true,
+            ],
+            'without aliased statement' => [
+                [
+                    'name' => 'Bug\\Events\\ManagerInterface',
+                    'alias' => 'ManagerInterface',
+                ], false,
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider statementDataProvider
+     */
+    public function shouldCheckAliasedStatement(array $useStatements, bool $expected)
+    {
+        $this->testAliasMgr->add([
+            'aliases' => [$useStatements],
+        ]);
+
+        $alias = $useStatements['alias'];
+        $namespace = $useStatements['name'];
+
+        $this->assertSame($this->testAliasMgr->isUseStatementAliased($alias), $expected);
+        $this->assertSame($this->testAliasMgr->isNamespaceAliased($namespace), $expected);
+    }
 }

--- a/unit-tests/Zephir/Test/AliasManagerTest.php
+++ b/unit-tests/Zephir/Test/AliasManagerTest.php
@@ -27,7 +27,7 @@ class AliasManagerTest extends TestCase
     public function aliasDataProvider(): array
     {
         return [
-            'with Alias' => [
+            'with alias' => [
                 // Actual
                 [
                     'name' => 'Bug\\Events\\ManagerInterface',
@@ -38,7 +38,18 @@ class AliasManagerTest extends TestCase
                     'EventsManagerInterface' => 'Bug\\Events\\ManagerInterface',
                 ],
             ],
-            'without Alias' => [
+            'with alias and namespace from root' => [
+                // Actual
+                [
+                    'name' => '\\Bug\\Events\\ManagerInterface',
+                    'alias' => 'EventsManagerInterface',
+                ],
+                // Expected
+                [
+                    'EventsManagerInterface' => '\\Bug\\Events\\ManagerInterface',
+                ],
+            ],
+            'without explicit alias' => [
                 // Actual
                 [
                     'name' => 'Throwable',

--- a/unit-tests/Zephir/Test/Stubs/DocBlockTest.php
+++ b/unit-tests/Zephir/Test/Stubs/DocBlockTest.php
@@ -187,7 +187,7 @@ DOC;
         $doc = <<<DOC
     /**
      * Method with various tags
-     * @author Alexander Andriiako <AlexNDR@phalconphp.com>
+     * @author Zephir Team <noreply@zephir-lang.com>
      * @copyright (c) 2013-present Zephir Team (https://zephir-lang.com/)
      * @license MIT http://zephir-lang.com/license.html
      * @link https://github.com/phalcon/zephir
@@ -204,7 +204,7 @@ DOC;
     /**
      * Method with various tags
      *
-     * @author Alexander Andriiako <AlexNDR@phalconphp.com>
+     * @author Zephir Team <noreply@zephir-lang.com>
      * @copyright (c) 2013-present Zephir Team (https://zephir-lang.com/)
      * @license MIT http://zephir-lang.com/license.html
      * @link https://github.com/phalcon/zephir

--- a/unit-tests/fixtures/stubs/issues/expected/Issue_1986.zep.php
+++ b/unit-tests/fixtures/stubs/issues/expected/Issue_1986.zep.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Stubs;
+
+use Stubs\Events\ManagerInterface as EventsManagerInterface;
+
+class Issue_1986 implements EventsManagerInterface
+{
+
+    public $eventsManager;
+
+
+    /**
+     * @return EventsManagerInterface
+     */
+    public function getEventsManager(): EventsManagerInterface
+    {
+    }
+
+    /**
+     * Attach a listener to the events manager
+     *
+     * @param object|callable $handler
+     * @param string $eventType
+     */
+    public function attach(string $eventType, $handler)
+    {
+    }
+
+}

--- a/unit-tests/fixtures/stubs/issues/stubs/events/ManagerInterface.zep
+++ b/unit-tests/fixtures/stubs/issues/stubs/events/ManagerInterface.zep
@@ -1,0 +1,17 @@
+namespace Stubs\Events;
+
+/**
+ * Test Events Manager, offers an easy way to intercept and manipulate, if
+ * needed, the normal flow of operation. With the EventsManager the developer
+ * can create hooks or plugins that will offer monitoring of data, manipulation,
+ * conditional execution and much more.
+ */
+interface ManagerInterface
+{
+    /**
+    * Attach a listener to the events manager
+    *
+    * @param object|callable handler
+    */
+    public function attach(string! eventType, handler) -> void;
+}

--- a/unit-tests/fixtures/stubs/issues/stubs/issue_1986.zep
+++ b/unit-tests/fixtures/stubs/issues/stubs/issue_1986.zep
@@ -1,0 +1,22 @@
+namespace Stubs;
+
+use Stubs\Events\ManagerInterface as EventsManagerInterface;
+
+class Issue_1986 implements EventsManagerInterface
+{
+    public eventsManager;
+
+    public function getEventsManager() -> <EventsManagerInterface>
+    {
+        return this->eventsManager;
+    }
+
+    /**
+    * Attach a listener to the events manager
+    *
+    * @param object|callable handler
+    */
+    public function attach(string! eventType, handler) -> void
+    {
+    }
+}

--- a/unit-tests/sharness/t0005-stubs.sh
+++ b/unit-tests/sharness/t0005-stubs.sh
@@ -37,4 +37,12 @@ test_expect_success "Should properly generate Namespace for extends (slash)" "
   test_cmp expected/Issue_1907.zep.php ide/0.0.1/Stubs/Issue_1907.zep.php
 "
 
+# See: https://github.com/phalcon/zephir/issues/1986
+test_expect_success "Should properly generate Aliases for use statements" "
+  cd $FIXTURESDIR/stubs/issues &&
+  zephirc generate --no-ansi 2>&1 >/dev/null &&
+  zephirc stubs --no-ansi 2>&1 >/dev/null &&
+  test_cmp expected/Issue_1986.zep.php ide/0.0.1/Stubs/Issue_1986.zep.php
+"
+
 test_done


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #1986

In raising this pull request, I confirm the following:

- [X] I have checked that another pull request for this purpose does not exist
- [X] I wrote some tests for this PR
- [ ] I updated the CHANGELOG

Small description of change:

- fixed stub generation for aliases in use statement
- small code refactoring
- added sharness test
- added unit tests