### PR TITLE
Feature | Respect camelcase directory names for Stubs

### DIFF
--- a/Library/Stubs/Generator.php
+++ b/Library/Stubs/Generator.php
@@ -72,10 +72,10 @@ class Generator
             $source = $this->buildClass($class, $indent);
 
             $filename = ucfirst($class->getName()).'.zep.php';
-            $filePath = $path.str_replace(
+            $filePath = $path.str_ireplace(
                 $namespace,
                 '',
-                str_replace($namespace.'\\\\', \DIRECTORY_SEPARATOR, strtolower($class->getNamespace()))
+                str_replace($namespace.'\\\\', \DIRECTORY_SEPARATOR, $class->getNamespace())
             );
             $filePath = str_replace('\\', \DIRECTORY_SEPARATOR, $filePath);
             $filePath = str_replace(\DIRECTORY_SEPARATOR.\DIRECTORY_SEPARATOR, \DIRECTORY_SEPARATOR, $filePath);

--- a/unit-tests/sharness/t0005-stubs.sh
+++ b/unit-tests/sharness/t0005-stubs.sh
@@ -6,27 +6,35 @@ test_description="Test generate IDE stubs"
 # shellcheck disable=SC1091
 source ./setup.sh
 
+# shellcheck disable=SC2164,SC2069
+# Generate Stubs for test
+zephir_stubs() {
+  cd "$FIXTURESDIR"/stubs/issues
+  zephirc generate --no-ansi 2>&1 >/dev/null
+  zephirc stubs --no-ansi 2>&1 >/dev/null
+}
+
+# This test generates Stubs once and all other tests uses this build artifacts
+test_expect_success "Should generate Stubs" "
+  zephir_stubs &&
+  test -d ./ide/0.0.1/Stubs
+"
+
 # See: https://github.com/phalcon/zephir/issues/1922
 test_expect_success "Should properly generate type hint" "
   cd $FIXTURESDIR/stubs/issues &&
-  zephirc generate --no-ansi 2>&1 >/dev/null &&
-  zephirc stubs --no-ansi 2>&1 >/dev/null &&
   test_cmp expected/Issue_1922.zep.php ide/0.0.1/Stubs/Issue_1922.zep.php
 "
 
 # See: https://github.com/phalcon/zephir/issues/1778
 test_expect_success "Should properly namespace imports (use block)" "
   cd $FIXTURESDIR/stubs/issues &&
-  zephirc generate --no-ansi 2>&1 >/dev/null &&
-  zephirc stubs --no-ansi 2>&1 >/dev/null &&
   test_cmp expected/Issue_1778.zep.php ide/0.0.1/Stubs/Issue_1778.zep.php
 "
 
 # See: https://github.com/phalcon/zephir/issues/1900
 test_expect_success "Should properly generate return types for stubs" "
   cd $FIXTURESDIR/stubs/issues &&
-  zephirc generate --no-ansi 2>&1 >/dev/null &&
-  zephirc stubs --no-ansi 2>&1 >/dev/null &&
   test_cmp expected/Issue_1900.zep.php ide/0.0.1/Stubs/Issue_1900.zep.php
 "
 
@@ -41,17 +49,19 @@ test_expect_success "Should properly generate Namespace for extends" "
 # See: https://github.com/phalcon/zephir/issues/1907
 test_expect_success "Should properly generate Namespace for extends (slash)" "
   cd $FIXTURESDIR/stubs/issues &&
-  zephirc generate --no-ansi 2>&1 >/dev/null &&
-  zephirc stubs --no-ansi 2>&1 >/dev/null &&
   test_cmp expected/Issue_1907.zep.php ide/0.0.1/Stubs/Issue_1907.zep.php
 "
 
 # See: https://github.com/phalcon/zephir/issues/1986
 test_expect_success "Should properly generate Aliases for use statements" "
   cd $FIXTURESDIR/stubs/issues &&
-  zephirc generate --no-ansi 2>&1 >/dev/null &&
-  zephirc stubs --no-ansi 2>&1 >/dev/null &&
   test_cmp expected/Issue_1986.zep.php ide/0.0.1/Stubs/Issue_1986.zep.php
+"
+
+# See: https://github.com/phalcon/zephir/issues/1896
+test_expect_success "Should generage CamelCase folders for stubs" "
+  cd $FIXTURESDIR/stubs/issues &&
+  test $(ls ./ide/0.0.1/Stubs/Events/ManagerInterface.zep.php | sed -e 's~\/~\\~g') = .\ide\0.0.1\Stubs\Events\ManagerInterface.zep.php
 "
 
 test_done


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #1892

In raising this pull request, I confirm the following:

- [X] I have checked that another pull request for this purpose does not exist
- [X] I wrote some tests for this PR
- [ ] I updated the CHANGELOG

Small description of change:

- now directory names for Stubs can be CamelCase
- added sharness test
- speedup sharness tests for stubs

Thanks
