### PR TITLE
Bugfix | #2016 Fixed incorrect stubs generation for classes in the same namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Option to set banner for stubs [#1987](https://github.com/phalcon/zephir/1987)
-- Interface stubs have relative namespace [#2016](https://github.com/phalcon/zephir/2016)
 
 ## [0.12.11] - 2019-11-02
 ### Fixed
@@ -22,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   [#1986](https://github.com/phalcon/zephir/issues/1986)
 - Fixed incorrect namespace on type hinted return when generating API docs
   [#1229](https://github.com/phalcon/zephir/issues/1229)
+- Fixed incorrect stubs generation for classes in the same namespace
+  [#2016](https://github.com/phalcon/zephir/issues/2016)
 
 ## [0.12.10] - 2019-10-19
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Option to set banner for stubs [#1987](https://github.com/phalcon/zephir/1987)
+- Interface stubs have relative namespace [#2016](https://github.com/phalcon/zephir/2016)
 
 ## [0.12.11] - 2019-11-02
 ### Fixed

--- a/Library/AliasManager.php
+++ b/Library/AliasManager.php
@@ -113,7 +113,10 @@ final class AliasManager
     {
         $extractAlias = $this->implicitAlias($className);
 
-        return !isset($this->aliases[$extractAlias]);
+        $isClassDeclarated = \in_array($className, $this->aliases);
+        $classAlias = array_flip($this->aliases)[$className] ?? null;
+
+        return $isClassDeclarated && $classAlias !== $extractAlias;
     }
 
     /**

--- a/unit-tests/Zephir/Test/AliasManagerTest.php
+++ b/unit-tests/Zephir/Test/AliasManagerTest.php
@@ -182,6 +182,9 @@ class AliasManagerTest extends TestCase
                     'name' => 'AnotherClass',
                     'alias' => 'AnotherClass',
                 ],
+                [
+                    'name' => 'Bug\\Storage\\FileSystem',
+                ],
             ],
         ]);
 
@@ -189,5 +192,6 @@ class AliasManagerTest extends TestCase
         $this->assertFalse($this->testAliasMgr->isAliasPresentFor('\\Root\SomeNamespace\\SomeClassName'));
         $this->assertFalse($this->testAliasMgr->isAliasPresentFor('AnotherClass'));
         $this->assertFalse($this->testAliasMgr->isAliasPresentFor('NonExistingClass'));
+        $this->assertFalse($this->testAliasMgr->isAliasPresentFor('Bug\\Storage\\FileSystem'));
     }
 }

--- a/unit-tests/Zephir/Test/AliasManagerTest.php
+++ b/unit-tests/Zephir/Test/AliasManagerTest.php
@@ -54,16 +54,21 @@ class AliasManagerTest extends TestCase
             ],
             'without explicit alias' => [
                 [
-                    'name' => 'Throwable',
-                    'alias' => 'Throwable',
+                    'name' => '\\Throwable',
+                ],
+            ],
+            'without explicit alias and FQN' => [
+                [
+                    'name' => 'Zephir\\Compiler\\CompilerInterface',
                 ],
             ],
         ];
     }
 
-    public function aliasDataProvider(): array
+    public function aliasProvider(): array
     {
         $expected = [
+            //   [ alias => name ]
             [
                 'EventsManagerInterface' => 'Bug\\Events\\ManagerInterface',
             ],
@@ -71,7 +76,10 @@ class AliasManagerTest extends TestCase
                 'EventsManagerInterface' => '\\Bug\\Events\\ManagerInterface',
             ],
             [
-                'Throwable' => 'Throwable',
+                'Throwable' => '\Throwable',
+            ],
+            [
+                'CompilerInterface' => 'Zephir\\Compiler\\CompilerInterface',
             ],
         ];
 
@@ -80,7 +88,7 @@ class AliasManagerTest extends TestCase
 
     /**
      * @test
-     * @dataProvider aliasDataProvider
+     * @dataProvider aliasProvider
      */
     public function shouldProperAddStatements(array $useStatements, array $expected)
     {
@@ -88,18 +96,20 @@ class AliasManagerTest extends TestCase
             'aliases' => [$useStatements],
         ]);
 
-        $alias = $useStatements['alias'];
         $className = $useStatements['name'];
 
+        $parts = explode('\\', $className);
+        $alias = $useStatements['alias'] ?? $parts[\count($parts) - 1];
+
         $this->assertTrue($this->testAliasMgr->isAlias($alias));
-        $this->assertSame($this->testAliasMgr->getAliases(), $expected);
-        $this->assertSame($this->testAliasMgr->getAlias($alias), $className);
+        $this->assertSame($expected, $this->testAliasMgr->getAliases());
+        $this->assertSame($className, $this->testAliasMgr->getAlias($alias));
     }
 
-    public function statementDataProvider(): array
+    public function statementProvider(): array
     {
         $expected = [
-            true, true, false,
+            true, true, false, false,
         ];
 
         return $this->injectExpectedResult($expected);
@@ -107,7 +117,7 @@ class AliasManagerTest extends TestCase
 
     /**
      * @test
-     * @dataProvider statementDataProvider
+     * @dataProvider statementProvider
      */
     public function shouldCheckAliasedStatement(array $useStatements, bool $expected)
     {
@@ -115,11 +125,11 @@ class AliasManagerTest extends TestCase
             'aliases' => [$useStatements],
         ]);
 
-        $alias = $useStatements['alias'];
         $className = $useStatements['name'];
+        $alias = $useStatements['alias'] ?? trim($className, '\\');
 
-        $this->assertSame($this->testAliasMgr->isUseStatementAliased($alias), $expected);
-        $this->assertSame($this->testAliasMgr->isAliasPresentFor($className), $expected);
+        $this->assertSame($expected, $this->testAliasMgr->isUseStatementAliased($alias));
+        $this->assertSame($expected, $this->testAliasMgr->isAliasPresentFor($className));
     }
 
     public function classNameDataProvider(): array
@@ -127,7 +137,8 @@ class AliasManagerTest extends TestCase
         $expected = [
             'EventsManagerInterface',
             '\Bug\Events\ManagerInterface',
-            'Throwable',
+            '\Throwable',
+            'CompilerInterface',
         ];
 
         return $this->injectExpectedResult($expected);
@@ -145,6 +156,36 @@ class AliasManagerTest extends TestCase
 
         $className = $useStatements['name'];
 
-        $this->assertSame($this->testAliasMgr->getAliasForClassName($className), $expected);
+        $this->assertSame($expected, $this->testAliasMgr->getAliasForClassName($className));
+    }
+
+    /** @test */
+    public function shouldCheckIfAliasPresentForClass()
+    {
+        $this->testAliasMgr->add([
+            'aliases' => [
+                [
+                    'name' => 'One',
+                    'alias' => 'One',
+                ],
+                [
+                    'name' => 'Bug\\Events\\ManagerInterface',
+                    'alias' => 'EventsManagerInterface',
+                ],
+                [
+                    'name' => '\\Root\SomeNamespace\\SomeClassName',
+                    'alias' => 'SomeClassName',
+                ],
+                [
+                    'name' => 'AnotherClass',
+                    'alias' => 'AnotherClass',
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($this->testAliasMgr->isAliasPresentFor('Bug\\Events\\ManagerInterface'));
+        $this->assertFalse($this->testAliasMgr->isAliasPresentFor('\\Root\SomeNamespace\\SomeClassName'));
+        $this->assertFalse($this->testAliasMgr->isAliasPresentFor('AnotherClass'));
+        $this->assertFalse($this->testAliasMgr->isAliasPresentFor('NonExistingClass'));
     }
 }

--- a/unit-tests/Zephir/Test/AliasManagerTest.php
+++ b/unit-tests/Zephir/Test/AliasManagerTest.php
@@ -126,7 +126,9 @@ class AliasManagerTest extends TestCase
         ]);
 
         $className = $useStatements['name'];
-        $alias = $useStatements['alias'] ?? trim($className, '\\');
+
+        $parts = explode('\\', $className);
+        $alias = $useStatements['alias'] ?? $parts[\count($parts) - 1];
 
         $this->assertSame($expected, $this->testAliasMgr->isUseStatementAliased($alias));
         $this->assertSame($expected, $this->testAliasMgr->isAliasPresentFor($className));


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #2016

In raising this pull request, I confirm the following:

- [X] I have checked that another pull request for this purpose does not exist
- [X] I wrote some tests for this PR
- [X] I updated the CHANGELOG

Small description of change:

- fixed bug with stubs generation in case of relative namespaces for interfaces
- added test cases
- minor improvement for tests

Thanks
