### PR TITLE
Removed zend_uint typedef usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Removed `zend_uint` typedef usage
+
 ## [0.12.13] - 2019-12-08
 ### Fixed
 - Fixed PHP 7.4 support for macOS [phalcon/cphalcon#14577](https://github.com/phalcon/cphalcon/issues/14577)
 
 ### Removed
-- Removed `uint` and `ulong` typedefs support
+- Removed `uint` and `ulong` typedefs usage
 
 ## [0.12.12] - 2019-11-25
 ### Added

--- a/Library/Backends/ZendEngine3/StringsManager.php
+++ b/Library/Backends/ZendEngine3/StringsManager.php
@@ -87,7 +87,7 @@ class StringsManager extends BaseStringsManager
                 $t = substr($key, $i, 1);
                 $sparams[] = 'op'.$n;
                 if ('s' == $t) {
-                    $params[] = 'const char *op'.$n.', zend_uint op'.$n.'_len';
+                    $params[] = 'const char *op'.$n.', uint32_t op'.$n.'_len';
                     $lparams[] = 'op'.$n.', sizeof(op'.$n.')-1';
                     $lengths[] = 'op'.$n.'_len';
                     $svars[] = $n;

--- a/kernels/ZendEngine3/array.c
+++ b/kernels/ZendEngine3/array.c
@@ -28,7 +28,7 @@
 #include "kernel/object.h"
 #include "kernel/fcall.h"
 
-void ZEPHIR_FASTCALL zephir_create_array(zval *return_value, zend_uint size, int initialize)
+void ZEPHIR_FASTCALL zephir_create_array(zval *return_value, uint32_t size, int initialize)
 {
 	uint i;
 	zval null_value;
@@ -153,7 +153,7 @@ int zephir_array_isset_fetch(zval *fetched, const zval *arr, zval *index, int re
 	return 0;
 }
 
-int zephir_array_isset_string_fetch(zval *fetched, const zval *arr, char *index, zend_uint index_length, int readonly)
+int zephir_array_isset_string_fetch(zval *fetched, const zval *arr, char *index, uint32_t index_length, int readonly)
 {
 	zval *zv;
 	if (UNEXPECTED(Z_TYPE_P(arr) == IS_OBJECT && zephir_instance_of_ev((zval *)arr, (const zend_class_entry *)zend_ce_arrayaccess))) {
@@ -280,7 +280,7 @@ int ZEPHIR_FASTCALL zephir_array_isset(const zval *arr, zval *index)
 	}
 }
 
-int ZEPHIR_FASTCALL zephir_array_isset_string(const zval *arr, const char *index, zend_uint index_length)
+int ZEPHIR_FASTCALL zephir_array_isset_string(const zval *arr, const char *index, uint32_t index_length)
 {
 	if (UNEXPECTED(Z_TYPE_P(arr) == IS_OBJECT && zephir_instance_of_ev((zval *)arr, (const zend_class_entry *)zend_ce_arrayaccess))) {
 		zend_long ZEPHIR_LAST_CALL_STATUS;
@@ -369,7 +369,7 @@ int ZEPHIR_FASTCALL zephir_array_unset(zval *arr, zval *index, int flags)
 	}
 }
 
-int ZEPHIR_FASTCALL zephir_array_unset_string(zval *arr, const char *index, zend_uint index_length, int flags)
+int ZEPHIR_FASTCALL zephir_array_unset_string(zval *arr, const char *index, uint32_t index_length, int flags)
 {
 	if (UNEXPECTED(Z_TYPE_P(arr) == IS_OBJECT && zephir_instance_of_ev(arr, (const zend_class_entry *)zend_ce_arrayaccess))) {
 		zend_long ZEPHIR_LAST_CALL_STATUS;
@@ -515,7 +515,7 @@ int zephir_array_fetch(zval *return_value, zval *arr, zval *index, int flags ZEP
 	return FAILURE;
 }
 
-int zephir_array_fetch_string(zval *return_value, zval *arr, const char *index, zend_uint index_length, int flags ZEPHIR_DEBUG_PARAMS)
+int zephir_array_fetch_string(zval *return_value, zval *arr, const char *index, uint32_t index_length, int flags ZEPHIR_DEBUG_PARAMS)
 {
 	zval *zv;
 
@@ -698,7 +698,7 @@ int zephir_array_update_zval(zval *arr, zval *index, zval *value, int flags)
 	return ret != NULL ? FAILURE : SUCCESS;
 }
 
-int zephir_array_update_string(zval *arr, const char *index, zend_uint index_length, zval *value, int flags)
+int zephir_array_update_string(zval *arr, const char *index, uint32_t index_length, zval *value, int flags)
 {
 
 	if (UNEXPECTED(Z_TYPE_P(arr) == IS_OBJECT && zephir_instance_of_ev(arr, (const zend_class_entry *)zend_ce_arrayaccess))) {

--- a/kernels/ZendEngine3/array.h
+++ b/kernels/ZendEngine3/array.h
@@ -18,7 +18,7 @@
 #include "kernel/globals.h"
 #include "kernel/main.h"
 
-void ZEPHIR_FASTCALL zephir_create_array(zval *return_value, zend_uint size, int initialize);
+void ZEPHIR_FASTCALL zephir_create_array(zval *return_value, uint32_t size, int initialize);
 
 /**
  * Simple convenience function which ensures that you are dealing with an array and you can
@@ -28,22 +28,22 @@ void ZEPHIR_FASTCALL zephir_ensure_array(zval *probable_array);
 
 /** Combined isset/fetch */
 int zephir_array_isset_fetch(zval *fetched, const zval *arr, zval *index, int readonly);
-int zephir_array_isset_string_fetch(zval *fetched, const zval *arr, char *index, zend_uint index_length, int readonly);
+int zephir_array_isset_string_fetch(zval *fetched, const zval *arr, char *index, uint32_t index_length, int readonly);
 int zephir_array_isset_long_fetch(zval *fetched, const zval *arr, unsigned long index, int readonly);
 
 /** Check for index existence */
 int ZEPHIR_FASTCALL zephir_array_isset(const zval *arr, zval *index);
 int ZEPHIR_FASTCALL zephir_array_isset_long(const zval *arr, unsigned long index);
-int ZEPHIR_FASTCALL zephir_array_isset_string(const zval *arr, const char *index, zend_uint index_length);
+int ZEPHIR_FASTCALL zephir_array_isset_string(const zval *arr, const char *index, uint32_t index_length);
 
 /** Unset existing indexes */
 int ZEPHIR_FASTCALL zephir_array_unset(zval *arr, zval *index, int flags);
 int ZEPHIR_FASTCALL zephir_array_unset_long(zval *arr, unsigned long index, int flags);
-int ZEPHIR_FASTCALL zephir_array_unset_string(zval *arr, const char *index, zend_uint index_length, int flags);
+int ZEPHIR_FASTCALL zephir_array_unset_string(zval *arr, const char *index, uint32_t index_length, int flags);
 
 /** Fetch items from arrays */
 int zephir_array_fetch(zval *return_value, zval *arr, zval *index, int flags ZEPHIR_DEBUG_PARAMS);
-int zephir_array_fetch_string(zval *return_value, zval *arr, const char *index, zend_uint index_length, int flags ZEPHIR_DEBUG_PARAMS);
+int zephir_array_fetch_string(zval *return_value, zval *arr, const char *index, uint32_t index_length, int flags ZEPHIR_DEBUG_PARAMS);
 int zephir_array_fetch_long(zval *return_value, zval *arr, unsigned long index, int flags ZEPHIR_DEBUG_PARAMS);
 
 /** Append elements to arrays */
@@ -52,7 +52,7 @@ void zephir_merge_append(zval *left, zval *values);
 
 /** Modify array */
 int zephir_array_update_zval(zval *arr, zval *index, zval *value, int flags);
-int zephir_array_update_string(zval *arr, const char *index, zend_uint index_length, zval *value, int flags);
+int zephir_array_update_string(zval *arr, const char *index, uint32_t index_length, zval *value, int flags);
 int zephir_array_update_long(zval *arr, unsigned long index, zval *value, int flags ZEPHIR_DEBUG_PARAMS);
 
 void zephir_array_keys(zval *return_value, zval *arr);

--- a/kernels/ZendEngine3/exception.c
+++ b/kernels/ZendEngine3/exception.c
@@ -37,7 +37,7 @@
 /**
  * Throws a zval object as exception
  */
-void zephir_throw_exception_debug(zval *object, const char *file, zend_uint line)
+void zephir_throw_exception_debug(zval *object, const char *file, uint32_t line)
 {
 	zend_class_entry *default_exception_ce;
 	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
@@ -77,7 +77,7 @@ void zephir_throw_exception_debug(zval *object, const char *file, zend_uint line
 /**
  * Throws an exception with a single string parameter + debug info
  */
-void zephir_throw_exception_string_debug(zend_class_entry *ce, const char *message, zend_uint message_len, const char *file, zend_uint line)
+void zephir_throw_exception_string_debug(zend_class_entry *ce, const char *message, uint32_t message_len, const char *file, uint32_t line)
 {
 	zval object, msg;
 	int ZEPHIR_LAST_CALL_STATUS = 0;
@@ -105,7 +105,7 @@ void zephir_throw_exception_string_debug(zend_class_entry *ce, const char *messa
 /**
  * Throws an exception with a single string parameter
  */
-void zephir_throw_exception_string(zend_class_entry *ce, const char *message, zend_uint message_len)
+void zephir_throw_exception_string(zend_class_entry *ce, const char *message, uint32_t message_len)
 {
 	zval object, msg;
 	int ZEPHIR_LAST_CALL_STATUS = 0;

--- a/kernels/ZendEngine3/exception.h
+++ b/kernels/ZendEngine3/exception.h
@@ -56,9 +56,9 @@
 #define ZEPHIR_THROW_EXCEPTION_DEBUG_ZVALW(class_entry, message, file, line) zephir_throw_exception_zval_debug(class_entry, message, file, line)
 
 /** Throw Exceptions */
-void zephir_throw_exception_string(zend_class_entry *ce, const char *message, zend_uint message_len);
-void zephir_throw_exception_debug(zval *object, const char *file, zend_uint line);
+void zephir_throw_exception_string(zend_class_entry *ce, const char *message, uint32_t message_len);
+void zephir_throw_exception_debug(zval *object, const char *file, uint32_t line);
 void zephir_throw_exception_format(zend_class_entry *ce, const char *format, ...);
-void zephir_throw_exception_string_debug(zend_class_entry *ce, const char *message, zend_uint message_len, const char *file, zend_uint line);
+void zephir_throw_exception_string_debug(zend_class_entry *ce, const char *message, uint32_t message_len, const char *file, uint32_t line);
 
 #endif /* ZEPHIR_KERNEL_EXCEPTIONS_H */

--- a/kernels/ZendEngine3/fcall.c
+++ b/kernels/ZendEngine3/fcall.c
@@ -283,7 +283,7 @@ static void populate_fcic(zend_fcall_info_cache* fcic, zephir_call_type type, ze
  * Calls a function/method in the PHP userland
  */
 int zephir_call_user_function(zval *object_pp, zend_class_entry *obj_ce, zephir_call_type type,
-	zval *function_name, zval *retval_ptr, zephir_fcall_cache_entry **cache_entry, int cache_slot, zend_uint param_count,
+	zval *function_name, zval *retval_ptr, zephir_fcall_cache_entry **cache_entry, int cache_slot, uint32_t param_count,
 	zval *params[])
 {
 	zval local_retval_ptr;

--- a/kernels/ZendEngine3/main.h
+++ b/kernels/ZendEngine3/main.h
@@ -36,8 +36,9 @@ extern zend_string* i_self;
 #define PH_COPY 1024
 #define PH_CTOR 4096
 
+/* Deprecated */
 #ifndef zend_uint
- #define zend_uint unsigned int
+ #define zend_uint uint32_t
 #endif
 
 #ifndef ZEND_ACC_FINAL_CLASS

--- a/kernels/ZendEngine3/object.c
+++ b/kernels/ZendEngine3/object.c
@@ -67,7 +67,7 @@ int zephir_is_instance_of(zval *object, const char *class_name, unsigned int cla
 int zephir_zval_is_traversable(zval *object)
 {
 	zend_class_entry *ce;
-	zend_uint i;
+	uint32_t i;
 	zval *z = Z_ISREF_P(object) ? Z_REFVAL_P(object) : object;
 
 	if (Z_TYPE_P(z) == IS_OBJECT) {
@@ -462,7 +462,7 @@ static inline zend_class_entry *zephir_lookup_class_ce(zend_class_entry *ce, con
 /**
  * Reads a property from an object
  */
-int zephir_read_property(zval *result, zval *object, const char *property_name, zend_uint property_length, int flags)
+int zephir_read_property(zval *result, zval *object, const char *property_name, uint32_t property_length, int flags)
 {
 	zval property;
 	zend_class_entry *ce, *old_scope;
@@ -524,7 +524,7 @@ int zephir_read_property(zval *result, zval *object, const char *property_name, 
 /**
  * Fetches a property using a const char
  */
-int zephir_fetch_property(zval *result, zval *object, const char *property_name, zend_uint property_length, int silent)
+int zephir_fetch_property(zval *result, zval *object, const char *property_name, uint32_t property_length, int silent)
 {
 	if (zephir_isset_property(object, property_name, property_length)) {
 		zephir_read_property(result, object, property_name, property_length, 0);
@@ -655,7 +655,7 @@ int zephir_update_property_zval_zval(zval *object, zval *property, zval *value)
 /**
  * Updates an array property
  */
-int zephir_update_property_array(zval *object, const char *property, zend_uint property_length, const zval *index, zval *value)
+int zephir_update_property_array(zval *object, const char *property, uint32_t property_length, const zval *index, zval *value)
 {
 	zval tmp, sep_value;
 	int separated = 0;
@@ -818,7 +818,7 @@ int zephir_update_property_array_append(zval *object, char *property, unsigned i
 /**
  * Multiple array-offset update
  */
-int zephir_update_property_array_multi(zval *object, const char *property, zend_uint property_length, zval *value, const char *types, int types_length, int types_count, ...)
+int zephir_update_property_array_multi(zval *object, const char *property, uint32_t property_length, zval *value, const char *types, int types_length, int types_count, ...)
 {
 	va_list ap;
 	zval tmp_arr;
@@ -1049,7 +1049,7 @@ int zephir_update_static_property_ce(zend_class_entry *ce, const char *property_
 /*
  * Multiple array-offset update
  */
-int zephir_update_static_property_array_multi_ce(zend_class_entry *ce, const char *property, zend_uint property_length, zval *value, const char *types, int types_length, int types_count, ...)
+int zephir_update_static_property_array_multi_ce(zend_class_entry *ce, const char *property, uint32_t property_length, zval *value, const char *types, int types_length, int types_count, ...)
 {
 	va_list ap;
 	zval tmp_arr;
@@ -1191,7 +1191,7 @@ typedef struct _zend_closure {
 /**
  * Creates a closure
  */
-int zephir_create_closure_ex(zval *return_value, zval *this_ptr, zend_class_entry *ce, const char *method_name, zend_uint method_length)
+int zephir_create_closure_ex(zval *return_value, zval *this_ptr, zend_class_entry *ce, const char *method_name, uint32_t method_length)
 {
 	zend_function *function_ptr;
 	zend_closure *closure;

--- a/kernels/ZendEngine3/object.h
+++ b/kernels/ZendEngine3/object.h
@@ -42,10 +42,10 @@ int zephir_isset_property(zval *object, const char *property_name, unsigned int 
 int zephir_isset_property_zval(zval *object, const zval *property);
 
 /** Reading properties */
-int zephir_read_property(zval *result, zval *object, const char *property_name, zend_uint property_length, int silent);
+int zephir_read_property(zval *result, zval *object, const char *property_name, uint32_t property_length, int silent);
 int zephir_read_property_zval(zval *result, zval *object, zval *property, int silent);
 int zephir_return_property(zval *return_value, zval *object, char *property_name, unsigned int property_length);
-int zephir_fetch_property(zval *result, zval *object, const char *property_name, zend_uint property_length, int silent);
+int zephir_fetch_property(zval *result, zval *object, const char *property_name, uint32_t property_length, int silent);
 int zephir_fetch_property_zval(zval *result, zval *object, zval *property, int silent);
 
 /** Updating properties */
@@ -53,10 +53,10 @@ int zephir_update_property_zval(zval *obj, const char *property_name, unsigned i
 int zephir_update_property_zval_zval(zval *obj, zval *property, zval *value);
 
 /** Updating array properties */
-int zephir_update_property_array(zval *object, const char *property, zend_uint property_length, const zval *index, zval *value);
+int zephir_update_property_array(zval *object, const char *property, uint32_t property_length, const zval *index, zval *value);
 int zephir_update_property_array_string(zval *object, char *property, unsigned int property_length, char *index, unsigned int index_length, zval *value);
 int zephir_update_property_array_append(zval *object, char *property, unsigned int property_length, zval *value);
-int zephir_update_property_array_multi(zval *object, const char *property, zend_uint property_length, zval *value, const char *types, int types_length, int types_count, ...);
+int zephir_update_property_array_multi(zval *object, const char *property, uint32_t property_length, zval *value, const char *types, int types_length, int types_count, ...);
 
 /** Unset properties */
 int zephir_unset_property(zval* object, const char* name);
@@ -65,10 +65,10 @@ int zephir_unset_property_array(zval *object, char *property, unsigned int prope
 /** Static properties */
 int zephir_read_static_property_ce(zval *result, zend_class_entry *ce, const char *property, int len, int flags);
 int zephir_update_static_property_ce(zend_class_entry *ce, const char *property, uint32_t len, zval *value);
-int zephir_update_static_property_array_multi_ce(zend_class_entry *ce, const char *property, zend_uint property_length, zval *value, const char *types, int types_length, int types_count, ...);
+int zephir_update_static_property_array_multi_ce(zend_class_entry *ce, const char *property, uint32_t property_length, zval *value, const char *types, int types_length, int types_count, ...);
 
 /** Create closures */
-int zephir_create_closure_ex(zval *return_value, zval *this_ptr, zend_class_entry *ce, const char *method_name, zend_uint method_length);
+int zephir_create_closure_ex(zval *return_value, zval *this_ptr, zend_class_entry *ce, const char *method_name, uint32_t method_length);
 
 /** Create instances */
 int zephir_create_instance(zval *return_value, const zval *class_name);

--- a/kernels/ZendEngine3/operators.h
+++ b/kernels/ZendEngine3/operators.h
@@ -103,7 +103,7 @@ int zephir_compare_strict_long(zval *op1, long op2);
 int zephir_compare_strict_double(zval *op1, double op2);
 int zephir_compare_strict_bool(zval *op1, zend_bool op2);
 
-void zephir_cast(zval *result, zval *var, zend_uint type);
+void zephir_cast(zval *result, zval *var, uint32_t type);
 void zephir_convert_to_object(zval *op);
 long zephir_get_intval_ex(const zval *op);
 long zephir_get_charval_ex(const zval *op);


### PR DESCRIPTION
Hello!

* Type: bug fix | code quality
* Link to issue: -

In raising this pull request, I confirm the following:

- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I updated the CHANGELOG

Removed zend_uint typedef usage

Thanks
