### PR TITLE
Feature | type hint for arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ## [0.12.15] - 2019-12-12
+### Added
+- Improved type hint for arrays when generating stubs
+  [#2026](https://github.com/phalcon/zephir/issues/2026)
+
 ### Removed
 - Removed `uint` typedef usage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-## [0.12.15] - 2019-12-12
-### Added
+### Changed
 - Improved type hint for arrays when generating stubs
   [#2026](https://github.com/phalcon/zephir/issues/2026)
-
+  
+## [0.12.15] - 2019-12-12
 ### Removed
 - Removed `uint` typedef usage
 

--- a/Library/ClassMethod.php
+++ b/Library/ClassMethod.php
@@ -206,6 +206,42 @@ class ClassMethod
         $this->setReturnTypes($returnType);
     }
 
+    /**
+     * Process RAW return types structure.
+     *
+     * Example:
+     * $returnType = [
+     *  'type' => 'return-type',
+     *  'list' => [
+     *      [
+     *          'type' => 'return-type-parameter',
+     *          'cast' => [
+     *              'type' => 'variable',
+     *              'value' => '\StdClass',
+     *              'file' => './stubs.zep',
+     *              'line' => 21,
+     *              'char' => 48
+     *          ],
+     *          'collection' => 1,
+     *          'file' => './stubs.zep',
+     *          'line' => 21,
+     *          'char' => 48
+     *      ],
+     *      [
+     *          'type' => 'return-type-parameter',
+     *          'data-type' => 'bool',
+     *          'mandatory' => 0,
+     *          'file' => './stubs.zep',
+     *          'line' => 22,
+     *          'char' => 5
+     *      ]
+     *  ],
+     *  'void' => 0,
+     *  'file' => './stubs.zep',
+     *  'line' => 22,
+     *  'char' => 5
+     * ];
+     */
     public function setReturnTypes(array $returnType = null)
     {
         $this->returnTypesRaw = $returnType;

--- a/Library/Stubs/MethodDocBlock.php
+++ b/Library/Stubs/MethodDocBlock.php
@@ -98,6 +98,8 @@ class MethodDocBlock extends DocBlock
             $return = array_merge($return, $returnClassTypes);
         }
 
+        // Prepare return types for Collections compatible types
+        $collections = [];
         if ($method->hasReturnTypesRaw()) {
             $returnClassTypes = $method->getReturnTypesRaw();
 
@@ -115,12 +117,16 @@ class MethodDocBlock extends DocBlock
                     }
 
                     $return[$key] = $type.'[]';
+                    $collections[$type.'[]'] = $returnType;
                 }
             }
         }
 
         $processedTypes = !empty($method->getReturnClassTypes()) ? $return : null;
-        $returnType = $this->types->getReturnTypeAnnotation($this->classMethod, $processedTypes);
+        $returnType = $this->types->getReturnTypeAnnotation(
+            $this->classMethod,
+            $processedTypes ?? array_merge($method->getReturnTypes(), $collections)
+        );
 
         if (!empty($returnType)) {
             // Empty line in array - it's an empty description. Don't remove it!

--- a/Library/Types.php
+++ b/Library/Types.php
@@ -295,6 +295,18 @@ final class Types
      * Match if return types from Zephir are compatible
      * with allowed return types from PHP.
      *
+     * Examples:
+     *  $types = [
+     *      'variable' => [
+     *          'type' => 'return-type-parameter',
+     *          'data-type' => 'variable',
+     *          'mandatory' => 0,
+     *          'file' => '../path-to-file/stubs.zep',
+     *          'line' => 21,
+     *          'char' => 48,
+     *       ]
+     *  ]
+     *
      * @param array $types        - Return types from parser
      * @param array $allowedTypes - Allowed return types
      *

--- a/Library/Types.php
+++ b/Library/Types.php
@@ -66,6 +66,7 @@ final class Types
         $isNumeric = $this->isNumeric($returnTypes);
         $isIterable = $this->areReturnTypesIterableCompatible($returnTypes);
         $isResource = $this->areReturnTypesResourceCompatible($returnTypes);
+        $isCollection = $this->areReturnTypesCollectionCompatible($returnTypes);
 
         $isTypeHinted = $method->isReturnTypesHintDetermined();
         $isBasicTypes = $isArray || $isBool || $isDouble || $isInteger || $isResource || $isString || $isVoid || $isNumeric;
@@ -118,6 +119,10 @@ final class Types
 
         if ($isTypeHinted && !$isBasicTypes && !$isDynamic) {
             return implode('|', array_keys($returnTypes));
+        }
+
+        if ($isCollection) {
+            return implode('|', array_values($returnTypes));
         }
 
         return static::T_MIXED.$nullableType;
@@ -252,6 +257,26 @@ final class Types
     private function areReturnTypesResourceCompatible(array $types): bool
     {
         return $this->areReturnTypesCompatible($types, [static::T_RESOURCE]);
+    }
+
+    /**
+     * Match Zephir types with Collections.
+     *
+     * @param array $types
+     *
+     * @return bool
+     */
+    private function areReturnTypesCollectionCompatible(array $types): bool
+    {
+        $result = false;
+
+        foreach ($types as $type => $data) {
+            if (false !== strpos($type, '[]')) {
+                $result = true;
+            }
+        }
+
+        return $result;
     }
 
     /**

--- a/unit-tests/Zephir/Test/TypesTest.php
+++ b/unit-tests/Zephir/Test/TypesTest.php
@@ -38,8 +38,8 @@ class TypesTest extends TestCase
     /**
      * Builds base object definition for return type.
      *
-     * @param array $types - list of method return types
-     * @param int $mandatory - is mandatory flag
+     * @param array $types     - list of method return types
+     * @param int   $mandatory - is mandatory flag
      */
     private function baseReturnTypeDefinition(array $types, int $mandatory = 0): array
     {
@@ -61,8 +61,8 @@ class TypesTest extends TestCase
     /**
      * Builds variable/collection object definition for return type.
      *
-     * @param array $types - list of method return types
-     * @param int $collection - is collection flag
+     * @param array $types      - list of method return types
+     * @param int   $collection - is collection flag
      */
     private function variableReturnTypeDefinition(array $types, int $collection = 0): array
     {
@@ -90,8 +90,8 @@ class TypesTest extends TestCase
     /**
      * Helper to build test Method with injected test data.
      *
-     * @param array $testData - dataProvider data set
-     * @param int $definition - (optional) one of mandatory/collection flag
+     * @param array $testData   - dataProvider data set
+     * @param int   $definition - (optional) one of mandatory/collection flag
      */
     private function buildMethod(array $testData, int $definition = 0): ClassMethod
     {
@@ -274,7 +274,7 @@ class TypesTest extends TestCase
         foreach ($returnTypes as $type) {
             if (false !== strpos($type, '[]')) {
                 $typesList[] = $this->variableReturnTypeDefinition([$type], 1)[0];
-                $collectionType = \trim($type, "<>");
+                $collectionType = trim($type, '<>');
                 $collections[$collectionType] = $collectionType;
             } else {
                 $typesList[] = $this->baseReturnTypeDefinition([$type])[0];
@@ -287,7 +287,7 @@ class TypesTest extends TestCase
 
         $actual = $testTypes->getReturnTypeAnnotation(
             $testMethod,
-            \array_merge($testMethod->getReturnTypes(), $collections)
+            array_merge($testMethod->getReturnTypes(), $collections)
         );
 
         $this->assertSame($expected, $actual);

--- a/unit-tests/Zephir/Test/TypesTest.php
+++ b/unit-tests/Zephir/Test/TypesTest.php
@@ -174,7 +174,7 @@ class TypesTest extends TestCase
 
         $actual = $testTypes->getReturnTypeAnnotation($testMethod);
 
-        $this->assertSame($actual, $expected);
+        $this->assertSame($expected, $actual);
     }
 
     public function objectsDataProvider(): array
@@ -220,6 +220,6 @@ class TypesTest extends TestCase
             $processedReturnTypes
         );
 
-        $this->assertSame($actual, $expected);
+        $this->assertSame($expected, $actual);
     }
 }

--- a/unit-tests/fixtures/stubs/issues/expected/Issue_2026.zep.php
+++ b/unit-tests/fixtures/stubs/issues/expected/Issue_2026.zep.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Stubs;
+
+use Stubs\Events\EventManager;
+
+class Issue_2026
+{
+
+    /**
+     * Should process return type and generate docblock.
+     * Expects:
+     *  return array|\StdClass[]
+     *
+     * @return array|\StdClass[]
+     */
+    public function getClassCollection(): array
+    {
+    }
+
+    /**
+     * Should process return type and generate docblock.
+     * Expects:
+     *  return array|bool|\StdClass[]
+     *
+     * @return array|bool|\StdClass[]
+     */
+    public function getClassCollectionOrBool()
+    {
+    }
+
+    /**
+     * Should process return type and generate docblock.
+     * Expects:
+     *  return array|bool|\Stubs\Events\EventManager[]
+     *
+     * @return array|bool|\Stubs\Events\EventManager[]
+     */
+    public function getInterfaceCollectionOrBool()
+    {
+    }
+
+}

--- a/unit-tests/fixtures/stubs/issues/expected/Issue_2026.zep.php
+++ b/unit-tests/fixtures/stubs/issues/expected/Issue_2026.zep.php
@@ -4,11 +4,13 @@ namespace Stubs;
 
 use Stubs\Events\EventManager;
 
+/**
+ * Should process return type and generate docblock.
+ */
 class Issue_2026
 {
 
     /**
-     * Should process return type and generate docblock.
      * Expects:
      *  return array|\StdClass[]
      *
@@ -19,7 +21,6 @@ class Issue_2026
     }
 
     /**
-     * Should process return type and generate docblock.
      * Expects:
      *  return array|bool|\StdClass[]
      *
@@ -30,13 +31,32 @@ class Issue_2026
     }
 
     /**
-     * Should process return type and generate docblock.
      * Expects:
      *  return array|bool|\Stubs\Events\EventManager[]
      *
      * @return array|bool|\Stubs\Events\EventManager[]
      */
     public function getInterfaceCollectionOrBool()
+    {
+    }
+
+    /**
+     * Expects:
+     *  return array|\Stubs\Events\EventManager[]
+     *
+     * @return array|\Stubs\Events\EventManager[]
+     */
+    public function getInterfaceCollectionOrArray(): array
+    {
+    }
+
+    /**
+     * Expects:
+     *  return array|\Stubs\Events\EventManager[]|\StdClass[]
+     *
+     * @return array|\Stubs\Events\EventManager[]|\StdClass[]
+     */
+    public function getMixedCollectionOrArray(): array
     {
     }
 

--- a/unit-tests/fixtures/stubs/issues/stubs/events/EventManager.zep
+++ b/unit-tests/fixtures/stubs/issues/stubs/events/EventManager.zep
@@ -1,0 +1,16 @@
+namespace Stubs\Events;
+
+use Stubs\Events\ManagerInterface;
+
+class EventManager implements ManagerInterface
+{
+    /**
+    * Attach a listener to the events manager
+    *
+    * @param object|callable handler
+    */
+    public function attach(string! eventType, handler) -> void
+    {
+        // mock implementation...
+    }
+}

--- a/unit-tests/fixtures/stubs/issues/stubs/issue_2026.zep
+++ b/unit-tests/fixtures/stubs/issues/stubs/issue_2026.zep
@@ -1,0 +1,42 @@
+namespace Stubs;
+
+use Stubs\Events\EventManager;
+
+class Issue_2026
+{
+    /**
+     * Should process return type and generate docblock.
+     * Expects:
+     *  return array|\StdClass[]
+     */
+    public function getClassCollection() -> <\StdClass[]>
+    {
+        return [
+            new \StdClass()
+        ];
+    }
+
+    /**
+     * Should process return type and generate docblock.
+     * Expects:
+     *  return array|bool|\StdClass[]
+     */
+    public function getClassCollectionOrBool() -> <\StdClass[]> | bool
+    {
+        return [
+            new \StdClass()
+        ];
+    }
+
+    /**
+     * Should process return type and generate docblock.
+     * Expects:
+     *  return array|bool|\Stubs\Events\EventManager[]
+     */
+    public function getInterfaceCollectionOrBool() -> <EventManager[]> | bool
+    {
+        return [
+            new EventManager()
+        ];
+    }
+}

--- a/unit-tests/fixtures/stubs/issues/stubs/issue_2026.zep
+++ b/unit-tests/fixtures/stubs/issues/stubs/issue_2026.zep
@@ -2,10 +2,12 @@ namespace Stubs;
 
 use Stubs\Events\EventManager;
 
+/**
+ * Should process return type and generate docblock.
+ */
 class Issue_2026
 {
     /**
-     * Should process return type and generate docblock.
      * Expects:
      *  return array|\StdClass[]
      */
@@ -17,7 +19,6 @@ class Issue_2026
     }
 
     /**
-     * Should process return type and generate docblock.
      * Expects:
      *  return array|bool|\StdClass[]
      */
@@ -29,11 +30,32 @@ class Issue_2026
     }
 
     /**
-     * Should process return type and generate docblock.
      * Expects:
      *  return array|bool|\Stubs\Events\EventManager[]
      */
     public function getInterfaceCollectionOrBool() -> <EventManager[]> | bool
+    {
+        return [
+            new EventManager()
+        ];
+    }
+
+    /**
+     * Expects:
+     *  return array|\Stubs\Events\EventManager[]
+     */
+    public function getInterfaceCollectionOrArray() -> <EventManager[]> | array
+    {
+        return [
+            new EventManager()
+        ];
+    }
+
+    /**
+     * Expects:
+     *  return array|\Stubs\Events\EventManager[]|\StdClass[]
+     */
+    public function getMixedCollectionOrArray() -> <EventManager[]> | <\StdClass[]> | array
     {
         return [
             new EventManager()

--- a/unit-tests/sharness/t0005-stubs.sh
+++ b/unit-tests/sharness/t0005-stubs.sh
@@ -46,4 +46,8 @@ test_expect_success "Should properly generate Aliases for use statements" \
 test_expect_success "Should generage CamelCase folders for stubs" \
   "test $(ls ./ide/0.0.1/Stubs/Events/ManagerInterface.zep.php | sed -e 's~\/~\\~g') = .\ide\0.0.1\Stubs\Events\ManagerInterface.zep.php"
 
+# See: https://github.com/phalcon/zephir/issues/2026
+test_expect_success "Should properly generate return type for Collections" \
+  "test_cmp expected/Issue_2026.zep.php ide/0.0.1/Stubs/Issue_2026.zep.php"
+
 test_done


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #2026 

In raising this pull request, I confirm the following:

- [X] I have checked that another pull request for this purpose does not exist
- [X] I wrote some tests for this PR
- [X] I updated the CHANGELOG

Small description of change:

- Added type hint for return types in case of Zephir has arrays or collections as return type
- Added unit tests
- Added Sharness tests

Thanks
