### PR TITLE
Do not dump config file if config was changed

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,7 +5,7 @@ codecov:
 coverage:
   precision: 2
   round: down
-  range: "33...90"
+  range: "35...90"
 
   status:
     project:
@@ -19,9 +19,9 @@ coverage:
     changes: no
 
 comment:
-  layout: "header, diff"
+  layout: diff
   behavior: default
-  require_changes: no
+  require_changes: false
 
 ignore:
   - ".git"
@@ -38,3 +38,4 @@ ignore:
   - ".phpunit/.*"
   - "tests/.*"
   - "vendor/.*"
+  - "php-zephir-parser/.*"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -28,6 +28,7 @@ ignore:
   - "*.yml"
   - "*.json"
   - "*.md"
+  - "*.mk"
   # ignore folders and all its contents
   - ".ci/.*"
   - ".github/.*"
@@ -38,4 +39,3 @@ ignore:
   - ".phpunit/.*"
   - "tests/.*"
   - "vendor/.*"
-  - "php-zephir-parser/.*"

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -21,9 +21,6 @@ jobs:
         with:
             fetch-depth: 1
 
-      - name: Install Prerequisites
-        run: sudo apt install --no-install-recommends --quiet --assume-yes wget shellcheck
-
       - name: Setup PHP
         uses: shivammathur/setup-php@v1
         with:

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -26,6 +26,9 @@ jobs:
           mkdir -p $HOME/bin
           echo "::set-env name=PATH::$HOME/bin:$PATH"
 
+      - name: Install Prerequisites
+        run: apt install --no-install-recommends --quiet --assume-yes wget shellcheck
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v1
         with:

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -21,13 +21,8 @@ jobs:
         with:
             fetch-depth: 1
 
-      - name: Setup environments
-        run:
-          mkdir -p $HOME/bin
-          echo "::set-env name=PATH::$HOME/bin:$PATH"
-
       - name: Install Prerequisites
-        run: apt install --no-install-recommends --quiet --assume-yes wget shellcheck
+        run: sudo apt install --no-install-recommends --quiet --assume-yes wget shellcheck
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v1
@@ -37,22 +32,22 @@ jobs:
           pecl: false
 
       - name: Install PHP CS Fixer
-        run:
-          wget --quiet -O "$HOME/bin/php-cs-fixer" https://cs.sensiolabs.org/download/php-cs-fixer-v2.phar
-          chmod +x "$HOME/bin/php-cs-fixer"
-          php-cs-fixer --version
+        run: |
+          wget --quiet -O ./php-cs-fixer https://cs.sensiolabs.org/download/php-cs-fixer-v2.phar
+          chmod +x ./php-cs-fixer
+          ./php-cs-fixer --version
 
       - name: Install PHP_CodeSniffer
-        run:
-          wget --quiet -O "$HOME/bin/phpcs" https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar
-          chmod +x "$HOME/bin/phpcs"
-          phpcs --version
+        run: |
+          wget --quiet -O ./phpcs https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar
+          chmod +x ./phpcs
+          ./phpcs --version
 
       - name: Run PHP_CodeSniffer
-        run: phpcs
+        run: ./phpcs
 
       - name: Run PHP CS Fixer
-        run: php-cs-fixer fix --diff --dry-run -v
+        run: ./php-cs-fixer fix --diff --dry-run -v
 
       - name: Run Shell Check
         run: shellcheck .ci/*.sh

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -1,0 +1,55 @@
+name: Static Code Analysis
+
+on:
+  push:
+    branches-ignore:
+      - 'wip-*'
+    paths-ignore:
+      - 'README.md'
+
+  pull_request:
+    branches:
+      - 'master'
+
+jobs:
+  analysis:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2-beta
+        with:
+            fetch-depth: 1
+
+      - name: Setup environments
+        run:
+          mkdir -p $HOME/bin
+          echo "::set-env name=PATH::$HOME/bin:$PATH"
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v1
+        with:
+          php-version: '7.3'
+          coverage: none
+          pecl: false
+
+      - name: Install PHP CS Fixer
+        run:
+          wget --quiet -O "$HOME/bin/php-cs-fixer" https://cs.sensiolabs.org/download/php-cs-fixer-v2.phar
+          chmod +x "$HOME/bin/php-cs-fixer"
+          php-cs-fixer --version
+
+      - name: Install PHP_CodeSniffer
+        run:
+          wget --quiet -O "$HOME/bin/phpcs" https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar
+          chmod +x "$HOME/bin/phpcs"
+          phpcs --version
+
+      - name: Run PHP_CodeSniffer
+        run: phpcs
+
+      - name: Run PHP CS Fixer
+        run: php-cs-fixer fix --diff --dry-run -v
+
+      - name: Run Shell Check
+        run: shellcheck .ci/*.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,8 @@ env:
   global:
     - BUILD_PHAR=1
     - BOX_VERSION=3.8.1
-    - REPORT_COVERAGE=1
     - ZEPHIR_PARSER_VERSION="v1.3.3"
-    - PATH="${HOME}/bin:${PATH}"
+    - PATH="$HOME/bin:${PATH}"
     - TRAVIS_COMMIT_LOG="$(git log --format=fuller -5)"
     - MAKEFLAGS="-j $(getconf _NPROCESSORS_ONLN)"
     - SYMFONY_PHPUNIT_DIR="$HOME/.phpunit"
@@ -84,16 +83,6 @@ matrix:
             - gdb
       env:
         - SYMFONY_PHPUNIT_VERSION=7.4
-
-    - os: linux
-      cache: false
-      addons:
-        apt:
-          packages:
-            - shellcheck
-      env:
-        - BUILD_PHAR=0
-        - REPORT_COVERAGE=0
 
 before_install:
   - |
@@ -165,7 +154,7 @@ after_script:
   - printf "$TRAVIS_COMMIT_LOG\n"
 
 after_success:
-  - '[[ "$REPORT_COVERAGE" -eq 1 ]] && bash <(curl -s https://codecov.io/bash)'
+  - bash <(curl -s https://codecov.io/bash)
 
 after_failure:
   - echo "$($(phpenv which php) -v)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ cache:
 env:
   global:
     - BUILD_PHAR=1
-    - BUILD_TYPE=regular
     - BOX_VERSION=3.8.1
     - REPORT_COVERAGE=1
     - ZEPHIR_PARSER_VERSION="v1.3.3"
@@ -95,7 +94,6 @@ matrix:
       env:
         - BUILD_PHAR=0
         - REPORT_COVERAGE=0
-        - BUILD_TYPE=analysis
 
 before_install:
   - |
@@ -122,24 +120,8 @@ before_install:
 install:
   - |
     # Install regular dependencies
-    if [ "$BUILD_TYPE" == "regular" ]; then
-      .ci/install-prereqs.sh
-      composer install --no-interaction --no-ansi --no-progress --no-suggest
-    fi
-
-  - |
-    # Install dependencies needed for static code analysis
-    if [ "$BUILD_TYPE" == "analysis" ]; then
-      if [ ! -f "$HOME/bin/php-cs-fixer" ]; then
-        wget --quiet -O "$HOME/bin/php-cs-fixer" https://cs.sensiolabs.org/download/php-cs-fixer-v2.phar
-        chmod +x "$HOME/bin/php-cs-fixer"
-      fi
-
-      if [ ! -f "$HOME/bin/phpcs" ]; then
-        wget --quiet -O "$HOME/bin/phpcs" https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar
-        chmod +x "$HOME/bin/phpcs"
-      fi
-    fi
+    .ci/install-prereqs.sh
+    composer install --no-interaction --no-ansi --no-progress --no-suggest
 
   - |
     # Prepare Zephir executable
@@ -156,34 +138,26 @@ install:
 before_script:
   - cat .ci/travis.ini >> "$(phpenv root)/versions/$(phpenv version-name)/etc/conf.d/travis.ini"
   - cat "$(phpenv root)/versions/$(phpenv version-name)/etc/conf.d/travis.ini"
-  - if [ "$BUILD_TYPE" == "regular" ]; then zephir clean; fi
-  - if [ "$BUILD_TYPE" == "regular" ]; then zephir fullclean; fi
-  - if [ "$BUILD_TYPE" == "regular" ]; then zephir generate; fi
-  - if [ "$BUILD_TYPE" == "regular" ]; then zephir stubs; fi
-  - if [ "$BUILD_TYPE" == "regular" ]; then zephir api; fi
+  - zephir clean
+  - zephir fullclean
+  - zephir generate
+  - zephir stubs
+  - zephir api
   - |
-    if [ "$BUILD_TYPE" == "regular" ]; then
-      # These variables is needed to produce non optimized code and use code coverage
-      LDFLAGS="--coverage"
-      CFLAGS="-O0 -ggdb -fprofile-arcs -ftest-coverage"
-      CXXFLAGS="-O0 -ggdb -fprofile-arcs -ftest-coverage"
+    # These variables are needed to produce non optimized code as well as for code coverage
+    LDFLAGS="--coverage"
+    CFLAGS="-O0 -ggdb -fprofile-arcs -ftest-coverage"
+    CXXFLAGS="-O0 -ggdb -fprofile-arcs -ftest-coverage"
 
-      # Export variables in the subshell to not shadow global variables
-      ( export LDFLAGS CFLAGS CXXFLAGS; zephir compile ) || false
-    fi
+    # Export variables in the subshell to not shadow global variables
+    ( export LDFLAGS CFLAGS CXXFLAGS; zephir compile ) || false
 
 script:
   # Unit testing
-  - if [ "$BUILD_TYPE" == "regular" ]; then .ci/run-tests.sh; fi
+  - .ci/run-tests.sh
 
   # Black-box testing
-  - if [ "$BUILD_TYPE" == "regular" ]; then ( cd unit-tests/sharness && PHP=$(phpenv which php) make ); fi
-
-  # Static Code Analysis
-  - phpenv config-rm xdebug.ini || true
-  - if [ "$BUILD_TYPE" == "analysis" ]; then phpcs --version; phpcs; fi
-  - if [ "$BUILD_TYPE" == "analysis" ]; then php-cs-fixer --version; php-cs-fixer fix --diff --dry-run -v; fi
-  - if [ "$BUILD_TYPE" == "analysis" ]; then shellcheck .ci/*.sh; fi
+  - ( cd unit-tests/sharness && PHP=$(phpenv which php) make )
 
 after_script:
   - re2c --version
@@ -210,5 +184,4 @@ deploy:
   on:
     tags: true
     php: '7.2'
-    condition: $BUILD_TYPE = regular
   repo: phalcon/zephir

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Do not dump config file if config was changed.
   Usually we need dump configuration exactly once - at project initialization.
   There are no needs to dump it for every config change. Also, this patch
-  removes `Config::$changed` variable that is no longer needed.
+  removes `Config::$changed` variable that is no longer needed
+  [#2035](https://github.com/phalcon/zephir/pull/2035)
 
 ### Changed
 - Improved type hint for arrays when generating stubs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Do not dump config file if config was changed.
+  Usually we need dump configuration exactly once - at project initialization.
+  There are no needs to dump it for every config change. Also, this patch
+  removes `Config::$changed` variable that is no longer needed.
+
 ### Changed
 - Improved type hint for arrays when generating stubs
   [#2026](https://github.com/phalcon/zephir/issues/2026)

--- a/Library/Console/Command/InitCommand.php
+++ b/Library/Console/Command/InitCommand.php
@@ -76,6 +76,9 @@ final class InitCommand extends Command
         // Copy the latest kernel files
         $this->recursiveProcess($this->backend->getInternalKernelPath(), 'ext/kernel');
 
+        // Dump initial configuration on project creation
+        $this->config->dumpToFile();
+
         return 0;
     }
 

--- a/unit-tests/Zephir/Test/ConfigTest.php
+++ b/unit-tests/Zephir/Test/ConfigTest.php
@@ -150,7 +150,6 @@ DOC;
             'stubs run' => ['stubs', 'stubs-run-after-generate', false],
             'stubs banner' => ['stubs', 'banner', $this->stubsBanner()],
             'api path' => ['api', 'path', 'doc/%version%'],
-            'api path' => ['api', 'path', 'doc/%version%'],
             'warnings unused-variable' => ['warnings', 'unused-variable', true],
             'optimizations static-type-inference' => ['optimizations', 'static-type-inference', true],
             'extra indent' => ['extra', 'indent', 'spaces'],
@@ -231,7 +230,7 @@ DOC;
     }
 
     /** @test */
-    public function shouldSaveConfigOnExit()
+    public function shouldSaveConfig()
     {
         chdir(sys_get_temp_dir());
 

--- a/unit-tests/Zephir/Test/ConfigTest.php
+++ b/unit-tests/Zephir/Test/ConfigTest.php
@@ -82,8 +82,7 @@ DOC;
      *
      * @test
      * @expectedException \Zephir\Exception
-     * @expectedExceptionMessage The config.json file is not valid or there is
-     * no Zephir extension initialized in this directory.
+     * @expectedExceptionMessage The config.json file is invalid: Syntax error, malformed JSON
      */
     public function constructWithBadConfigFile()
     {

--- a/unit-tests/sharness/Makefile
+++ b/unit-tests/sharness/Makefile
@@ -23,31 +23,27 @@ all: aggregate
 
 .PHONY: clean
 clean: clean-test-results
-	find $(TESTSDIR)/fixtures -name compile-errors.log -o -name compile.log -delete
-	find $(TESTSDIR)/fixtures -name .zephir -type d -exec rm -rf {} +
-	find $(TESTSDIR)/fixtures -name ext -type d -exec rm -rf {} +
-	find $(TESTSDIR)/output/* -type d -exec rm -rf {} +
-	find $(TESTSDIR)/output -type f -not -name .gitignore -delete
-	-rm -rf "trash "directory.*
+	@find $(TESTSDIR)/fixtures -name compile-errors.log -o -name compile.log -delete
+	@find $(TESTSDIR)/fixtures -name .zephir -type d -exec rm -rf {} +
+	@find $(TESTSDIR)/fixtures -name ext -type d -exec rm -rf {} +
+	@find $(TESTSDIR)/output -type d -not -name output -exec rm -rf {} +
+	@find $(TESTSDIR)/output -type f -not -name .gitignore -delete
+	@rm -rf "trash "directory.*
 
 .PHONY: clean-test-results
 clean-test-results:
-	@echo "*** $@ ***"
-	-rm -rf test-results
+	@rm -rf test-results
 
 .PHONY: $(T)
 $(T): clean-test-results deps
-	@echo "*** $@ ***"
 	./$@
 
 .PHONY: aggregate
 aggregate: clean-test-results $(T)
-	@echo "*** $@ ***"
-	find ./test-results -name 't*-*.sh.*.counts' | $(AGGREGATE)
+	@find ./test-results -name 't*-*.sh.*.counts' | $(AGGREGATE)
 
 .PHONY: deps
 deps: $(SHARNESS) $(BINS)
 
 $(SHARNESS):
-	@echo "*** checking $@ ***"
 	$(LIBDIR)/install-sharness.sh

--- a/unit-tests/sharness/t0001-compile.sh
+++ b/unit-tests/sharness/t0001-compile.sh
@@ -11,7 +11,7 @@ test_expect_success "Compile the extension in production mode" "
   cd $FIXTURESDIR/devmode &&
   zephirc fullclean 2>&1 >/dev/null &&
   zephirc compile --no-dev 2>&1 >/dev/null &&
-  grep -q -e \"^CFLAGS=$regexp\" ext/config.nice
+  cat ext/config.nice | grep -q -e \"^CFLAGS=$regexp\"
 "
 
 regexp="'-O0 -g3'"
@@ -19,7 +19,7 @@ test_expect_success "Compile the extension in development mode" "
   cd $FIXTURESDIR/devmode &&
   zephirc fullclean 2>&1 >/dev/null &&
   zephirc compile --dev 2>&1 >/dev/null &&
-  grep -q -e \"^CFLAGS=$regexp\" ext/config.nice
+  cat ext/config.nice | grep -q -e \"^CFLAGS=$regexp\"
 "
 
 test_done

--- a/unit-tests/sharness/t0003-init-success.sh
+++ b/unit-tests/sharness/t0003-init-success.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC2034
+test_description="Test init command for success"
+
+# shellcheck disable=SC1091
+source ./setup.sh
+
+test_expect_success "Should not dump config file" "
+  cd $OUTPUTDIR &&
+  zephirc --version -Wunused-variable 2>&1 >/dev/null &&
+  test ! -f ./config.json
+"
+
+test_expect_success "Should generate a project and dump config file" "
+  cd $OUTPUTDIR &&
+  zephirc init success &&
+  test -d ./success &&
+  test -d ./success/success &&
+  test -d ./success/ext &&
+  test -f ./success/config.json
+"
+
+# Cleanup
+[ -d "$OUTPUTDIR/config.json" ] && rm -rf "$OUTPUTDIR/config.json"
+[ -d "$OUTPUTDIR/success" ] && rm -rf "$OUTPUTDIR/success"
+
+test_done


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: -

In raising this pull request, I confirm the following:

- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I updated the CHANGELOG

Small description of change:

Usually we need dump configuration exactly once - at project initialization. There are no needs to dump it for every config change. Also, this patch removes `Config::$changed` variable that is no longer needed.

Thanks
