### PR TITLE
Use a different path for the Kernel cache if possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   There are no needs to dump it for every config change. Also, this patch
   removes `Config::$changed` variable that is no longer needed
   [#2035](https://github.com/phalcon/zephir/pull/2035)
+- Use a different path for the Kernel cache if possible.
+  This patch fixes a cache collision issue. The issue is after creating the
+  cache and filling it with a project-specific configuration, there is no
+  way to invalidate it. Any next project will use the same Kernel cache and
+  the same Kernel configuration (if any).
 
 ### Changed
 - Improved type hint for arrays when generating stubs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   cache and filling it with a project-specific configuration, there is no
   way to invalidate it. Any next project will use the same Kernel cache and
   the same Kernel configuration (if any).
+  [#2036](https://github.com/phalcon/zephir/pull/2036)
 
 ### Changed
 - Improved type hint for arrays when generating stubs

--- a/Library/DependencyInjection/ZephirKernel.php
+++ b/Library/DependencyInjection/ZephirKernel.php
@@ -82,8 +82,6 @@ final class ZephirKernel extends Kernel
      */
     public function getCacheDir(): string
     {
-        // allows container rebuild when config or version changes
-
         $home = getenv('HOME') ?: (getenv('HOMEDRIVE').DIRECTORY_SEPARATOR.getenv('HOMEPATH'));
 
         if (is_macos()) {
@@ -99,7 +97,9 @@ final class ZephirKernel extends Kernel
 
         $path = $cacheDir.DIRECTORY_SEPARATOR.$this->getPathSalt();
         if (!is_dir($path) && !mkdir($path, 0755, true) && !is_dir($path)) {
-            throw new RuntimeException(sprintf('Unable to create cache directory: "%s"', $path));
+            throw new RuntimeException(
+                sprintf('Unable to create cache directory: "%s"', $path)
+            );
         }
 
         return $path;
@@ -113,7 +113,10 @@ final class ZephirKernel extends Kernel
      */
     private function getPathSalt(): string
     {
-        $hash = Zephir::VERSION.$this->environment.serialize($this->extraConfigFiles);
+        $hash =
+            Zephir::VERSION.
+            $this->environment.
+            serialize($this->extraConfigFiles);
 
         $localConfig = $this->startedDir.DIRECTORY_SEPARATOR.'config.json';
         if (file_exists($localConfig) && is_readable($localConfig)) {
@@ -148,7 +151,9 @@ final class ZephirKernel extends Kernel
 
         $path = $stateDir.DIRECTORY_SEPARATOR.$this->getPathSalt();
         if (!is_dir($path) && !mkdir($path, 0755, true) && !is_dir($path)) {
-            throw new RuntimeException(sprintf('Unable to create logs directory: "%s"', $path));
+            throw new RuntimeException(
+                sprintf('Unable to create logs directory: "%s"', $path)
+            );
         }
 
         return $path;

--- a/Library/DependencyInjection/ZephirKernel.php
+++ b/Library/DependencyInjection/ZephirKernel.php
@@ -12,12 +12,15 @@
 namespace Zephir\DependencyInjection;
 
 use const DIRECTORY_SEPARATOR;
+use Exception;
 use Oneup\FlysystemBundle\OneupFlysystemBundle;
+use RuntimeException;
 use Symfony\Bundle\MonologBundle\MonologBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\Kernel;
+use Throwable;
 use Zephir\DependencyInjection\CompilerPass\CollectCommandsToApplicationCompilerPass;
 use function Zephir\is_macos;
 use function Zephir\is_windows;
@@ -61,7 +64,7 @@ final class ZephirKernel extends Kernel
      *
      * @param LoaderInterface $loader
      *
-     * @throws \Exception|\Throwable
+     * @throws Exception|Throwable
      */
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
@@ -77,10 +80,10 @@ final class ZephirKernel extends Kernel
      *
      * @return string
      */
-    public function getCacheDir()
+    public function getCacheDir(): string
     {
         // allows container rebuild when config or version changes
-        $hash = Zephir::VERSION.$this->environment.serialize($this->extraConfigFiles);
+
         $home = getenv('HOME') ?: (getenv('HOMEDRIVE').DIRECTORY_SEPARATOR.getenv('HOMEPATH'));
 
         if (is_macos()) {
@@ -94,12 +97,32 @@ final class ZephirKernel extends Kernel
             $cacheDir .= '/zephir';
         }
 
-        $path = $cacheDir.DIRECTORY_SEPARATOR.substr(md5($hash), 0, 16);
-        if (!is_dir($path) && !mkdir($path, 0777, true) && !is_dir($path)) {
-            throw new \RuntimeException(sprintf('Directory "%s" was not created', $path));
+        $path = $cacheDir.DIRECTORY_SEPARATOR.$this->getPathSalt();
+        if (!is_dir($path) && !mkdir($path, 0755, true) && !is_dir($path)) {
+            throw new RuntimeException(sprintf('Unable to create cache directory: "%s"', $path));
         }
 
         return $path;
+    }
+
+    /**
+     * Allows container rebuild when config or version changes.
+     * This also used to get unique path to kernel logs.
+     *
+     * @return string
+     */
+    private function getPathSalt(): string
+    {
+        $hash = Zephir::VERSION.$this->environment.serialize($this->extraConfigFiles);
+
+        $localConfig = $this->startedDir.DIRECTORY_SEPARATOR.'config.json';
+        if (file_exists($localConfig) && is_readable($localConfig)) {
+            $salt = md5_file($localConfig);
+        } else {
+            $salt = $this->startedDir;
+        }
+
+        return substr(md5("{$hash}{$salt}"), 0, 16);
     }
 
     /**
@@ -107,7 +130,7 @@ final class ZephirKernel extends Kernel
      *
      * @return string
      */
-    public function getLogDir()
+    public function getLogDir(): string
     {
         $home = getenv('HOME') ?: (getenv('HOMEDRIVE').DIRECTORY_SEPARATOR.getenv('HOMEPATH'));
 
@@ -123,9 +146,9 @@ final class ZephirKernel extends Kernel
             $stateDir .= '/zephir';
         }
 
-        $path = $stateDir.DIRECTORY_SEPARATOR.Zephir::VERSION;
-        if (!is_dir($path) && !mkdir($path, 0777, true) && !is_dir($path)) {
-            throw new \RuntimeException(sprintf('Directory "%s" was not created', $path));
+        $path = $stateDir.DIRECTORY_SEPARATOR.$this->getPathSalt();
+        if (!is_dir($path) && !mkdir($path, 0755, true) && !is_dir($path)) {
+            throw new RuntimeException(sprintf('Unable to create logs directory: "%s"', $path));
         }
 
         return $path;
@@ -136,15 +159,17 @@ final class ZephirKernel extends Kernel
      *
      * @return string The project root dir
      */
-    public function getProjectDir()
+    public function getProjectDir(): string
     {
-        return \dirname(\dirname(__DIR__));
+        return \dirname(__DIR__, 2);
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
-    public function getRootDir()
+    public function getRootDir(): string
     {
         return \dirname(__DIR__);
     }
@@ -154,7 +179,7 @@ final class ZephirKernel extends Kernel
      *
      * @return string The local cache dir
      */
-    public function getStartedDir()
+    public function getStartedDir(): string
     {
         return $this->startedDir.'/.zephir';
     }
@@ -174,7 +199,7 @@ final class ZephirKernel extends Kernel
      *
      * @return array An array of kernel parameters
      */
-    protected function getKernelParameters()
+    protected function getKernelParameters(): array
     {
         $parameters = parent::getKernelParameters();
         $parameters['kernel.local_cache_dir'] = $this->getStartedDir();

--- a/Library/DependencyInjection/ZephirKernel.php
+++ b/Library/DependencyInjection/ZephirKernel.php
@@ -113,19 +113,18 @@ final class ZephirKernel extends Kernel
      */
     private function getPathSalt(): string
     {
-        $hash =
+        $prefix =
             Zephir::VERSION.
             $this->environment.
             serialize($this->extraConfigFiles);
 
         $localConfig = $this->startedDir.DIRECTORY_SEPARATOR.'config.json';
-        if (file_exists($localConfig) && is_readable($localConfig)) {
-            $salt = md5_file($localConfig);
-        } else {
-            $salt = $this->startedDir;
+        $suffix = $this->startedDir;
+        if (file_exists($localConfig)) {
+            $suffix = md5_file($localConfig);
         }
 
-        return substr(md5("{$hash}{$salt}"), 0, 16);
+        return substr(md5("{$prefix}{$suffix}"), 0, 16);
     }
 
     /**

--- a/Library/FileSystem/FileSystemInterface.php
+++ b/Library/FileSystem/FileSystemInterface.php
@@ -18,7 +18,7 @@ interface FileSystemInterface
      *
      * @return bool
      */
-    public function isInitialized();
+    public function isInitialized(): bool;
 
     /**
      * Initialize the filesystem.
@@ -32,7 +32,7 @@ interface FileSystemInterface
      *
      * @return bool
      */
-    public function exists($path);
+    public function exists(string $path): bool;
 
     /**
      * Creates a directory inside the temporary container.
@@ -41,7 +41,7 @@ interface FileSystemInterface
      *
      * @return bool
      */
-    public function makeDirectory($path);
+    public function makeDirectory(string $path): bool;
 
     /**
      * Returns a temporary entry as an array.
@@ -50,7 +50,7 @@ interface FileSystemInterface
      *
      * @return array
      */
-    public function file($path);
+    public function file(string $path): array;
 
     /**
      * Requires a file from the temporary directory.
@@ -59,7 +59,7 @@ interface FileSystemInterface
      *
      * @return mixed
      */
-    public function requireFile($path);
+    public function requireFile(string $path);
 
     /**
      * Attempts to remove recursively the temporary directory with all subdirectories and files.
@@ -72,7 +72,7 @@ interface FileSystemInterface
      * @param string $path
      * @param string $data
      */
-    public function write($path, $data);
+    public function write(string $path, string $data);
 
     /**
      * Writes data from a temporary entry.
@@ -81,14 +81,14 @@ interface FileSystemInterface
      *
      * @return string
      */
-    public function read($path);
+    public function read(string $path): string;
 
     /**
      * Deletes a temporary entry.
      *
      * @param string $path
      */
-    public function delete($path);
+    public function delete(string $path);
 
     /**
      * Generate a hash value using the contents of a given file.
@@ -99,7 +99,7 @@ interface FileSystemInterface
      *
      * @return string
      */
-    public function getHashFile($algorithm, $sourceFile, $useCache = false);
+    public function getHashFile(string $algorithm, string $sourceFile, $useCache = false): string;
 
     /**
      * Returns the modification time of a temporary entry.
@@ -108,7 +108,7 @@ interface FileSystemInterface
      *
      * @return int
      */
-    public function modificationTime($path);
+    public function modificationTime(string $path): int;
 
     /**
      * Executes a command and saves the result into a temporary entry.
@@ -117,7 +117,7 @@ interface FileSystemInterface
      * @param string $descriptor
      * @param string $destination
      */
-    public function system($command, $descriptor, $destination);
+    public function system(string $command, string $descriptor, string $destination);
 
     /**
      * Normalizes path to be used as a temporary entry.
@@ -126,5 +126,5 @@ interface FileSystemInterface
      *
      * @return string
      */
-    public function normalizePath($path);
+    public function normalizePath(string $path): string;
 }

--- a/Library/FileSystem/HardDisk.php
+++ b/Library/FileSystem/HardDisk.php
@@ -11,6 +11,7 @@
 
 namespace Zephir\FileSystem;
 
+use ErrorException;
 use League\Flysystem;
 use Zephir\Exception\CompilerException;
 use Zephir\Exception\FileSystemException;
@@ -70,7 +71,7 @@ class HardDisk implements FileSystemInterface
      *
      * @return bool
      */
-    public function isInitialized()
+    public function isInitialized(): bool
     {
         return $this->initialized;
     }
@@ -98,7 +99,7 @@ class HardDisk implements FileSystemInterface
      *
      * @return bool
      */
-    public function exists($path)
+    public function exists(string $path): bool
     {
         if ('.' === $path || empty($path)) {
             $path = $this->localPath;
@@ -116,7 +117,7 @@ class HardDisk implements FileSystemInterface
      *
      * @return bool
      */
-    public function makeDirectory($path)
+    public function makeDirectory(string $path): bool
     {
         if ('.' === $path || empty($path)) {
             $path = $this->localPath;
@@ -136,7 +137,7 @@ class HardDisk implements FileSystemInterface
      *
      * @return array
      */
-    public function file($path)
+    public function file(string $path): array
     {
         try {
             $contents = $this->filesystem->read($this->localPath."/{$path}");
@@ -152,9 +153,11 @@ class HardDisk implements FileSystemInterface
      *
      * @param string $path
      *
+     * @return int
+     *
      * @throws Flysystem\FileNotFoundException
      */
-    public function modificationTime($path)
+    public function modificationTime(string $path): int
     {
         return (int) $this->filesystem->getTimestamp($this->localPath."/{$path}");
     }
@@ -168,7 +171,7 @@ class HardDisk implements FileSystemInterface
      *
      * @return string
      */
-    public function read($path)
+    public function read(string $path): string
     {
         return (string) $this->filesystem->read($this->localPath."/{$path}");
     }
@@ -180,7 +183,7 @@ class HardDisk implements FileSystemInterface
      *
      * @throws Flysystem\FileNotFoundException
      */
-    public function delete($path)
+    public function delete(string $path)
     {
         $this->filesystem->delete($this->localPath."/{$path}");
     }
@@ -193,7 +196,7 @@ class HardDisk implements FileSystemInterface
      *
      * @throws Flysystem\FileExistsException
      */
-    public function write($path, $contents)
+    public function write(string $path, string $contents)
     {
         $this->filesystem->write($this->localPath."/{$path}", $contents);
     }
@@ -205,11 +208,11 @@ class HardDisk implements FileSystemInterface
      * @param string $descriptor
      * @param string $destination
      */
-    public function system($command, $descriptor, $destination)
+    public function system(string $command, string $descriptor, string $destination)
     {
         // fallback
         $redirect = "{$this->localPath}/{$destination}";
-        if (false == empty($this->basePath)) {
+        if (!empty($this->basePath)) {
             $redirect = "{$this->basePath}/{$this->localPath}/{$destination}";
         }
 
@@ -233,9 +236,9 @@ class HardDisk implements FileSystemInterface
      *
      * @throws Flysystem\FileNotFoundException
      */
-    public function requireFile($path)
+    public function requireFile(string $path)
     {
-        if (false == empty($this->basePath)) {
+        if (!empty($this->basePath)) {
             return require "{$this->basePath}/{$this->localPath}/{$path}";
         }
 
@@ -254,7 +257,7 @@ class HardDisk implements FileSystemInterface
     {
         try {
             $this->filesystem->deleteDir($this->localPath);
-        } catch (\ErrorException $e) {
+        } catch (ErrorException $e) {
             // For reasons beyond our control, the actual owner of the directory
             // contents may not be the same as the current user. Therefore we need
             // to catch ErrorException and throw an expected exception with informing
@@ -278,7 +281,7 @@ class HardDisk implements FileSystemInterface
      *
      * @return string
      */
-    public function getHashFile($algorithm, $sourceFile, $useCache = false)
+    public function getHashFile(string $algorithm, string $sourceFile, $useCache = false): string
     {
         if (false === $useCache) {
             return hash_file($algorithm, $sourceFile);
@@ -296,14 +299,16 @@ class HardDisk implements FileSystemInterface
             $this->filesystem->write($cacheFile, $contents);
 
             return $contents;
-        } elseif (filemtime($sourceFile) > $this->filesystem->getTimestamp($cacheFile)) {
+        }
+
+        if (filemtime($sourceFile) > $this->filesystem->getTimestamp($cacheFile)) {
             $contents = hash_file($algorithm, $sourceFile);
             $this->filesystem->update($cacheFile, $contents);
 
             return $contents;
-        } else {
-            return $this->filesystem->read($cacheFile);
         }
+
+        return $this->filesystem->read($cacheFile);
     }
 
     /**
@@ -313,7 +318,7 @@ class HardDisk implements FileSystemInterface
      *
      * @return string
      */
-    public function normalizePath($path)
+    public function normalizePath(string $path): string
     {
         return str_replace(['\\', ':', '/'], '_', $path);
     }

--- a/unit-tests/sharness/t0004-generate-success.sh
+++ b/unit-tests/sharness/t0004-generate-success.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC2034
+test_description="Test generate command for success"
+
+# shellcheck disable=SC1091
+source ./setup.sh
+
+test_expect_success "Should not use the same cache when working with different projects" "
+  cd $OUTPUTDIR &&
+  rm -rf ./gen1 &&
+  zephirc init gen1 &&
+  cd ./gen1 &&
+  echo 'namespace Gen1;' > ./gen1/test.zep &&
+  echo 'class Test { }' >> ./gen1/test.zep &&
+  zephirc generate &&
+  test -d ./.zephir &&
+  rm -r ./.zephir &&
+
+  cd $OUTPUTDIR &&
+  rm -rf ./gen2 &&
+  zephirc init gen2 &&
+  cd ./gen2 &&
+  echo 'namespace Gen2;' > ./gen2/test.zep &&
+  echo 'class Test { }' >> ./gen2/test.zep &&
+  zephirc generate &&
+  test -d ./.zephir &&
+  test ! -d $OUTPUTDIR/gen1/.zephir
+"
+
+test_done


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: -

In raising this pull request, I confirm the following:

- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I updated the CHANGELOG

Small description of change:

This patch fixes a cache collision issue. The issue is after creating the cache and filling it with a project-specific configuration, there is no way to invalidate it. Any next project will use the same Kernel cache and the same Kernel configuration (if any).

For more details see the test.

Thanks
