### PR TITLE
Characters escape fix 

### DIFF
--- a/ext/kernel/filter.c
+++ b/ext/kernel/filter.c
@@ -218,7 +218,7 @@ void zephir_escape_multi(zval *return_value, zval *param, const char *escape_cha
 		/**
 		 * Alphanumeric characters are not escaped
 		 */
-		if (value < 256 && isalnum(value)) {
+		if (value < 123 && isalnum(value)) {
 			smart_str_appendc(&escaped_str, (unsigned char) value);
 			continue;
 		}

--- a/kernels/ZendEngine3/filter.c
+++ b/kernels/ZendEngine3/filter.c
@@ -218,7 +218,7 @@ void zephir_escape_multi(zval *return_value, zval *param, const char *escape_cha
 		/**
 		 * Alphanumeric characters are not escaped
 		 */
-		if (value < 256 && isalnum(value)) {
+		if (value < 123 && isalnum(value)) {
 			smart_str_appendc(&escaped_str, (unsigned char) value);
 			continue;
 		}


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/14763

In raising this pull request, I confirm the following:

- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I updated the CHANGELOG

Small description of change:
I think this fixes our characters issues in Phalcon. 122 is the decimal index of the letter z (the basic (ascii) character map). Currently we're checking below 256 that allows on certain OS (latests windows and osx) to not escape é since this is an index > 122 and < 256