### PR TITLE
Fixed property visibility

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -4,3 +4,7 @@ engines:
     enabled: true
     config:
       rulesets: "phpmd.xml.dist"
+
+exclude_paths:
+  - 'ext/**'
+  - 'prototypes/**'

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,10 +1,21 @@
 ;;; Directory Local Variables
 ;; For more information see (info "(emacs) Directory Variables")
 
-((zephir-mode . ((fill-column . 120)
-		 (indent-tabs-mode . nil)))
- (c-mode . ((fill-column . 80)
-	    (c-file-style . "k&r")
-	    (tab-width . 4)
-	    (c-basic-offset . 4)
-	    (indent-tabs-mode . t))))
+((nil
+  (indent-tabs-mode . nil))
+ (zephir-mode
+  (fill-column . 120))
+ (c-mode
+  (fill-column . 80)
+  (c-file-style . "k&r")
+  (tab-width . 4)
+  (c-basic-offset . 4)
+  (indent-tabs-mode . t)
+  (flycheck-checker . c/c++-gcc)
+  (flycheck-disabled-checkers . (c/c++-clang))
+  (flycheck-gcc-language-standard . "gnu99"))
+ (php-mode
+  (fill-column . 120)
+  (c-file-style . nil)
+  (indent-tabs-mode . nil)
+  (flycheck-disabled-checkers . (php-phpmd php-phpcs))))

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 # Directories to ignore (do not add trailing '/'s, they skip symlinks).
 .zephir
 .libs
-.phpunit
 ide
 doc
 vendor
@@ -28,11 +27,13 @@ compile.log
 compile-errors.log
 
 # Test and build configurations.
-phpunit.xml
-phpcs.xml
 .php_cs
 .php_cs.cache
+.phpunit
 box.json
+phpcs.xml
+phpmd.xml
+phpunit.xml
 
 # Build artefact
 zephir.phar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 ### Fixed
 - In some cases for C "control characters" aren't properly escaped
   [#2065](https://github.com/phalcon/zephir/issues/2065)
+- Zephir ignored property visibility and has not thrown error when setting
+  private/protected properties in scope that shouldn't intened for it
+  [#2078](https://github.com/phalcon/zephir/pull/2078),
+  [phalcon/cphalcon#14810](https://github.com/phalcon/cphalcon/issues/14810),
+  [phalcon/cphalcon#14766](https://github.com/phalcon/cphalcon/issues/14766)
 
 ## [0.12.17] - 2020-02-14
 ### Fixed

--- a/Library/Backends/ZendEngine2/Backend.php
+++ b/Library/Backends/ZendEngine2/Backend.php
@@ -274,22 +274,8 @@ class Backend extends BaseBackend
         $context->codePrinter->output('zephir_concat_self('.$variable.', '.$itemVariable.');');
     }
 
-    /**
-     * {@inheritdoc}
-     *
-     * @param Variable           $variable
-     * @param CompilationContext $context
-     * @param int                $size
-     * @param bool               $print
-     *
-     * @return string
-     */
-    public function initArray(
-        Variable $variable,
-        CompilationContext $context,
-        int $size = null,
-        $print = true
-    ): string {
+    public function initArray(Variable $variable, CompilationContext $context, int $size = null)
+    {
         throw new CompilerException(
             'ZendEngine2 backend is no longer supported'
         );

--- a/Library/Backends/ZendEngine2/Backend.php
+++ b/Library/Backends/ZendEngine2/Backend.php
@@ -274,18 +274,25 @@ class Backend extends BaseBackend
         $context->codePrinter->output('zephir_concat_self('.$variable.', '.$itemVariable.');');
     }
 
-    public function initArray(Variable $variable, CompilationContext $context, $size = null, $useCodePrinter = true)
-    {
-        if (!isset($size)) {
-            $output = 'array_init('.$this->getVariableCode($variable).');';
-        } else {
-            $output = 'zephir_create_array('.$this->getVariableCode($variable).', '.$size.', 0);';
-        }
-        if ($useCodePrinter) {
-            $context->codePrinter->output($output);
-        }
-
-        return $output;
+    /**
+     * {@inheritdoc}
+     *
+     * @param Variable           $variable
+     * @param CompilationContext $context
+     * @param int                $size
+     * @param bool               $print
+     *
+     * @return string
+     */
+    public function initArray(
+        Variable $variable,
+        CompilationContext $context,
+        int $size = null,
+        $print = true
+    ): string {
+        throw new CompilerException(
+            'ZendEngine2 backend is no longer supported'
+        );
     }
 
     public function createClosure(Variable $variable, $classDefinition, CompilationContext $context)

--- a/Library/Backends/ZendEngine2/Backend.php
+++ b/Library/Backends/ZendEngine2/Backend.php
@@ -697,7 +697,17 @@ class Backend extends BaseBackend
         return $value;
     }
 
-    public function updateProperty(Variable $symbolVariable, $propertyName, $value, CompilationContext $context)
+    /**
+     * {@inheritdoc}
+     *
+     * @param Variable           $variable
+     * @param string|Variable    $property
+     * @param mixed              $value
+     * @param CompilationContext $context
+     *
+     * @return void
+     */
+    public function updateProperty(Variable $variable, $property, $value, CompilationContext $context)
     {
         throw new CompilerException(
             'ZendEngine2 backend is no longer supported'

--- a/Library/Backends/ZendEngine2/Backend.php
+++ b/Library/Backends/ZendEngine2/Backend.php
@@ -142,7 +142,7 @@ class Backend extends BaseBackend
     /**
      * {@inheritdoc}
      */
-    public function initializeVariableDefaults($variables, CompilationContext $compilationContext): string
+    public function initializeVariableDefaults(array $variables, CompilationContext $context): string
     {
         throw new CompilerException(
             'ZendEngine2 backend is no longer supported'

--- a/Library/Backends/ZendEngine3/Backend.php
+++ b/Library/Backends/ZendEngine3/Backend.php
@@ -1176,16 +1176,11 @@ class Backend extends BackendZendEngine2
      * @param Variable           $variable
      * @param CompilationContext $context
      * @param int                $size
-     * @param bool               $print
      *
-     * @return string
+     * @return void
      */
-    public function initArray(
-        Variable $variable,
-        CompilationContext $context,
-        int $size = null,
-        $print = true
-    ): string {
+    public function initArray(Variable $variable, CompilationContext $context, int $size = null)
+    {
         $code = $this->getVariableCode($variable);
 
         if (null === $size) {
@@ -1194,10 +1189,6 @@ class Backend extends BackendZendEngine2
             $output = "zephir_create_array({$code}, {$size}, 0);";
         }
 
-        if ($print) {
-            $context->codePrinter->output($output);
-        }
-
-        return $output;
+        $context->codePrinter->output($output);
     }
 }

--- a/Library/Backends/ZendEngine3/Backend.php
+++ b/Library/Backends/ZendEngine3/Backend.php
@@ -868,6 +868,21 @@ class Backend extends BackendZendEngine2
             return;
         }
 
+        /* Are we going to init default object property value? */
+        if ($context->currentMethod &&
+            preg_match('/^zephir_init_properties/', $context->currentMethod->getName())) {
+            $context->codePrinter->output(
+                sprintf(
+                    'zephir_init_property_zval(%s, ZEND_STRL("%s"), %s);',
+                    $this->getVariableCode($variable),
+                    $property,
+                    $value
+                )
+            );
+
+            return;
+        }
+
         $context->codePrinter->output(
             sprintf(
                 'zephir_update_property_zval(%s, ZEND_STRL("%s"), %s);',

--- a/Library/Backends/ZendEngine3/Backend.php
+++ b/Library/Backends/ZendEngine3/Backend.php
@@ -873,7 +873,8 @@ class Backend extends BackendZendEngine2
             preg_match('/^zephir_init_properties/', $context->currentMethod->getName())) {
             $context->codePrinter->output(
                 sprintf(
-                    'zephir_init_property_zval(%s, ZEND_STRL("%s"), %s);',
+                    'zend_update_property(Z_OBJCE_P(%s), %s, ZEND_STRL("%s"), %s);',
+                    $this->getVariableCode($variable),
                     $this->getVariableCode($variable),
                     $property,
                     $value

--- a/Library/Backends/ZendEngine3/Backend.php
+++ b/Library/Backends/ZendEngine3/Backend.php
@@ -840,17 +840,27 @@ class Backend extends BackendZendEngine2
         return $value;
     }
 
-    public function updateProperty(Variable $symbolVariable, $propertyName, $value, CompilationContext $context)
+    /**
+     * {@inheritdoc}
+     *
+     * @param Variable           $variable
+     * @param string|Variable    $property
+     * @param mixed              $value
+     * @param CompilationContext $context
+     *
+     * @return void
+     */
+    public function updateProperty(Variable $variable, $property, $value, CompilationContext $context)
     {
         // TODO(serghei): maybe optimizations as well as above
         $value = $this->resolveValue($value, $context);
 
-        if ($propertyName instanceof Variable) {
+        if ($property instanceof Variable) {
             $context->codePrinter->output(
                 sprintf(
                     'zephir_update_property_zval_zval(%s, %s, %s);',
-                    $this->getVariableCode($symbolVariable),
-                    $this->getVariableCode($propertyName),
+                    $this->getVariableCode($variable),
+                    $this->getVariableCode($property),
                     $value
                 )
             );
@@ -861,8 +871,8 @@ class Backend extends BackendZendEngine2
         $context->codePrinter->output(
             sprintf(
                 'zephir_update_property_zval(%s, ZEND_STRL("%s"), %s);',
-                $this->getVariableCode($symbolVariable),
-                $propertyName,
+                $this->getVariableCode($variable),
+                $property,
                 $value
             )
         );

--- a/Library/Backends/ZendEngine3/Backend.php
+++ b/Library/Backends/ZendEngine3/Backend.php
@@ -410,6 +410,7 @@ class Backend extends BackendZendEngine2
     {
         $codePrinter = new CodePrinter();
         $codePrinter->increaseLevel();
+
         $oldCodePrinter = $context->codePrinter;
         $context->codePrinter = $codePrinter;
 
@@ -1131,16 +1132,47 @@ class Backend extends BackendZendEngine2
      * {@inheritdoc}
      *
      * @param string             $type
-     * @param CompilationContext $compilationContext
+     * @param CompilationContext $context
      * @param bool               $isLocal
      *
      * @return Variable
      */
     public function getScalarTempVariable(
         string $type,
-        CompilationContext $compilationContext,
+        CompilationContext $context,
         $isLocal = true
     ): Variable {
-        return $compilationContext->symbolTable->getTempNonTrackedVariable($type, $compilationContext);
+        return $context->symbolTable->getTempNonTrackedVariable($type, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param Variable           $variable
+     * @param CompilationContext $context
+     * @param int                $size
+     * @param bool               $print
+     *
+     * @return string
+     */
+    public function initArray(
+        Variable $variable,
+        CompilationContext $context,
+        int $size = null,
+        $print = true
+    ): string {
+        $code = $this->getVariableCode($variable);
+
+        if (null === $size) {
+            $output = "array_init({$code});";
+        } else {
+            $output = "zephir_create_array({$code}, {$size}, 0);";
+        }
+
+        if ($print) {
+            $context->codePrinter->output($output);
+        }
+
+        return $output;
     }
 }

--- a/Library/Backends/ZendEngine3/VariablesManager.php
+++ b/Library/Backends/ZendEngine3/VariablesManager.php
@@ -1,0 +1,218 @@
+<?php
+
+/*
+ * This file is part of the Zephir.
+ *
+ * (c) Phalcon Team <team@zephir-lang.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Zephir\Backends\ZendEngine3;
+
+use Zephir\CompilationContext as Context;
+use Zephir\Exception\CompilerException as Exception;
+use Zephir\Types;
+use Zephir\Variable;
+
+class VariablesManager
+{
+    const RESERVED_NAMES = [
+        'this_ptr',
+        'return_value',
+        'return_value_ptr',
+    ];
+
+    /**
+     * Initialize variable defaults.
+     *
+     * Meant for Backend::initializeVariableDefaults.
+     * Shouldn't called directly.
+     *
+     * @param Variable $variable
+     * @param array    $value
+     * @param Context  $context
+     *
+     * @return void
+     */
+    public function initializeDefaults(Variable $variable, array $value, Context $context)
+    {
+        switch ($variable->getType()) {
+            case Types::T_VARIABLE:
+                $this->initDynamicVar($variable, $value, $context);
+                break;
+            case Types::T_STRING:
+                $this->initStringVar($variable, $value, $context);
+                break;
+            case Types::T_ARRAY:
+                $this->initArrayVar($variable, $value, $context);
+                break;
+        }
+    }
+
+    /**
+     * Initialize 'dynamic' variables with default values.
+     * Meant for VariablesManager::initializeDefaults.
+     *
+     * @param Variable $variable
+     * @param array    $value
+     * @param Context  $context
+     *
+     * @return void
+     */
+    private function initDynamicVar(Variable $variable, array $value, Context $context)
+    {
+        /* These ones are system variables, do not add default values.
+           Also see: https://github.com/phalcon/zephir/issues/1660 */
+        if (\in_array($variable->getName(), self::RESERVED_NAMES, true)) {
+            return;
+        }
+
+        $context->symbolTable->mustGrownStack(true);
+        $context->backend->initVar($variable, $context);
+
+        switch ($value['type']) {
+            case Types::T_INT:
+            case Types::T_UINT:
+            case Types::T_LONG:
+            case Types::T_ULONG:
+                $context->backend->assignLong($variable, $value['value'], $context);
+                break;
+
+            case Types::T_BOOL:
+                $context->backend->assignBool($variable, $value['value'], $context);
+                break;
+
+            case Types::T_CHAR:
+            case Types::T_UCHAR:
+                $this->validateCharValue($value);
+                $context->backend->assignLong($variable, "'".$value['value']."'", $context);
+                break;
+
+            case Types::T_NULL:
+                $context->backend->assignNull($variable, $context);
+                break;
+
+            case Types::T_DOUBLE:
+                $context->backend->assignDouble($variable, $value['value'], $context);
+                break;
+
+            case Types::T_STRING:
+                $string = add_slashes($value['value']);
+                $context->backend->assignString($variable, $string, $context);
+                break;
+
+            case Types::T_ARRAY:
+            case 'empty-array':
+                $context->backend->initArray($variable, $context);
+                break;
+
+            default:
+                throw $this->invalidDefaulTypeException($variable, $value);
+        }
+    }
+
+    /**
+     * Initialize 'string' variables with default values.
+     * Meant for VariablesManager::initializeDefaults.
+     *
+     * @param Variable $variable
+     * @param array    $value
+     * @param Context  $context
+     *
+     * @return void
+     */
+    private function initStringVar(Variable $variable, array $value, Context $context)
+    {
+        $context->symbolTable->mustGrownStack(true);
+        $context->backend->initVar($variable, $context);
+
+        switch ($value['type']) {
+            case Types::T_STRING:
+                $string = add_slashes($value['value']);
+                $context->backend->assignString($variable, $string, $context);
+                break;
+
+            case Types::T_NULL:
+                $context->backend->assignString($variable, null, $context);
+                break;
+
+            default:
+                throw $this->invalidDefaulTypeException($variable, $value);
+        }
+    }
+
+    /**
+     * Initialize 'array' variables with default values.
+     * Meant for VariablesManager::initializeDefaults.
+     *
+     * @param Variable $variable
+     * @param array    $value
+     * @param Context  $context
+     *
+     * @return void
+     */
+    private function initArrayVar(Variable $variable, array $value, Context $context)
+    {
+        $context->symbolTable->mustGrownStack(true);
+        $context->backend->initVar($variable, $context);
+
+        switch ($value['type']) {
+            case Types::T_NULL:
+                $context->backend->assignNull($variable, $context);
+                break;
+
+            case Types::T_ARRAY:
+            case 'empty-array':
+                $context->backend->initArray($variable, $context);
+                break;
+
+            default:
+                throw $this->invalidDefaulTypeException($variable, $value);
+        }
+    }
+
+    /**
+     * Create a compiler exception with 'Invalid default type' message.
+     *
+     * @param Variable $variable
+     * @param array    $value
+     *
+     * @return Exception
+     */
+    private function invalidDefaulTypeException(Variable $variable, array $value): Exception
+    {
+        new Exception(
+            sprintf(
+                'Invalid default type: %s for data type: %s',
+                $value['type'],
+                $variable->getType()
+            ),
+            $variable->getOriginal()
+        );
+    }
+
+    /**
+     * Validate 'char' value type.
+     *
+     * @param array $value
+     *
+     * @throws Exception
+     *
+     * @return void
+     */
+    private function validateCharValue(array $value)
+    {
+        if (\strlen($value['value']) > 2) {
+            throw new Exception(
+                sprintf(
+                    "Invalid char literal: '%s%s'",
+                    substr($value['value'], 0, 10),
+                    \strlen($value['value']) > 10 ? '...' : ''
+                ),
+                $value
+            );
+        }
+    }
+}

--- a/Library/BaseBackend.php
+++ b/Library/BaseBackend.php
@@ -128,11 +128,11 @@ abstract class BaseBackend implements FcallAwareInterface
      * Initialize variable defaults.
      *
      * @param Variable[]         $variables
-     * @param CompilationContext $compilationContext
+     * @param CompilationContext $context
      *
      * @return string
      */
-    abstract public function initializeVariableDefaults($variables, CompilationContext $compilationContext): string;
+    abstract public function initializeVariableDefaults(array $variables, CompilationContext $context): string;
 
     abstract public function generateInitCode(&$groupVariables, $type, $pointer, Variable $variable);
 

--- a/Library/BaseBackend.php
+++ b/Library/BaseBackend.php
@@ -198,7 +198,23 @@ abstract class BaseBackend implements FcallAwareInterface
 
     abstract public function returnString($value, CompilationContext $context, $useCodePrinter = true);
 
-    abstract public function initArray(Variable $variable, CompilationContext $context, $size = null, $useCodePrinter = true);
+    /**
+     * Generate the code to initialize array typed variable.
+     * The optional $print argument maybe used to print result using code printer.
+     *
+     * @param Variable           $variable
+     * @param CompilationContext $context
+     * @param int                $size
+     * @param bool               $print
+     *
+     * @return string
+     */
+    abstract public function initArray(
+        Variable $variable,
+        CompilationContext $context,
+        int $size = null,
+        $print = true
+    ): string;
 
     abstract public function createClosure(Variable $variable, $classDefinition, CompilationContext $context);
 

--- a/Library/BaseBackend.php
+++ b/Library/BaseBackend.php
@@ -236,7 +236,19 @@ abstract class BaseBackend implements FcallAwareInterface
 
     abstract public function fetchStaticProperty(Variable $symbolVariable, $classDefinition, $property, $readOnly, CompilationContext $context);
 
-    abstract public function updateProperty(Variable $symbolVariable, $propertyName, $value, CompilationContext $compilationContext);
+    /**
+     * Update object property.
+     *
+     * object->property = value
+     *
+     * @param Variable           $variable
+     * @param string|Variable    $property
+     * @param mixed              $value
+     * @param CompilationContext $context
+     *
+     * @return void
+     */
+    abstract public function updateProperty(Variable $variable, $property, $value, CompilationContext $context);
 
     abstract public function updateStaticProperty($classEntry, $property, $value, CompilationContext $context);
 

--- a/Library/BaseBackend.php
+++ b/Library/BaseBackend.php
@@ -200,21 +200,14 @@ abstract class BaseBackend implements FcallAwareInterface
 
     /**
      * Generate the code to initialize array typed variable.
-     * The optional $print argument maybe used to print result using code printer.
      *
      * @param Variable           $variable
      * @param CompilationContext $context
      * @param int                $size
-     * @param bool               $print
      *
-     * @return string
+     * @return void
      */
-    abstract public function initArray(
-        Variable $variable,
-        CompilationContext $context,
-        int $size = null,
-        $print = true
-    ): string;
+    abstract public function initArray(Variable $variable, CompilationContext $context, int $size = null);
 
     abstract public function createClosure(Variable $variable, $classDefinition, CompilationContext $context);
 

--- a/Library/ClassMethod.php
+++ b/Library/ClassMethod.php
@@ -1859,11 +1859,7 @@ class ClassMethod
          * Compile the block of statements if any
          */
         if (\is_object($this->statements)) {
-            if ($this->hasModifier('static')) {
-                $compilationContext->staticContext = true;
-            } else {
-                $compilationContext->staticContext = false;
-            }
+            $compilationContext->staticContext = $this->hasModifier('static');
 
             /*
              * Compile the statements block as a 'root' branch
@@ -1874,7 +1870,10 @@ class ClassMethod
         /**
          * Initialize variable default values.
          */
-        $initVarCode = $compilationContext->backend->initializeVariableDefaults($symbolTable->getVariables(), $compilationContext);
+        $initVarCode = $compilationContext->backend->initializeVariableDefaults(
+            $symbolTable->getVariables(),
+            $compilationContext
+        );
 
         /**
          * Fetch parameters from vm-top.

--- a/Library/ClassMethod.php
+++ b/Library/ClassMethod.php
@@ -1867,7 +1867,7 @@ class ClassMethod
             $this->statements->compile($compilationContext, false, Branch::TYPE_ROOT);
         }
 
-        /**
+        /*
          * Initialize variable default values.
          */
         $initVarCode = $compilationContext->backend->initializeVariableDefaults(
@@ -1875,7 +1875,7 @@ class ClassMethod
             $compilationContext
         );
 
-        /**
+        /*
          * Fetch parameters from vm-top.
          */
         $initCode = '';
@@ -2098,6 +2098,7 @@ class ClassMethod
         $codePrinter->preOutput($code);
 
         $compilationContext->headersManager->add('kernel/object');
+
         /*
          * Fetch used superglobals
          */
@@ -2135,7 +2136,7 @@ class ClassMethod
             $codePrinter->preOutput("\t".'ZEPHIR_MM_GROW();');
         }
 
-        /**
+        /*
          * Check if there are unused variables.
          */
         $usedVariables = [];
@@ -2204,13 +2205,22 @@ class ClassMethod
             $codePrinter->preOutputBlankLine();
         }
 
-        /**
+        /*
          * Generate the variable definition for variables used.
          */
-        $initCode = "\t".implode(PHP_EOL."\t", $compilationContext->backend->declareVariables($this, $usedVariables, $compilationContext));
-        if ($initCode) {
-            $codePrinter->preOutput($initCode);
-        }
+        $initCode = sprintf(
+            "\t%s",
+            implode(
+                PHP_EOL."\t",
+                $compilationContext->backend->declareVariables(
+                    $this,
+                    $usedVariables,
+                    $compilationContext
+                )
+            )
+        );
+
+        $codePrinter->preOutput($initCode);
 
         /*
          * Finalize the method compilation

--- a/Library/CodePrinter.php
+++ b/Library/CodePrinter.php
@@ -202,9 +202,9 @@ class CodePrinter
      *
      * @return string
      */
-    public function getOutput()
+    public function getOutput(): string
     {
-        return $this->code;
+        return (string) $this->code;
     }
 
     /**

--- a/Library/Support/PropertyAccessor.php
+++ b/Library/Support/PropertyAccessor.php
@@ -41,12 +41,12 @@ trait PropertyAccessor
             return $this->$getter();
         } elseif (method_exists($this, $setter)) {
             throw new InvalidCallException(
-                sprintf('Getting write-only property: %s::%s', \get_class($this), $name)
+                sprintf('Getting write-only property: %s::%s', static::class, $name)
             );
         }
 
         throw new UnknownPropertyException(
-            sprintf('Getting unknown property: %s::%s', \get_class($this), $name)
+            sprintf('Getting unknown property: %s::%s', static::class, $name)
         );
     }
 }

--- a/Library/Variable.php
+++ b/Library/Variable.php
@@ -558,19 +558,19 @@ class Variable implements TypeAwareInterface
     /**
      * Checks if the variable has any of the passed dynamic.
      *
-     * @param mixed $types
+     * @param array|string $types
      *
      * @return bool
      */
     public function hasAnyDynamicType($types)
     {
         if (\is_string($types)) {
-            return isset($this->dynamicTypes[$types]);
-        } else {
-            foreach ($types as $type) {
-                if (isset($this->dynamicTypes[$type])) {
-                    return true;
-                }
+            $types = [$types];
+        }
+
+        foreach ($types as $type) {
+            if (isset($this->dynamicTypes[$type])) {
+                return true;
             }
         }
 

--- a/Library/Zephir.php
+++ b/Library/Zephir.php
@@ -16,7 +16,7 @@ namespace Zephir;
  */
 final class Zephir
 {
-    const VERSION = '0.12.17-$Id$';
+    const VERSION = '0.12.18-$Id$';
 
     const LOGO = <<<'ASCII'
  _____              __    _

--- a/kernels/ZendEngine3/fcall.h
+++ b/kernels/ZendEngine3/fcall.h
@@ -114,12 +114,13 @@ typedef enum _zephir_call_type {
 		new_execute_data.func = NULL; \
 		execute_data = EG(current_execute_data) = &new_execute_data; \
 	}
-
+// TODO(serghei): Deprecated
 #define ZEPHIR_RESTORE_SCOPE() \
 	EG(scope) = old_scope; \
 	execute_data = old_call; \
 	EG(current_execute_data) = old_execute_data;
 
+// TODO(serghei): Deprecated
 #define ZEPHIR_SET_SCOPE(_scope, _scope_called) \
 	EG(scope) = _scope; \
 	EG(current_execute_data)->called_scope = _scope_called;

--- a/kernels/ZendEngine3/main.h
+++ b/kernels/ZendEngine3/main.h
@@ -22,7 +22,7 @@ extern zend_string* i_parent;
 extern zend_string* i_static;
 extern zend_string* i_self;
 
-/** Main macros */
+/* Main macros */
 #define PH_DEBUG 0
 
 #define PH_NOISY 256

--- a/kernels/ZendEngine3/object.c
+++ b/kernels/ZendEngine3/object.c
@@ -650,7 +650,7 @@ int zephir_init_property_zval(zval *object, const char *property_name,
 int zephir_update_property_zval(zval *object, const char *property_name,
 								unsigned int property_length, zval *value)
 {
-	zend_class_entry *ce, *scope;
+	zend_class_entry *ce;
 	zval property, sep_value;
 
 	if (Z_TYPE_P(object) != IS_OBJECT) {
@@ -659,9 +659,6 @@ int zephir_update_property_zval(zval *object, const char *property_name,
 						 property_name);
 		return FAILURE;
 	}
-
-	/* Backup current scope */
-	scope = zephir_get_scope(0);
 
 	/* Is this function was called from within caller scope */
 	ce = zend_get_called_scope(EG(current_execute_data));
@@ -673,9 +670,6 @@ int zephir_update_property_zval(zval *object, const char *property_name,
 	if (ce->parent) {
 		ce = zephir_lookup_class_ce(ce, property_name, property_length);
 	}
-
-	/* Use caller's scope */
-	zephir_set_scope(ce);
 
 	if (!Z_OBJ_HT_P(object)->write_property) {
 		const char *class_name;
@@ -701,9 +695,6 @@ int zephir_update_property_zval(zval *object, const char *property_name,
 	   so no Z_TRY_ADDREF_P(value) is necessary */
 	Z_OBJ_HT_P(object)->write_property(object, &property, &sep_value, 0);
 	zval_ptr_dtor(&property);
-
-	/* Restore original scope */
-	zephir_set_scope(scope);
 
 	return SUCCESS;
 }

--- a/kernels/ZendEngine3/object.c
+++ b/kernels/ZendEngine3/object.c
@@ -463,51 +463,38 @@ zend_class_entry *zephir_lookup_class_ce(zend_class_entry *ce,
 
 
 /**
- * Reads a property from an object
+ * Checks whether obj is an object and reads a property from this object
  */
-int zephir_read_property(zval *result, zval *object, const char *property_name, uint32_t property_length, int flags)
+int zephir_read_property(zval *result, zval *object, const char *property_name,
+						 uint32_t property_length, int flags)
 {
-	zval property;
-	zend_class_entry *ce, *old_scope;
-	zval tmp;
+	zval property, tmp;
 	zval *res;
 
 	ZVAL_UNDEF(&tmp);
 
 	if (Z_TYPE_P(object) != IS_OBJECT) {
-
 		if ((flags & PH_NOISY) == PH_NOISY) {
-			php_error_docref(NULL, E_NOTICE, "Trying to get property \"%s\" of non-object", property_name);
+			php_error_docref(NULL, E_NOTICE,
+							 "Trying to get property '%s' of non-object",
+							 property_name);
 		}
 
 		ZVAL_NULL(result);
 		return FAILURE;
 	}
 
-	ce = Z_OBJCE_P(object);
-
-	if (ce->parent) {
-		ce = zephir_lookup_class_ce(ce, property_name, property_length);
-	}
-
-#if PHP_VERSION_ID >= 70100
-	old_scope = EG(fake_scope);
-	EG(fake_scope) = ce;
-#else
-	old_scope = EG(scope);
-	EG(scope) = ce;
-#endif
-
 	if (!Z_OBJ_HT_P(object)->read_property) {
-		const char *class_name;
-
-		class_name = Z_OBJ_P(object) ? ZSTR_VAL(Z_OBJCE_P(object)->name) : "";
-		zend_error(E_CORE_ERROR, "Property %s of class %s cannot be read", property_name, class_name);
+		zend_error(E_CORE_ERROR,
+				   "Property %s of class %s cannot be read",
+				   property_name, ZSTR_VAL(Z_OBJCE_P(object)->name));
 	}
 
 	ZVAL_STRINGL(&property, property_name, property_length);
 
-	res = Z_OBJ_HT_P(object)->read_property(object, &property, flags ? BP_VAR_IS : BP_VAR_R, NULL, &tmp);
+	res = Z_OBJ_HT_P(object)->read_property(object, &property,
+											flags ? BP_VAR_IS : BP_VAR_R,
+											NULL, &tmp);
 	if ((flags & PH_READONLY) == PH_READONLY) {
 		ZVAL_COPY_VALUE(result, res);
 	} else {
@@ -516,11 +503,6 @@ int zephir_read_property(zval *result, zval *object, const char *property_name, 
 
 	zval_ptr_dtor(&property);
 
-#if PHP_VERSION_ID >= 70100
-	EG(fake_scope) = old_scope;
-#else
-	EG(scope) = old_scope;
-#endif
 	return SUCCESS;
 }
 
@@ -614,12 +596,9 @@ int zephir_init_property_zval(zval *object, const char *property_name,
 	zephir_set_scope(ce);
 
 	if (!Z_OBJ_HT_P(object)->write_property) {
-		const char *class_name;
-
-		class_name = Z_OBJ_P(object) ? ZSTR_VAL(Z_OBJCE_P(object)->name) : "";
 		zend_error(E_CORE_ERROR,
 				   "Property %s of class %s cannot be updated",
-				   property_name, class_name);
+				   property_name, ZSTR_VAL(Z_OBJCE_P(object)->name));
 	}
 
 	ZVAL_STRINGL(&property, property_name, property_length);
@@ -650,7 +629,6 @@ int zephir_init_property_zval(zval *object, const char *property_name,
 int zephir_update_property_zval(zval *object, const char *property_name,
 								unsigned int property_length, zval *value)
 {
-	zend_class_entry *ce, *scope;
 	zval property, sep_value;
 
 	if (Z_TYPE_P(object) != IS_OBJECT) {
@@ -660,30 +638,10 @@ int zephir_update_property_zval(zval *object, const char *property_name,
 		return FAILURE;
 	}
 
-	/* Is this function was called from within caller scope */
-	ce = zend_get_called_scope(EG(current_execute_data));
-	if (UNEXPECTED(!ce)) {
-		ce = Z_OBJCE_P(object);
-	}
-
-	/* Backup current scope */
-	scope = zephir_get_scope(0);
-
-	/* Lookup real property owner */
-	if (ce->parent) {
-		ce = zephir_lookup_class_ce(ce, property_name, property_length);
-	}
-
-	/* Use caller's scope */
-	zephir_set_scope(ce);
-
 	if (!Z_OBJ_HT_P(object)->write_property) {
-		const char *class_name;
-
-		class_name = Z_OBJ_P(object) ? ZSTR_VAL(Z_OBJCE_P(object)->name) : "";
 		zend_error(E_CORE_ERROR,
 				   "Property %s of class %s cannot be updated",
-				   property_name, class_name);
+				   property_name, ZSTR_VAL(Z_OBJCE_P(object)->name));
 	}
 
 	ZVAL_STRINGL(&property, property_name, property_length);
@@ -701,9 +659,6 @@ int zephir_update_property_zval(zval *object, const char *property_name,
 	   so no Z_TRY_ADDREF_P(value) is necessary */
 	Z_OBJ_HT_P(object)->write_property(object, &property, &sep_value, 0);
 	zval_ptr_dtor(&property);
-
-	/* Restore original scope */
-	zephir_set_scope(scope);
 
 	return SUCCESS;
 }

--- a/kernels/ZendEngine3/object.c
+++ b/kernels/ZendEngine3/object.c
@@ -436,8 +436,10 @@ int zephir_isset_property_zval(zval *object, const zval *property)
 	return 0;
 }
 
-static inline zend_class_entry *zephir_lookup_class_ce(zend_class_entry *ce, const char *property_name, unsigned int property_length)
-{
+static inline
+zend_class_entry *zephir_lookup_class_ce(zend_class_entry *ce,
+										 const char *property_name,
+										 unsigned int property_length) {
 	zend_class_entry *original_ce = ce;
 	zend_property_info *info;
 
@@ -455,6 +457,7 @@ static inline zend_class_entry *zephir_lookup_class_ce(zend_class_entry *ce, con
 #endif
 		ce = ce->parent;
 	}
+
 	return original_ce;
 }
 
@@ -580,40 +583,43 @@ int zephir_read_property_zval(zval *result, zval *object, zval *property, int fl
 }
 
 /**
- * Checks whether obj is an object and updates property with another zval
+ * Checks whether obj is an object and updates property with another zval.
+ *
+ * This function is intended to set initial values to object properties.
+ * Do not use it for a regular property updating.
  */
-int zephir_update_property_zval(zval *object, const char *property_name, unsigned int property_length, zval *value)
+int zephir_init_property_zval(zval *object, const char *property_name,
+								unsigned int property_length, zval *value)
 {
-	zend_class_entry *ce, *old_scope;
+	zend_class_entry *ce, *scope;
 	zval property, sep_value;
 
-#if PHP_VERSION_ID >= 70100
-	old_scope = EG(fake_scope);
-#else
-	old_scope = EG(scope);
-#endif
-
 	if (Z_TYPE_P(object) != IS_OBJECT) {
-		php_error_docref(NULL, E_WARNING, "Attempt to assign property of non-object");
+		php_error_docref(NULL, E_WARNING,
+						 "Attempt to assign property '%s' of non-object",
+						 property_name);
 		return FAILURE;
 	}
 
+	/* Backup current scope */
+	scope = zephir_get_scope(0);
 	ce = Z_OBJCE_P(object);
+
+	/* Lookup real property owner */
 	if (ce->parent) {
 		ce = zephir_lookup_class_ce(ce, property_name, property_length);
 	}
 
-#if PHP_VERSION_ID >= 70100
-	EG(fake_scope) = ce;
-#else
-	EG(scope) = ce;
-#endif
+	/* Use caller's scope */
+	zephir_set_scope(ce);
 
 	if (!Z_OBJ_HT_P(object)->write_property) {
 		const char *class_name;
 
 		class_name = Z_OBJ_P(object) ? ZSTR_VAL(Z_OBJCE_P(object)->name) : "";
-		zend_error(E_CORE_ERROR, "Property %s of class %s cannot be updated", property_name, class_name);
+		zend_error(E_CORE_ERROR,
+				   "Property %s of class %s cannot be updated",
+				   property_name, class_name);
 	}
 
 	ZVAL_STRINGL(&property, property_name, property_length);
@@ -627,15 +633,78 @@ int zephir_update_property_zval(zval *object, const char *property_name, unsigne
 		}
 	}
 
-	/* write_property will add 1 to refcount, so no Z_TRY_ADDREF_P(value); is necessary */
+	/* write_property will add 1 to refcount,
+	   so no Z_TRY_ADDREF_P(value) is necessary */
 	Z_OBJ_HT_P(object)->write_property(object, &property, &sep_value, 0);
 	zval_ptr_dtor(&property);
 
-#if PHP_VERSION_ID >= 70100
-	EG(fake_scope) = old_scope;
-#else
-	EG(scope) = old_scope;
-#endif
+	/* Restore original scope */
+	zephir_set_scope(scope);
+
+	return SUCCESS;
+}
+
+/**
+ * Checks whether obj is an object and updates property with another zval
+ */
+int zephir_update_property_zval(zval *object, const char *property_name,
+								unsigned int property_length, zval *value)
+{
+	zend_class_entry *ce, *scope;
+	zval property, sep_value;
+
+	if (Z_TYPE_P(object) != IS_OBJECT) {
+		php_error_docref(NULL, E_WARNING,
+						 "Attempt to assign property '%s' of non-object",
+						 property_name);
+		return FAILURE;
+	}
+
+	/* Backup current scope */
+	scope = zephir_get_scope(0);
+
+	/* Is this function was called from within caller scope */
+	ce = zend_get_called_scope(EG(current_execute_data));
+	if (UNEXPECTED(!ce)) {
+		ce = Z_OBJCE_P(object);
+	}
+
+	/* Lookup real property owner */
+	if (ce->parent) {
+		ce = zephir_lookup_class_ce(ce, property_name, property_length);
+	}
+
+	/* Use caller's scope */
+	zephir_set_scope(ce);
+
+	if (!Z_OBJ_HT_P(object)->write_property) {
+		const char *class_name;
+
+		class_name = Z_OBJ_P(object) ? ZSTR_VAL(Z_OBJCE_P(object)->name) : "";
+		zend_error(E_CORE_ERROR,
+				   "Property %s of class %s cannot be updated",
+				   property_name, class_name);
+	}
+
+	ZVAL_STRINGL(&property, property_name, property_length);
+	ZVAL_COPY_VALUE(&sep_value, value);
+	if (Z_TYPE(sep_value) == IS_ARRAY) {
+		ZVAL_ARR(&sep_value, zend_array_dup(Z_ARR(sep_value)));
+		if (EXPECTED(!(GC_FLAGS(Z_ARRVAL(sep_value)) & IS_ARRAY_IMMUTABLE))) {
+			if (UNEXPECTED(GC_REFCOUNT(Z_ARR(sep_value)) > 0)) {
+				GC_DELREF(Z_ARR(sep_value));
+			}
+		}
+	}
+
+	/* write_property will add 1 to refcount,
+	   so no Z_TRY_ADDREF_P(value) is necessary */
+	Z_OBJ_HT_P(object)->write_property(object, &property, &sep_value, 0);
+	zval_ptr_dtor(&property);
+
+	/* Restore original scope */
+	zephir_set_scope(scope);
+
 	return SUCCESS;
 }
 

--- a/kernels/ZendEngine3/object.h
+++ b/kernels/ZendEngine3/object.h
@@ -18,6 +18,15 @@
 #include "kernel/globals.h"
 #include "kernel/main.h"
 
+/* Working with scopes */
+#if PHP_VERSION_ID >= 70100
+# define zephir_get_scope(e) ((e) ? zend_get_executed_scope() : EG(fake_scope))
+# define zephir_set_scope(s) EG(fake_scope) = (s)
+#else
+# define zephir_get_scope(e) EG(scope)
+# define zephir_set_scope(s) EG(scope) = (s)
+#endif
+
 /** Class Retrieving/Checking */
 int zephir_class_exists(zval *class_name, int autoload);
 int zephir_interface_exists(zval *interface_name, int autoload);
@@ -49,6 +58,7 @@ int zephir_fetch_property(zval *result, zval *object, const char *property_name,
 int zephir_fetch_property_zval(zval *result, zval *object, zval *property, int silent);
 
 /** Updating properties */
+int zephir_init_property_zval(zval *obj, const char *property_name, unsigned int property_length, zval *value);
 int zephir_update_property_zval(zval *obj, const char *property_name, unsigned int property_length, zval *value);
 int zephir_update_property_zval_zval(zval *obj, zval *property, zval *value);
 

--- a/kernels/ZendEngine3/object.h
+++ b/kernels/ZendEngine3/object.h
@@ -58,7 +58,6 @@ int zephir_fetch_property(zval *result, zval *object, const char *property_name,
 int zephir_fetch_property_zval(zval *result, zval *object, zval *property, int silent);
 
 /** Updating properties */
-int zephir_init_property_zval(zval *obj, const char *property_name, unsigned int property_length, zval *value);
 int zephir_update_property_zval(zval *obj, const char *property_name, unsigned int property_length, zval *value);
 int zephir_update_property_zval_zval(zval *obj, zval *property, zval *value);
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -39,6 +39,14 @@
         on the command line will ignore all file tags.
     -->
     <file>Library</file>
+
     <!-- file>unit-tests/Extension</file -->
     <!-- file>unit-tests/Zephir</file -->
+
+    <!--
+        Hard-code ignore patterns directly into custom standard
+        so we don't have to specify the patterns on the command line.
+    -->
+    <exclude-pattern>prototypes/*</exclude-pattern>
+    <exclude-pattern>unit-tests/fixtures/*</exclude-pattern>
 </ruleset>

--- a/phpmd.xml.dist
+++ b/phpmd.xml.dist
@@ -15,7 +15,12 @@
     <exclude-pattern>vendor/*</exclude-pattern>
 
     <!-- Code Size -->
-    <rule ref="rulesets/codesize.xml/CyclomaticComplexity"/>
+    <rule ref="rulesets/codesize.xml/CyclomaticComplexity">
+      <priority>1</priority>
+      <properties>
+        <property name="reportLevel" value="15"/>
+      </properties>
+    </rule>
     <rule ref="rulesets/codesize.xml/NPathComplexity"/>
     <rule ref="rulesets/codesize.xml/ExcessiveMethodLength"/>
     <rule ref="rulesets/codesize.xml/ExcessiveClassLength"/>

--- a/prototypes/mongo.php
+++ b/prototypes/mongo.php
@@ -9,70 +9,68 @@
  * the LICENSE file that was distributed with this source code.
  */
 
-namespace {
-    if (!class_exists('MongoRegex', false)) {
-        class MongoRegex
+if (!class_exists('MongoRegex', false)) {
+    class MongoRegex
+    {
+    }
+}
+
+if (!class_exists('MongoDate', false)) {
+    class MongoDate
+    {
+    }
+}
+
+if (!class_exists('MongoId', false)) {
+    class MongoId
+    {
+    }
+}
+
+if (!class_exists('MongoDB', false)) {
+    class MongoDB
+    {
+        const PROFILING_OFF = 0;
+        const PROFILING_SLOW = 1;
+        const PROFILING_ON = 2;
+
+        /**
+         * Creates a new database.
+         *
+         * @see https://www.php.net/manual/en/mongodb.construct.php
+         *
+         * @param MongoClient $conn
+         * @param string      $name
+         */
+        public function __construct(MongoClient $conn, $name)
         {
         }
     }
+}
 
-    if (!class_exists('MongoDate', false)) {
-        class MongoDate
+if (!class_exists('MongoClient', false)) {
+    class MongoClient
+    {
+        const VERSION = '';
+        const DEFAULT_HOST = 'localhost';
+        const DEFAULT_PORT = 27017;
+        const RP_PRIMARY = 'primary';
+        const RP_PRIMARY_PREFERRED = 'primaryPreferred';
+        const RP_SECONDARY = 'secondary';
+        const RP_SECONDARY_PREFERRED = 'secondaryPreferred';
+        const RP_NEAREST = 'nearest';
+
+        /**
+         * Gets a database.
+         *
+         * @see https://www.php.net/manual/en/mongoclient.selectdb.php
+         *
+         * @param string $name
+         *
+         * @return MongoDB
+         */
+        public function selectDB($name)
         {
-        }
-    }
-
-    if (!class_exists('MongoId', false)) {
-        class MongoId
-        {
-        }
-    }
-
-    if (!class_exists('MongoDB', false)) {
-        class MongoDB
-        {
-            const PROFILING_OFF = 0;
-            const PROFILING_SLOW = 1;
-            const PROFILING_ON = 2;
-
-            /**
-             * Creates a new database.
-             *
-             * @see https://www.php.net/manual/en/mongodb.construct.php
-             *
-             * @param MongoClient $conn
-             * @param string      $name
-             */
-            public function __construct(MongoClient $conn, $name)
-            {
-            }
-        }
-    }
-
-    if (!class_exists('MongoClient', false)) {
-        class MongoClient
-        {
-            const VERSION = '';
-            const DEFAULT_HOST = 'localhost';
-            const DEFAULT_PORT = 27017;
-            const RP_PRIMARY = 'primary';
-            const RP_PRIMARY_PREFERRED = 'primaryPreferred';
-            const RP_SECONDARY = 'secondary';
-            const RP_SECONDARY_PREFERRED = 'secondaryPreferred';
-            const RP_NEAREST = 'nearest';
-
-            /**
-             * Gets a database.
-             *
-             * @see https://www.php.net/manual/en/mongoclient.selectdb.php
-             *
-             * @param string $name
-             *
-             * @return MongoDB
-             */
-            public function selectDB($name)
-            {
-            }
         }
     }
 }

--- a/prototypes/mongodb.php
+++ b/prototypes/mongodb.php
@@ -11,61 +11,61 @@
  * the LICENSE file that was distributed with this source code.
  */
 
-namespace MongoDB\Driver {
-    if (!class_exists('MongoDB\Driver\Manager', false)) {
-        class mongodb
+namespace MongoDB\Driver;
+
+if (!class_exists('MongoDB\Driver\Manager', false)) {
+    class mongodb
+    {
+        public function __construct($uri = 'mongodb://127.0.0.1/', array $options = [], array $driverOptions = [])
         {
-            public function __construct($uri = 'mongodb://127.0.0.1/', array $options = [], array $driverOptions = [])
-            {
-            }
+        }
 
-            public function executeQuery($namespace, $query, $readPreference)
-            {
-            }
+        public function executeQuery($namespace, $query, $readPreference)
+        {
+        }
 
-            public function executeBulkWrite($namespace, $bulk, $writeConcern)
-            {
-            }
+        public function executeBulkWrite($namespace, $bulk, $writeConcern)
+        {
+        }
 
-            public function executeCommand($db, $command, $readPreference)
-            {
-            }
+        public function executeCommand($db, $command, $readPreference)
+        {
+        }
 
-            public function getServers()
-            {
-            }
+        public function getServers()
+        {
+        }
 
-            public function selectServer($readPreference)
-            {
-            }
+        public function selectServer($readPreference)
+        {
+        }
 
-            public function executeReadCommand($db, $command, array $options = [])
-            {
-            }
+        public function executeReadCommand($db, $command, array $options = [])
+        {
+        }
 
-            public function executeReadWriteCommand($db, $command, array $options = [])
-            {
-            }
+        public function executeReadWriteCommand($db, $command, array $options = [])
+        {
+        }
 
-            public function executeWriteCommand($db, $command, array $options = [])
-            {
-            }
+        public function executeWriteCommand($db, $command, array $options = [])
+        {
+        }
 
-            public function getReadConcern()
-            {
-            }
+        public function getReadConcern()
+        {
+        }
 
-            public function getReadPreference()
-            {
-            }
+        public function getReadPreference()
+        {
+        }
 
-            public function getWriteConcern()
-            {
-            }
+        public function getWriteConcern()
+        {
+        }
 
-            public function startSession(array $options = [])
-            {
-            }
+        public function startSession(array $options = [])
+        {
         }
     }
 }

--- a/test/oo/scopes/abstractclass.zep
+++ b/test/oo/scopes/abstractclass.zep
@@ -1,0 +1,24 @@
+namespace Test\Oo\Scopes;
+
+abstract class AbstractClass
+{
+    private privateProperty2 = "private2";
+    protected protectedProperty2 = "protected2";
+
+    public function setProperty(string name, var value) -> var
+    {
+        let this->{name} = value;
+
+        return this;
+    }
+
+    public function getPrivateProperty2() -> var
+    {
+        return this->privateProperty2;
+    }
+
+    public function getProtectedProperty2() -> var
+    {
+        return this->protectedProperty2;
+    }
+}

--- a/test/oo/scopes/abstractclassmagic.zep
+++ b/test/oo/scopes/abstractclassmagic.zep
@@ -1,0 +1,20 @@
+namespace Test\Oo\Scopes;
+
+abstract class AbstractClassMagic
+{
+    public setCount = 0;
+    private privateProperty = "private";
+    protected protectedProperty = "protected";
+    public publicProperty = "public";
+
+    public function __set(string name, var value) -> void
+    {
+        let this->{name} = value;
+        let this->setCount = this->setCount + 1;
+    }
+
+    public function __get(string name) -> var
+    {
+        return this->{name};
+    }
+}

--- a/test/oo/scopes/hasprivatemethod.zep
+++ b/test/oo/scopes/hasprivatemethod.zep
@@ -2,13 +2,13 @@ namespace Test\Oo\Scopes;
 
 class HasPrivateMethod
 {
-	public function callPrivateMethod() -> string
-	{
-		return this->isPrivate();
-	}
+    public function callPrivateMethod() -> string
+    {
+        return this->isPrivate();
+    }
 
-	private function isPrivate() -> string
-	{
-		return __FUNCTION__;
-	}
+    private function isPrivate() -> string
+    {
+        return __FUNCTION__;
+    }
 }

--- a/test/oo/scopes/privatescopetester.zep
+++ b/test/oo/scopes/privatescopetester.zep
@@ -2,8 +2,47 @@ namespace Test\Oo\Scopes;
 
 class PrivateScopeTester extends HasPrivateMethod implements ScopeTesterInterface
 {
-	public function run() -> string
-	{
-		return this->callPrivateMethod();
-	}
+    public function run() -> string
+    {
+        return this->callPrivateMethod();
+    }
+
+    /**
+     * @issue https://github.com/phalcon/zephir/issues/2057
+     */
+    public function setPropertyObj(var obj, string property, var value) -> var
+    {
+        let obj->{property} = value;
+
+        return obj->{property};
+    }
+
+    /**
+     * @issue https://github.com/phalcon/zephir/issues/2057
+     */
+    public function setPropertyNew(string className, string property, var value) -> var
+    {
+        var obj;
+
+        let obj = create_instance(className);
+        let obj->{property} = value;
+
+        return obj;
+    }
+
+    /**
+     * @issue https://github.com/phalcon/zephir/issues/2057
+     */
+    public function getObjVars(var obj) -> var
+    {
+        return get_object_vars(obj);
+    }
+
+    /**
+     * @issue https://github.com/phalcon/zephir/issues/2057
+     */
+    public function getNewVars(string className) -> var
+    {
+        return this->getObjVars(create_instance(className));
+    }
 }

--- a/unit-tests/Extension/ArraySearchTest.php
+++ b/unit-tests/Extension/ArraySearchTest.php
@@ -16,7 +16,7 @@ use Test\ArraySearch;
 
 class ArraySearchTest extends TestCase
 {
-    /** @var ArraySearch $test */
+    /** @var ArraySearch */
     private $test;
 
     public function setUp()

--- a/unit-tests/Extension/AssignTest.php
+++ b/unit-tests/Extension/AssignTest.php
@@ -16,7 +16,7 @@ use Test\Assign;
 
 class AssignTest extends TestCase
 {
-    /** @var Assign $test */
+    /** @var Assign */
     private $test;
 
     public function setUp()

--- a/unit-tests/Extension/BuiltIn/IntMethodTest.php
+++ b/unit-tests/Extension/BuiltIn/IntMethodTest.php
@@ -16,7 +16,7 @@ use Test\BuiltIn\IntMethods;
 
 class IntMethodTest extends TestCase
 {
-    /** @var IntMethods $test */
+    /** @var IntMethods */
     private $test;
 
     public function setUp()

--- a/unit-tests/Extension/BuiltIn/StringMethodTest.php
+++ b/unit-tests/Extension/BuiltIn/StringMethodTest.php
@@ -17,7 +17,7 @@ use Test\BuiltIn\StringMethods;
 
 class StringMethodTest extends TestCase
 {
-    /** @var StringMethods $test */
+    /** @var StringMethods */
     private $test;
 
     public function setUp()

--- a/unit-tests/Extension/CharsTest.php
+++ b/unit-tests/Extension/CharsTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 class CharsTest extends TestCase
 {
-    /** @var \Test\Chars $test */
+    /** @var \Test\Chars */
     private $test;
 
     public function setUp()

--- a/unit-tests/Extension/CompareTest.php
+++ b/unit-tests/Extension/CompareTest.php
@@ -16,7 +16,7 @@ use Test\Compare;
 
 class CompareTest extends TestCase
 {
-    /** @var Compare $test */
+    /** @var Compare */
     private $test;
 
     public function setUp()

--- a/unit-tests/Extension/ConcatTest.php
+++ b/unit-tests/Extension/ConcatTest.php
@@ -16,7 +16,7 @@ use Test\Concat;
 
 class ConcatTest extends TestCase
 {
-    /** @var Concat $test */
+    /** @var Concat */
     private $test;
 
     public function setUp()

--- a/unit-tests/Extension/ConstantsInterfaceTest.php
+++ b/unit-tests/Extension/ConstantsInterfaceTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 class ConstantsInterfaceTest extends TestCase
 {
-    /** @var \Test\ConstantsInterface $test */
+    /** @var \Test\ConstantsInterface */
     private $test;
 
     public function setUp()

--- a/unit-tests/Extension/ExceptionsTest.php
+++ b/unit-tests/Extension/ExceptionsTest.php
@@ -17,7 +17,7 @@ use Test\Exceptions;
 
 class ExceptionsTest extends TestCase
 {
-    /** @var Exceptions $test */
+    /** @var Exceptions */
     private $test;
 
     public function setUp()

--- a/unit-tests/Extension/FcallTest.php
+++ b/unit-tests/Extension/FcallTest.php
@@ -21,7 +21,7 @@ class UserExample extends PropertyAccess
 
 class FcallTest extends TestCase
 {
-    /** @var Fcall $test */
+    /** @var Fcall */
     private $test;
 
     public function setUp()

--- a/unit-tests/Extension/FunctionExistsTest.php
+++ b/unit-tests/Extension/FunctionExistsTest.php
@@ -16,7 +16,7 @@ use Test\FunctionExists;
 
 class FunctionExistsTest extends TestCase
 {
-    /** @var FunctionExists $test */
+    /** @var FunctionExists */
     private $test;
 
     public function setUp()

--- a/unit-tests/Extension/GlobalsTest.php
+++ b/unit-tests/Extension/GlobalsTest.php
@@ -19,7 +19,7 @@ use Test\Globals;
  */
 class GlobalsTest extends TestCase
 {
-    /** @var Test\Globals $test */
+    /** @var \Test\Globals */
     private $test;
 
     public function setUp()

--- a/unit-tests/Extension/InstanceOffTest.php
+++ b/unit-tests/Extension/InstanceOffTest.php
@@ -16,7 +16,7 @@ use Test\InstanceOff;
 
 class InstanceOffTest extends TestCase
 {
-    /** @var InstanceOff $test */
+    /** @var InstanceOff */
     private $test;
 
     public function setUp()

--- a/unit-tests/Extension/IssetTest.php
+++ b/unit-tests/Extension/IssetTest.php
@@ -18,7 +18,7 @@ class IssetTest extends TestCase
     public $b = 'a';
     private $test2 = 'b';
 
-    /** @var \Test\IssetTest $test */
+    /** @var \Test\IssetTest */
     private $test;
 
     public function setUp()

--- a/unit-tests/Extension/JsonTest.php
+++ b/unit-tests/Extension/JsonTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 class JsonTest extends TestCase
 {
-    /** @var \Test\Json $test */
+    /** @var \Test\Json */
     private $test;
 
     public function setUp()

--- a/unit-tests/Extension/MCallTest.php
+++ b/unit-tests/Extension/MCallTest.php
@@ -19,7 +19,7 @@ class MCallTest extends TestCase
     /** @var \ReflectionClass */
     private $reflection;
 
-    /** @var Mcall $test */
+    /** @var Mcall */
     private $test;
 
     public function setUp()

--- a/unit-tests/Extension/McallChainedTest.php
+++ b/unit-tests/Extension/McallChainedTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 class McallChainedTest extends TestCase
 {
-    /** @var \Test\McallChained $test */
+    /** @var \Test\McallChained */
     private $test;
 
     public function setUp()

--- a/unit-tests/Extension/Oo/Scopes/PrivateScopeTest.php
+++ b/unit-tests/Extension/Oo/Scopes/PrivateScopeTest.php
@@ -12,12 +12,12 @@
 namespace Extension\Oo;
 
 use Error;
-use TestScopeExtending;
-use TestScopePhp;
-use TestScopeExtendingMagic;
-use TestScopePhpMagic;
 use PHPUnit\Framework\TestCase;
 use Test\Oo\Scopes\PrivateScopeTester;
+use TestScopeExtending;
+use TestScopeExtendingMagic;
+use TestScopePhp;
+use TestScopePhpMagic;
 
 class PrivateScopeTest extends TestCase
 {
@@ -29,6 +29,7 @@ class PrivateScopeTest extends TestCase
 
     /**
      * @test
+     *
      * @see https://github.com/phalcon/zephir/issues/2057
      */
     public function shouldNotSetPrivatePropertyObjPhp()
@@ -44,6 +45,7 @@ class PrivateScopeTest extends TestCase
 
     /**
      * @test
+     *
      * @see https://github.com/phalcon/zephir/issues/2057
      */
     public function shouldNotSetPrivatePropertyNewPhp()
@@ -59,6 +61,7 @@ class PrivateScopeTest extends TestCase
 
     /**
      * @test
+     *
      * @see https://github.com/phalcon/zephir/issues/2057
      */
     public function shouldNotSetPrivatePropertyObjInternal()
@@ -74,6 +77,7 @@ class PrivateScopeTest extends TestCase
 
     /**
      * @test
+     *
      * @see https://github.com/phalcon/zephir/issues/2057
      */
     public function shouldNotSetPrivatePropertyNewInternal()
@@ -89,6 +93,7 @@ class PrivateScopeTest extends TestCase
 
     /**
      * @test
+     *
      * @see https://github.com/phalcon/zephir/issues/2057
      */
     public function shouldSetPrivatePropertyObjPhp()
@@ -103,6 +108,7 @@ class PrivateScopeTest extends TestCase
 
     /**
      * @test
+     *
      * @see https://github.com/phalcon/zephir/issues/2057
      */
     public function shouldSetPrivatePropertyNewPhp()
@@ -116,6 +122,7 @@ class PrivateScopeTest extends TestCase
 
     /**
      * @test
+     *
      * @see https://github.com/phalcon/zephir/issues/2057
      */
     public function shouldSetPrivatePropertyObjInternal()
@@ -130,6 +137,7 @@ class PrivateScopeTest extends TestCase
 
     /**
      * @test
+     *
      * @see https://github.com/phalcon/zephir/issues/2057
      */
     public function shouldSetPrivatePropertyNewInternal()
@@ -143,6 +151,7 @@ class PrivateScopeTest extends TestCase
 
     /**
      * @test
+     *
      * @see https://github.com/phalcon/zephir/issues/2057
      */
     public function shouldNotSetPrivatePropertyViaThis()
@@ -158,6 +167,7 @@ class PrivateScopeTest extends TestCase
 
     /**
      * @test
+     *
      * @see https://github.com/phalcon/zephir/issues/2057
      */
     public function shouldSetPrivatePropertyViaThis()
@@ -170,6 +180,7 @@ class PrivateScopeTest extends TestCase
 
     /**
      * @test
+     *
      * @see https://github.com/phalcon/zephir/issues/2057
      */
     public function shouldNotSetPrivatePropertyExtendedMagicObjInternal()

--- a/unit-tests/Extension/Oo/Scopes/PrivateScopeTest.php
+++ b/unit-tests/Extension/Oo/Scopes/PrivateScopeTest.php
@@ -12,6 +12,7 @@
 namespace Extension\Oo;
 
 use Error;
+use PHPUnit\Framework\Error\Notice;
 use PHPUnit\Framework\TestCase;
 use Test\Oo\Scopes\PrivateScopeTester;
 use TestScopeExtending;
@@ -220,10 +221,17 @@ class PrivateScopeTest extends TestCase
      */
     public function shouldNotSetPrivatePropertyExtendedMagicObjPhp()
     {
-        $this->expectException(Error::class);
-        $this->expectExceptionMessage(
-            'Cannot access private property TestScopePhpMagicExtending::$privateProperty2'
-        );
+        if (\PHP_VERSION_ID < 70400) {
+            $this->expectException(Notice::class);
+            $this->expectExceptionMessage(
+                'Undefined property: TestScopePhpMagicExtending::$privateProperty2'
+            );
+        } else {
+            $this->expectException(Error::class);
+            $this->expectExceptionMessage(
+                'Cannot access private property TestScopePhpMagicExtending::$privateProperty2'
+            );
+        }
 
         $obj = new TestScopePhpMagicExtending();
 

--- a/unit-tests/Extension/Oo/Scopes/PrivateScopeTest.php
+++ b/unit-tests/Extension/Oo/Scopes/PrivateScopeTest.php
@@ -157,7 +157,6 @@ class PrivateScopeTest extends TestCase
      */
     public function shouldNotSetPrivatePropertyViaThis()
     {
-        $this->markTestSkipped('This test is not ready');
         $this->expectException(Error::class);
         $this->expectExceptionMessage(
             'Cannot access private property TestScopeExtending::$privateProperty'
@@ -187,8 +186,10 @@ class PrivateScopeTest extends TestCase
      */
     public function shouldNotSetPrivatePropertyExtendedMagicObjInternal()
     {
-        $this->markTestSkipped('This test is not ready');
         $this->expectException(Error::class);
+        $this->expectExceptionMessage(
+            'Cannot access private property TestScopeExtendingMagic::$privateProperty2'
+        );
 
         $object = new TestScopeExtendingMagic();
         $tester = new PrivateScopeTester();
@@ -203,8 +204,10 @@ class PrivateScopeTest extends TestCase
      */
     public function shouldNotSetPrivatePropertyExtendedMagicNewInternal()
     {
-        $this->markTestSkipped('This test is not ready');
         $this->expectException(Error::class);
+        $this->expectExceptionMessage(
+            'Cannot access private property TestScopeExtendingMagic::$privateProperty2'
+        );
 
         $tester = new PrivateScopeTester();
         $tester->setPropertyNew(TestScopeExtendingMagic::class, 'privateProperty2', 'test');
@@ -217,8 +220,10 @@ class PrivateScopeTest extends TestCase
      */
     public function shouldNotSetPrivatePropertyExtendedMagicObjPhp()
     {
-        $this->markTestSkipped('This test is not ready');
         $this->expectException(Error::class);
+        $this->expectExceptionMessage(
+            'Cannot access private property TestScopePhpMagicExtending::$privateProperty2'
+        );
 
         $obj = new TestScopePhpMagicExtending();
 
@@ -233,8 +238,10 @@ class PrivateScopeTest extends TestCase
      */
     public function shouldNotSetPrivatePropertyExtendedMagicNewPhp()
     {
-        $this->markTestSkipped('This test is not ready');
         $this->expectException(Error::class);
+        $this->expectExceptionMessage(
+            'Cannot access private property TestScopePhpMagicExtending::$privateProperty2'
+        );
 
         $tester = new PrivateScopeTester();
         $tester->setPropertyNew(TestScopePhpMagicExtending::class, 'privateProperty2', 'test');

--- a/unit-tests/Extension/Oo/Scopes/PrivateScopeTest.php
+++ b/unit-tests/Extension/Oo/Scopes/PrivateScopeTest.php
@@ -187,15 +187,28 @@ class PrivateScopeTest extends TestCase
      */
     public function shouldNotSetPrivatePropertyExtendedMagicObjInternal()
     {
-        $this->expectException(Error::class);
-        $this->expectExceptionMessage(
-            'Cannot access private property TestScopeExtendingMagic::$privateProperty2'
-        );
+        if (\PHP_VERSION_ID >= 70400) {
+            $this->expectException(Error::class);
+            $this->expectExceptionMessage(
+                'Cannot access private property TestScopeExtendingMagic::$privateProperty2'
+            );
+        }
 
         $object = new TestScopeExtendingMagic();
         $tester = new PrivateScopeTester();
 
-        $tester->setPropertyObj($object, 'privateProperty2', 'test');
+        $this->assertEquals('private', $object->getPrivateProperty2());
+        $tester->setPropertyObj($object, 'privateProperty2', 'CHANGED');
+
+        // This related the way PHP < 7.4 handles object's properties when
+        // there  is a magic __set method present.
+        //
+        // Actually we DO NOT change property here (fixed).  Only PHP 7.4
+        // throws a Fatal Error.  All previous versions just out a Notice and
+        // continue execution.
+        if (\PHP_VERSION_ID < 70400) {
+            $this->assertEquals('private', $object->getPrivateProperty2());
+        }
     }
 
     /**
@@ -205,13 +218,29 @@ class PrivateScopeTest extends TestCase
      */
     public function shouldNotSetPrivatePropertyExtendedMagicNewInternal()
     {
-        $this->expectException(Error::class);
-        $this->expectExceptionMessage(
-            'Cannot access private property TestScopeExtendingMagic::$privateProperty2'
-        );
+        if (\PHP_VERSION_ID >= 70400) {
+            $this->expectException(Error::class);
+            $this->expectExceptionMessage(
+                'Cannot access private property TestScopeExtendingMagic::$privateProperty2'
+            );
+        }
 
         $tester = new PrivateScopeTester();
-        $tester->setPropertyNew(TestScopeExtendingMagic::class, 'privateProperty2', 'test');
+        $object = $tester->setPropertyNew(
+            TestScopeExtendingMagic::class,
+            'privateProperty2',
+            'CHANGED'
+        );
+
+        // This related the way PHP < 7.4 handles object's properties when
+        // there  is a magic __set method present.
+        //
+        // Actually we DO NOT change property here (fixed).  Only PHP 7.4
+        // throws a Fatal Error.  All previous versions just out a Notice and
+        // continue execution.
+        if (\PHP_VERSION_ID < 70400) {
+            $this->assertEquals('private', $object->getPrivateProperty2());
+        }
     }
 
     /**
@@ -246,13 +275,29 @@ class PrivateScopeTest extends TestCase
      */
     public function shouldNotSetPrivatePropertyExtendedMagicNewPhp()
     {
-        $this->expectException(Error::class);
-        $this->expectExceptionMessage(
-            'Cannot access private property TestScopePhpMagicExtending::$privateProperty2'
-        );
+        if (\PHP_VERSION_ID >= 70400) {
+            $this->expectException(Error::class);
+            $this->expectExceptionMessage(
+                'Cannot access private property TestScopePhpMagicExtending::$privateProperty2'
+            );
+        }
 
         $tester = new PrivateScopeTester();
-        $tester->setPropertyNew(TestScopePhpMagicExtending::class, 'privateProperty2', 'test');
+        $object = $tester->setPropertyNew(
+            TestScopePhpMagicExtending::class,
+            'privateProperty2',
+            'CHANGED'
+        );
+
+        // This related the way PHP < 7.4 handles object's properties when
+        // there  is a magic __set method present.
+        //
+        // Actually we DO NOT change property here (fixed).  Only PHP 7.4
+        // throws a Fatal Error.  All previous versions just out a Notice and
+        // continue execution.
+        if (\PHP_VERSION_ID < 70400) {
+            $this->assertEquals('private2', $object->getPrivateProperty2());
+        }
     }
 
     /**

--- a/unit-tests/Extension/Oo/Scopes/PrivateScopeTest.php
+++ b/unit-tests/Extension/Oo/Scopes/PrivateScopeTest.php
@@ -5,12 +5,17 @@
  *
  * (c) Phalcon Team <team@zephir-lang.com>
  *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
  */
 
 namespace Extension\Oo;
 
+use Error;
+use TestScopeExtending;
+use TestScopePhp;
+use TestScopeExtendingMagic;
+use TestScopePhpMagic;
 use PHPUnit\Framework\TestCase;
 use Test\Oo\Scopes\PrivateScopeTester;
 
@@ -20,5 +25,161 @@ class PrivateScopeTest extends TestCase
     public function shouldCallPrivateMethod()
     {
         $this->assertSame('isPrivate', (new PrivateScopeTester())->run());
+    }
+
+    /**
+     * @test
+     * @see https://github.com/phalcon/zephir/issues/2057
+     */
+    public function shouldNotSetPrivatePropertyObjPhp()
+    {
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage(
+            'Cannot access private property TestScopePhp::$privateProperty'
+        );
+
+        $tester = new PrivateScopeTester();
+        $tester->setPropertyObj(new TestScopePhp(), 'privateProperty', 'test');
+    }
+
+    /**
+     * @test
+     * @see https://github.com/phalcon/zephir/issues/2057
+     */
+    public function shouldNotSetPrivatePropertyNewPhp()
+    {
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage(
+            'Cannot access private property TestScopePhp::$privateProperty'
+        );
+
+        $tester = new PrivateScopeTester();
+        $tester->setPropertyNew(TestScopePhp::class, 'privateProperty', 'test');
+    }
+
+    /**
+     * @test
+     * @see https://github.com/phalcon/zephir/issues/2057
+     */
+    public function shouldNotSetPrivatePropertyObjInternal()
+    {
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage(
+            'Cannot access private property TestScopeExtending::$privateProperty'
+        );
+
+        $tester = new PrivateScopeTester();
+        $tester->setPropertyObj(new TestScopeExtending(), 'privateProperty', 'test');
+    }
+
+    /**
+     * @test
+     * @see https://github.com/phalcon/zephir/issues/2057
+     */
+    public function shouldNotSetPrivatePropertyNewInternal()
+    {
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage(
+            'Cannot access private property TestScopeExtending::$privateProperty'
+        );
+
+        $tester = new PrivateScopeTester();
+        $tester->setPropertyNew(TestScopeExtending::class, 'privateProperty', 'test');
+    }
+
+    /**
+     * @test
+     * @see https://github.com/phalcon/zephir/issues/2057
+     */
+    public function shouldSetPrivatePropertyObjPhp()
+    {
+        $object = new TestScopePhpMagic();
+        $tester = new PrivateScopeTester();
+
+        $actual = $tester->setPropertyObj($object, 'privateProperty', 'test');
+        $this->assertEquals('test', $actual);
+        $this->assertEquals(1, $object->setCount);
+    }
+
+    /**
+     * @test
+     * @see https://github.com/phalcon/zephir/issues/2057
+     */
+    public function shouldSetPrivatePropertyNewPhp()
+    {
+        $tester = new PrivateScopeTester();
+        $obj = $tester->setPropertyNew(TestScopePhpMagic::class, 'privateProperty', 'test');
+
+        $this->assertEquals('test', $obj->privateProperty);
+        $this->assertEquals(1, $obj->setCount);
+    }
+
+    /**
+     * @test
+     * @see https://github.com/phalcon/zephir/issues/2057
+     */
+    public function shouldSetPrivatePropertyObjInternal()
+    {
+        $tester = new PrivateScopeTester();
+        $object = new TestScopeExtendingMagic();
+
+        $actual = $tester->setPropertyObj($object, 'privateProperty', 'test');
+        $this->assertEquals('test', $actual);
+        $this->assertEquals(1, $object->setCount);
+    }
+
+    /**
+     * @test
+     * @see https://github.com/phalcon/zephir/issues/2057
+     */
+    public function shouldSetPrivatePropertyNewInternal()
+    {
+        $tester = new PrivateScopeTester();
+        $obj = $tester->setPropertyNew(TestScopeExtendingMagic::class, 'privateProperty', 'test');
+
+        $this->assertEquals('test', $obj->privateProperty);
+        $this->assertEquals(1, $obj->setCount);
+    }
+
+    /**
+     * @test
+     * @see https://github.com/phalcon/zephir/issues/2057
+     */
+    public function shouldNotSetPrivatePropertyViaThis()
+    {
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage(
+            'Cannot access private property TestScopeExtending::$privateProperty'
+        );
+
+        $obj = new TestScopeExtending();
+        $obj->setProperty('privateProperty', 'test');
+    }
+
+    /**
+     * @test
+     * @see https://github.com/phalcon/zephir/issues/2057
+     */
+    public function shouldSetPrivatePropertyViaThis()
+    {
+        $obj = new TestScopeExtending();
+        $obj->setProperty('privateProperty2', 'test');
+
+        $this->assertEquals('test', $obj->getPrivateProperty2());
+    }
+
+    /**
+     * @test
+     * @see https://github.com/phalcon/zephir/issues/2057
+     */
+    public function shouldNotSetPrivatePropertyExtendedMagicObjInternal()
+    {
+        $this->markTestSkipped('This test is not ready');
+        $this->expectException(Error::class);
+
+        $object = new TestScopeExtendingMagic();
+        $tester = new PrivateScopeTester();
+
+        $tester->setPropertyObj($object, 'privateProperty2', 'test');
     }
 }

--- a/unit-tests/Extension/Oo/Scopes/PrivateScopeTest.php
+++ b/unit-tests/Extension/Oo/Scopes/PrivateScopeTest.php
@@ -18,6 +18,7 @@ use TestScopeExtending;
 use TestScopeExtendingMagic;
 use TestScopePhp;
 use TestScopePhpMagic;
+use TestScopePhpMagicExtending;
 
 class PrivateScopeTest extends TestCase
 {
@@ -156,6 +157,7 @@ class PrivateScopeTest extends TestCase
      */
     public function shouldNotSetPrivatePropertyViaThis()
     {
+        $this->markTestSkipped('This test is not ready');
         $this->expectException(Error::class);
         $this->expectExceptionMessage(
             'Cannot access private property TestScopeExtending::$privateProperty'
@@ -192,5 +194,103 @@ class PrivateScopeTest extends TestCase
         $tester = new PrivateScopeTester();
 
         $tester->setPropertyObj($object, 'privateProperty2', 'test');
+    }
+
+    /**
+     * @test
+     *
+     * @see https://github.com/phalcon/zephir/issues/2057
+     */
+    public function shouldNotSetPrivatePropertyExtendedMagicNewInternal()
+    {
+        $this->markTestSkipped('This test is not ready');
+        $this->expectException(Error::class);
+
+        $tester = new PrivateScopeTester();
+        $tester->setPropertyNew(TestScopeExtendingMagic::class, 'privateProperty2', 'test');
+    }
+
+    /**
+     * @test
+     *
+     * @see https://github.com/phalcon/zephir/issues/2057
+     */
+    public function shouldNotSetPrivatePropertyExtendedMagicObjPhp()
+    {
+        $this->markTestSkipped('This test is not ready');
+        $this->expectException(Error::class);
+
+        $obj = new TestScopePhpMagicExtending();
+
+        $tester = new PrivateScopeTester();
+        $tester->setPropertyObj($obj, 'privateProperty2', 'test');
+    }
+
+    /**
+     * @test
+     *
+     * @see https://github.com/phalcon/zephir/issues/2057
+     */
+    public function shouldNotSetPrivatePropertyExtendedMagicNewPhp()
+    {
+        $this->markTestSkipped('This test is not ready');
+        $this->expectException(Error::class);
+
+        $tester = new PrivateScopeTester();
+        $tester->setPropertyNew(TestScopePhpMagicExtending::class, 'privateProperty2', 'test');
+    }
+
+    /**
+     * @test
+     *
+     * @see https://github.com/phalcon/zephir/issues/2057
+     */
+    public function shouldNotGetObjectVarsPrivatePropertyObjPhp()
+    {
+        $tester = new PrivateScopeTester();
+        $object = new TestScopePhp();
+
+        $objectVars = $tester->getObjVars($object);
+        $this->assertArrayNotHasKey('privateProperty', $objectVars);
+    }
+
+    /**
+     * @test
+     *
+     * @see https://github.com/phalcon/zephir/issues/2057
+     */
+    public function shouldNotGetObjectVarsPrivatePropertyNewPhp()
+    {
+        $tester = new PrivateScopeTester();
+        $objectVars = $tester->getNewVars(TestScopePhp::class);
+
+        $this->assertArrayNotHasKey('privateProperty', $objectVars);
+    }
+
+    /**
+     * @test
+     *
+     * @see https://github.com/phalcon/zephir/issues/2057
+     */
+    public function shouldNotGetObjectVarsPrivatePropertyObjInternal()
+    {
+        $tester = new PrivateScopeTester();
+        $object = new TestScopeExtending();
+        $objectVars = $tester->getObjVars($object);
+
+        $this->assertArrayNotHasKey('privateProperty', $objectVars);
+    }
+
+    /**
+     * @test
+     *
+     * @see https://github.com/phalcon/zephir/issues/2057
+     */
+    public function shouldNotGetObjectVarsPrivatePropertyNewInternal()
+    {
+        $tester = new PrivateScopeTester();
+        $objectVars = $tester->getNewVars(TestScopeExtending::class);
+
+        $this->assertArrayNotHasKey('privateProperty', $objectVars);
     }
 }

--- a/unit-tests/Extension/StringTest.php
+++ b/unit-tests/Extension/StringTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
 
 class StringTest extends TestCase
 {
-    /** @var \Test\Strings $test */
+    /** @var \Test\Strings */
     private $test;
 
     public function setUp()

--- a/unit-tests/Zephir/Test/ConfigTest.php
+++ b/unit-tests/Zephir/Test/ConfigTest.php
@@ -23,7 +23,7 @@ class ConfigTest extends TestCase
      */
     private $pwd;
 
-    /** @var Config $config */
+    /** @var Config */
     private $config;
 
     public function setUp()

--- a/unit-tests/Zephir/Test/Logger/Formatter/CompilerFormatterTest.php
+++ b/unit-tests/Zephir/Test/Logger/Formatter/CompilerFormatterTest.php
@@ -17,7 +17,7 @@ use Zephir\Logger\Formatter\CompilerFormatter;
 
 class CompilerFormatterTest extends TestCase
 {
-    /** @var Config $config */
+    /** @var Config */
     private $config;
 
     public function setUp()

--- a/unit-tests/fixtures/mocks/TestScopeExtending.php
+++ b/unit-tests/fixtures/mocks/TestScopeExtending.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * This file is part of the Zephir.
+ *
+ * (c) Phalcon Team <team@zephir-lang.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+use Test\Oo\Scopes\AbstractClass;
+
+class TestScopeExtending extends AbstractClass
+{
+    private $privateProperty = 'private';
+    protected $protectedProperty = 'protected';
+    public $publicProperty = 'public';
+
+    /**
+     * @return string
+     */
+    public function getProtectedProperty(): string
+    {
+        return $this->protectedProperty;
+    }
+}

--- a/unit-tests/fixtures/mocks/TestScopeExtendingMagic.php
+++ b/unit-tests/fixtures/mocks/TestScopeExtendingMagic.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * This file is part of the Zephir.
+ *
+ * (c) Phalcon Team <team@zephir-lang.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+use Test\Oo\Scopes\AbstractClassMagic;
+
+class TestScopeExtendingMagic extends AbstractClassMagic
+{
+    private $privateProperty2 = 'private';
+
+    public function getProtectedProperty(): string
+    {
+        return $this->protectedProperty;
+    }
+}

--- a/unit-tests/fixtures/mocks/TestScopeExtendingMagic.php
+++ b/unit-tests/fixtures/mocks/TestScopeExtendingMagic.php
@@ -19,4 +19,9 @@ class TestScopeExtendingMagic extends AbstractClassMagic
     {
         return $this->protectedProperty;
     }
+
+    public function getPrivateProperty2()
+    {
+        return $this->privateProperty2;
+    }
 }

--- a/unit-tests/fixtures/mocks/TestScopePhp.php
+++ b/unit-tests/fixtures/mocks/TestScopePhp.php
@@ -8,7 +8,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 class TestScopePhp
 {
     private $privateProperty = 'private';

--- a/unit-tests/fixtures/mocks/TestScopePhp.php
+++ b/unit-tests/fixtures/mocks/TestScopePhp.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * This file is part of the Zephir.
+ *
+ * (c) Phalcon Team <team@zephir-lang.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+class TestScopePhp
+{
+    private $privateProperty = 'private';
+    protected $protectedProperty = 'protected';
+    public $publicProperty = 'public';
+}

--- a/unit-tests/fixtures/mocks/TestScopePhpMagic.php
+++ b/unit-tests/fixtures/mocks/TestScopePhpMagic.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * This file is part of the Zephir.
+ *
+ * (c) Phalcon Team <team@zephir-lang.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+class TestScopePhpMagic
+{
+    public $setCount = 0;
+
+    private $privateProperty = 'private';
+    protected $protectedProperty = 'protected';
+    public $publicProperty = 'public';
+
+    public function __set($name, $value)
+    {
+        $this->setCount++;
+        $this->$name = $value;
+    }
+
+    public function __get($name)
+    {
+        return $this->$name;
+    }
+}

--- a/unit-tests/fixtures/mocks/TestScopePhpMagic.php
+++ b/unit-tests/fixtures/mocks/TestScopePhpMagic.php
@@ -8,7 +8,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 class TestScopePhpMagic
 {
     public $setCount = 0;
@@ -19,7 +18,7 @@ class TestScopePhpMagic
 
     public function __set($name, $value)
     {
-        $this->setCount++;
+        ++$this->setCount;
         $this->$name = $value;
     }
 

--- a/unit-tests/fixtures/mocks/TestScopePhpMagicExtending.php
+++ b/unit-tests/fixtures/mocks/TestScopePhpMagicExtending.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * This file is part of the Zephir.
+ *
+ * (c) Phalcon Team <team@zephir-lang.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+class TestScopePhpMagicExtending extends TestScopePhpMagic
+{
+    private $privateProperty2 = 'private2';
+}

--- a/unit-tests/fixtures/mocks/TestScopePhpMagicExtending.php
+++ b/unit-tests/fixtures/mocks/TestScopePhpMagicExtending.php
@@ -11,4 +11,9 @@
 class TestScopePhpMagicExtending extends TestScopePhpMagic
 {
     private $privateProperty2 = 'private2';
+
+    public function getPrivateProperty2()
+    {
+        return $this->privateProperty2;
+    }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #2057, https://github.com/phalcon/cphalcon/issues/14810, https://github.com/phalcon/cphalcon/issues/14766

In raising this pull request, I confirm the following:

- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I updated the CHANGELOG

Small description of change: 

Zephir ignored property visibility and has not thrown error when setting   private/protected properties in scope that shouldn't intended for it.

Thanks
