### PR TITLE
Stubs for array

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -28,11 +28,15 @@ jobs:
           tools: php-cs-fixer, phpcs
 
       - name: Run PHP_CodeSniffer
-        run: phpcs --runtime-set ignore_warnings_on_exit true
+        run: |
+          phpcs --version
+          phpcs --runtime-set ignore_warnings_on_exit true
 
       - name: Run PHP CS Fixer
         if: always()
-        run: php-cs-fixer fix --diff --dry-run -v
+        run: |
+          php-cs-fixer --version
+          php-cs-fixer fix --diff --dry-run -v
 
       - name: Run Shell Check
         if: always()

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,4 +1,4 @@
-<?php
+``<?php
 
 /*
  * This file is part of the Zephir.
@@ -49,5 +49,6 @@ return PhpCsFixer\Config::create()
         'protected_to_private' => false,
         'phpdoc_var_annotation_correct_order' => true,
         'no_superfluous_phpdoc_tags' => false,
-        'single_line_throw' => false,
+        // Removed this line, because latest php-cs-fixer v2.15.x does not support this rule
+        // 'single_line_throw' => false,
     ]);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 and this project adheres to [Semantic Versioning](http://semver.org).
 
 ## [Unreleased]
+### Fixed
+- Fixed stubs generation for case with array declaration with square brackets in params
+
 ## [0.12.19] - 2020-05-13
 ### Fixed
 - Fixed duplicate definition with GCC 10

--- a/Library/Stubs/MethodDocBlock.php
+++ b/Library/Stubs/MethodDocBlock.php
@@ -141,7 +141,7 @@ class MethodDocBlock extends DocBlock
     {
         $pattern = '~
             @(?P<doctype>param|return|var)\s+
-            (?P<type>[\\\\\w]+(:?\s*\|\s*[\\\\\w]+)*)\s*
+            (?P<type>[\\\\\w]+(:?\s*\|\s*[\\\\\w]+|\s*\[]+)*)\s*
             (?P<dollar>\$)?
             (?P<name>[a-z_][a-z0-9_]*)?\s*
             (?P<description>(.|\s)*)?

--- a/tests/Zephir/Stubs/DocBlockTest.php
+++ b/tests/Zephir/Stubs/DocBlockTest.php
@@ -142,6 +142,7 @@ DOC;
      * @param string \$valueString
      * @param bool \$valueBoolean
      * @param array \$valueArray
+     * @param string[] \$stringArray
      * @param object \$valueObject
      * @param resource \$valueResource
      * @param null \$valueNull
@@ -165,6 +166,7 @@ DOC;
      * @param string \$valueString
      * @param bool \$valueBoolean
      * @param array \$valueArray
+     * @param string[] \$stringArray
      * @param object \$valueObject
      * @param resource \$valueResource
      * @param null \$valueNull

--- a/tests/Zephir/Stubs/MethodDocBlockTest.php
+++ b/tests/Zephir/Stubs/MethodDocBlockTest.php
@@ -234,6 +234,12 @@ class MethodDocBlockTest extends TestCase
                 " *    \"test\" => \"xyz\"\n".
                 ' * ]',
             ],
+            'with square brackets array syntax' => [
+                // Zep
+                '@param Foo[] $name - some description',
+                // php
+                '@param Foo[] $name - some description',
+            ],
         ];
     }
 


### PR DESCRIPTION
Hello!

When generating stubs with array declaration in params as `Foo[]` - stubs are duplicates.

```php
    /**
     * @param Foo[] $param
     */
    public function bar(array param)
    {
        let this->foos = param;
    }

but it generates this:
    /**
     * @param Foo[] $param
     * @param array $param
     * @param Foo  [] $param
     */
    public function bar(array $param)
    {
    }
```

* Type: bug fix

In raising this pull request, I confirm the following:

- [X] I have checked that another pull request for this purpose does not exist
- [X] I wrote some tests for this PR
- [X] I updated the CHANGELOG

Small description of change:

- Added support for generating stubs with square array declaration in docblock params

Thanks
