### PR TITLE
Add build directories

### DIFF
--- a/templates/ZendEngine3/config.m4
+++ b/templates/ZendEngine3/config.m4
@@ -11,6 +11,8 @@ if test "$PHP_%PROJECT_UPPER%" = "yes"; then
 	AC_DEFINE(HAVE_%PROJECT_UPPER%, 1, [Whether you have %PROJECT_CAMELIZE%])
 	%PROJECT_LOWER%_sources="%PROJECT_LOWER_SAFE%.c kernel/main.c kernel/memory.c kernel/exception.c kernel/debug.c kernel/backtrace.c kernel/object.c kernel/array.c kernel/string.c kernel/fcall.c kernel/require.c kernel/file.c kernel/operators.c kernel/math.c kernel/concat.c kernel/variables.c kernel/filter.c kernel/iterator.c kernel/time.c kernel/exit.c %FILES_COMPILED% %EXTRA_FILES_COMPILED%"
 	PHP_NEW_EXTENSION(%PROJECT_LOWER%, $%PROJECT_LOWER%_sources, $ext_shared,, %PROJECT_EXTRA_CFLAGS%)
+	PHP_ADD_BUILD_DIR([$ext_builddir/kernel/])
+	PHP_ADD_BUILD_DIR([$ext_builddir/%PROJECT_LOWER%/])
 	PHP_SUBST(%PROJECT_UPPER%_SHARED_LIBADD)
 
 	old_CPPFLAGS=$CPPFLAGS


### PR DESCRIPTION
It's an attempt to fix the missing kernel directory at build time:
> mkdir kernel/.libs
mkdir: cannot create directory 'kernel/.libs': No such file or directory
make: *** [Makefile:194: kernel/main.lo] Error 1
ERROR: `make' failed
