### PR TITLE
Fix CI deprecated set-env

### DIFF
--- a/.ci/vsenv.bat
+++ b/.ci/vsenv.bat
@@ -36,6 +36,6 @@ rem See: https://help.github.com/en/articles/development-tools-for-github-action
 rem See: https://stackoverflow.com/questions/39183272/loop-through-all-environmental-variables-and-take-actions-depending-on-prefix
 setlocal
 for /f "delims== tokens=1,2" %%a in ('set') do (
-  Write-Output "%%a=%%b" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+  SET "%%a=%%b"
 )
 endlocal

--- a/.ci/vsenv.bat
+++ b/.ci/vsenv.bat
@@ -36,6 +36,6 @@ rem See: https://help.github.com/en/articles/development-tools-for-github-action
 rem See: https://stackoverflow.com/questions/39183272/loop-through-all-environmental-variables-and-take-actions-depending-on-prefix
 setlocal
 for /f "delims== tokens=1,2" %%a in ('set') do (
-  echo ::set-env name=%%a::%%b
+  Write-Output "%%a=%%b" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 )
 endlocal

--- a/.ci/vsenv.bat
+++ b/.ci/vsenv.bat
@@ -36,6 +36,6 @@ rem See: https://help.github.com/en/articles/development-tools-for-github-action
 rem See: https://stackoverflow.com/questions/39183272/loop-through-all-environmental-variables-and-take-actions-depending-on-prefix
 setlocal
 for /f "delims== tokens=1,2" %%a in ('set') do (
-  SET "%%a=%%b"
+  powershell -Command "& {Write-Output '%%a=%%b' | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append;}"
 )
 endlocal

--- a/.ci/win-ci-tools.psm1
+++ b/.ci/win-ci-tools.psm1
@@ -352,8 +352,8 @@ function InitializeReleaseVars {
 
     $env:RELEASE_DLL_PATH = "${env:GITHUB_WORKSPACE}\ext\${env:RELEASE_FOLDER}\${env:EXTENSION_FILE}"
 
-    Write-Output "::set-env name=RELEASE_ZIPBALL::${env:RELEASE_ZIPBALL}"
-    Write-Output "::set-env name=RELEASE_DLL_PATH::${env:RELEASE_DLL_PATH}"
+    Write-Output "RELEASE_ZIPBALL=${env:RELEASE_ZIPBALL}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+    Write-Output "RELEASE_DLL_PATH=${env:RELEASE_DLL_PATH}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 }
 
 function EnableTestExtension {

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   analysis:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -15,6 +15,10 @@ env:
 
 jobs:
   linux:
+    # To prevent build a particular commit use
+    #     git commit -m "......... [ci skip]"
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+
     name: "${{ matrix.os }}: PHP v${{ matrix.php }}"
     runs-on: ${{ matrix.os }}
 
@@ -204,7 +208,6 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          yml: ./.codecov.yml
           name: codecov-umbrella
           flags: unittests
           fail_ci_if_error: false

--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Set Environment Variables
         run: |
-          echo ::set-env name=SYMFONY_PHPUNIT_VERSION::${{ matrix.symfony_phpunit }}
+          echo "SYMFONY_PHPUNIT_VERSION=${{ matrix.symfony_phpunit }}" >> $GITHUB_ENV
 
       - name: Checkout Code
         uses: actions/checkout@v2

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -65,13 +65,13 @@ jobs:
 
       - name: Set Environment Variables
         run: |
-          echo "SYMFONY_PHPUNIT_VERSION=${{ matrix.symfony_phpunit }}" >> $GITHUB_ENV
-          echo "PHP_VERSION=$(php -r 'echo phpversion();')" >> $GITHUB_ENV
-          echo "PHP_MINOR=${{ matrix.php }}" >> $GITHUB_ENV
-          echo "TEST_PHP_EXECUTABLE=${env:PHPROOT}\php.exe" >> $GITHUB_ENV
-          echo "BUILD_TYPE=${{ matrix.build_type }}" >> $GITHUB_ENV
-          echo "VC_VERSION=${{ matrix.vc_num }}" >> $GITHUB_ENV
-          echo "PHP_ARCH=${{ matrix.arch }}" >> $GITHUB_ENV
+          Write-Output "SYMFONY_PHPUNIT_VERSION=${{ matrix.symfony_phpunit }}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          Write-Output "PHP_VERSION=$(php -r 'echo phpversion();')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          Write-Output "PHP_MINOR=${{ matrix.php }}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          Write-Output "TEST_PHP_EXECUTABLE=${env:PHPROOT}\php.exe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          Write-Output "BUILD_TYPE=${{ matrix.build_type }}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          Write-Output "VC_VERSION=${{ matrix.vc_num }}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          Write-Output "PHP_ARCH=${{ matrix.arch }}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Checkout Code
         uses: actions/checkout@v2

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -65,13 +65,13 @@ jobs:
 
       - name: Set Environment Variables
         run: |
-          echo "::set-env name=SYMFONY_PHPUNIT_VERSION::${{ matrix.symfony_phpunit }}"
-          echo "::set-env name=PHP_VERSION::$(php -r 'echo phpversion();')"
-          echo "::set-env name=PHP_MINOR::${{ matrix.php }}"
-          echo "::set-env name=TEST_PHP_EXECUTABLE::${env:PHPROOT}\php.exe"
-          echo "::set-env name=BUILD_TYPE::${{ matrix.build_type }}"
-          echo "::set-env name=VC_VERSION::${{ matrix.vc_num }}"
-          echo "::set-env name=PHP_ARCH::${{ matrix.arch }}"
+          echo "SYMFONY_PHPUNIT_VERSION=${{ matrix.symfony_phpunit }}" >> $GITHUB_ENV
+          echo "PHP_VERSION=$(php -r 'echo phpversion();')" >> $GITHUB_ENV
+          echo "PHP_MINOR=${{ matrix.php }}" >> $GITHUB_ENV
+          echo "TEST_PHP_EXECUTABLE=${env:PHPROOT}\php.exe" >> $GITHUB_ENV
+          echo "BUILD_TYPE=${{ matrix.build_type }}" >> $GITHUB_ENV
+          echo "VC_VERSION=${{ matrix.vc_num }}" >> $GITHUB_ENV
+          echo "PHP_ARCH=${{ matrix.arch }}" >> $GITHUB_ENV
 
       - name: Checkout Code
         uses: actions/checkout@v2
@@ -127,10 +127,10 @@ jobs:
         shell: powershell
         run: |
           $v = "${env:WindowsSDKVersion}" -replace '\\$', ''
-          Write-Output "::set-env name=WindowsSDKVersion::$v"
+          Write-Output "WindowsSDKVersion=$v" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
           $v = "${env:WindowsSDKLibVersion}" -replace '\\$', ''
-          Write-Output "::set-env name=WindowsSDKLibVersion::$v"
+          Write-Output "WindowsSDKLibVersion=$v" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Get Composer Cache Directory
         id: composer-cache

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -49,6 +49,5 @@ return PhpCsFixer\Config::create()
         'protected_to_private' => false,
         'phpdoc_var_annotation_correct_order' => true,
         'no_superfluous_phpdoc_tags' => false,
-        // Removed this line, because latest php-cs-fixer v2.15.x does not support this rule
-        // 'single_line_throw' => false,
+        'single_line_throw' => false,
     ]);

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -49,5 +49,5 @@ return PhpCsFixer\Config::create()
         'protected_to_private' => false,
         'phpdoc_var_annotation_correct_order' => true,
         'no_superfluous_phpdoc_tags' => false,
-        'single_line_throw' => false,
+        // 'single_line_throw' => false,
     ]);


### PR DESCRIPTION
Hello!

* Type: code quality

Small description of change:

- Fixed failed CI workflow caused by deprecated set-env syntax
- Added [ci skip] ability
- Fixed php-cs fixer rule for `single_line_thrown`
- Fixed codecov action input param

Thanks
