### PR TITLE
Fix PHP 8 warning missing arginfo

### DIFF
--- a/Library/ClassDefinition.php
+++ b/Library/ClassDefinition.php
@@ -1339,7 +1339,7 @@ final class ClassDefinition
                             $method->isReturnTypesHintDetermined() &&
                             $method->areReturnTypesCompatible();
 
-                        if ($richFormat || $method->hasParameters()) {
+                        if ($richFormat || $method->hasParameters() || version_compare(PHP_VERSION, '8.0.0', '>=')) {
                             $codePrinter->output(
                                 sprintf(
                                     "\tZEND_ME(%s_%s, %s, %s, %s)",

--- a/Library/ClassDefinition.php
+++ b/Library/ClassDefinition.php
@@ -1342,7 +1342,7 @@ final class ClassDefinition
                         if ($richFormat || $method->hasParameters()) {
                             $codePrinter->output(
                                 sprintf(
-                                    "\tPHP_ME(%s_%s, %s, %s, %s)",
+                                    "\tZEND_ME(%s_%s, %s, %s, %s)",
                                     $this->getCNamespace(),
                                     $this->getName(),
                                     $method->getName(),
@@ -1353,7 +1353,7 @@ final class ClassDefinition
                         } else {
                             $codePrinter->output(
                                 sprintf(
-                                    "\tPHP_ME(%s_%s, %s, NULL, %s)",
+                                    "\tZEND_ME(%s_%s, %s, NULL, %s)",
                                     $this->getCNamespace(),
                                     $this->getName(),
                                     $method->getName(),

--- a/Library/ClassDefinition.php
+++ b/Library/ClassDefinition.php
@@ -1342,7 +1342,8 @@ final class ClassDefinition
                         if ($richFormat || $method->hasParameters() || version_compare(PHP_VERSION, '8.0.0', '>=')) {
                             $codePrinter->output(
                                 sprintf(
-                                    "\tZEND_ME(%s_%s, %s, %s, %s)",
+                                    // TODO: Rename to ZEND_ME
+                                    "\tPHP_ME(%s_%s, %s, %s, %s)",
                                     $this->getCNamespace(),
                                     $this->getName(),
                                     $method->getName(),
@@ -1353,7 +1354,8 @@ final class ClassDefinition
                         } else {
                             $codePrinter->output(
                                 sprintf(
-                                    "\tZEND_ME(%s_%s, %s, NULL, %s)",
+                                    // TODO: Rename to ZEND_ME
+                                    "\tPHP_ME(%s_%s, %s, NULL, %s)",
                                     $this->getCNamespace(),
                                     $this->getName(),
                                     $method->getName(),


### PR DESCRIPTION
Hello!

* Type: bug fix | new feature | code quality | documentation
* Link to issue:

In raising this pull request, I confirm the following:

- [ ] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I updated the CHANGELOG

Small description of change:

Thanks
