### PR TITLE
#658 - Add test case for filter_var() PHP function

### DIFF
--- a/stub/functions.zep
+++ b/stub/functions.zep
@@ -1,0 +1,27 @@
+
+namespace Stub;
+
+class Functions
+{
+    /**
+     * @issue https://github.com/phalcon/zephir/issues/658
+     */
+    public function filterVar1() -> bool
+    {
+        var ret;
+        let ret = "0";
+
+        return false === filter_var($ret, FILTER_VALIDATE_FLOAT, 20480);
+    }
+
+    /**
+     * @issue https://github.com/phalcon/zephir/issues/658
+     */
+    public function filterVar2() -> bool
+    {
+        var ret;
+        let ret = "0";
+
+        return false == filter_var($ret, FILTER_VALIDATE_FLOAT, 20480);
+    }
+}

--- a/stub/functions.zep
+++ b/stub/functions.zep
@@ -11,7 +11,7 @@ class Functions
         var ret;
         let ret = "0";
 
-        return false === filter_var($ret, FILTER_VALIDATE_FLOAT, 20480);
+        return false === filter_var(ret, FILTER_VALIDATE_FLOAT, 20480);
     }
 
     /**
@@ -22,6 +22,6 @@ class Functions
         var ret;
         let ret = "0";
 
-        return false == filter_var($ret, FILTER_VALIDATE_FLOAT, 20480);
+        return false == filter_var(ret, FILTER_VALIDATE_FLOAT, 20480);
     }
 }

--- a/tests/Extension/FunctionsTest.php
+++ b/tests/Extension/FunctionsTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Zephir.
+ *
+ * (c) Phalcon Team <team@zephir-lang.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Extension;
+
+use PHPUnit\Framework\TestCase;
+use Stub\Functions;
+
+class FunctionsTest extends TestCase
+{
+    public function testFilterVar(): void
+    {
+        $class = new Functions();
+
+        $this->assertFalse($class->filterVar1());
+        $this->assertTrue($class->filterVar2());
+    }
+}


### PR DESCRIPTION
Hello!

* Type: bug fix | new feature | code quality | documentation
* Link to issue: #658

In raising this pull request, I confirm the following:

- [ ] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I updated the CHANGELOG

Small description of change:

Thanks
