### PR TITLE
Add test - Static Function call via constructor and late binding

### DIFF
--- a/stub/scalllateconstruct.zep
+++ b/stub/scalllateconstruct.zep
@@ -1,0 +1,30 @@
+/**
+ * Static Function call via constructor and late binding
+ */
+
+namespace Stub;
+
+class ScallLateConstruct
+{
+    protected protectedVar;
+
+    public function __construct()
+    {
+        this->testPublicInit();
+    }
+    
+	static public function testStaticInit() -> string
+	{
+		return "hello public";
+	}
+    
+    public function testPublicInit()
+    {
+        let this->protectedVar = self::testStaticInit();
+    }
+    
+    public function varValue() -> string
+    {
+        return this->protectedVar;
+    }
+}

--- a/tests/Extension/ScallLateConstructTest.php
+++ b/tests/Extension/ScallLateConstructTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Zephir.
+ *
+ * (c) Phalcon Team <team@zephir-lang.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Extension;
+
+use PHPUnit\Framework\TestCase;
+use Stub\ScallLateConstruct;
+
+class ScallLateConstructTest extends TestCase
+{
+    /**
+     * @see https://github.com/phalcon/zephir/issues/2111
+     */    
+    public function testConstruct()
+    {
+        if (version_compare(PHP_VERSION, '8.0.0', '>=')) {
+            //$this->markTestSkipped('Should be fixed static call before run this test (Invalid callback , no array or string given)');
+        }
+
+        $test = new ScallLateConstruct();
+        $this->assertSame('hello public', $test->varValue());
+    }
+}


### PR DESCRIPTION
Hello!

* Type: code quality
* Link to issue:
https://github.com/phalcon/zephir/issues/2111

In raising this pull request, I confirm the following:

- [ X ] I have checked that another pull request for this purpose does not exist
- [ X ] I wrote some tests for this PR
- [ ] I updated the CHANGELOG

Small description of change:
Static Function call via constructor and late binding test that should work.

Thanks
