### PR TITLE
Always use / as path separator in config.m4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 - Fixed missing kernel directory at build time [ice/framework#271](https://github.com/ice/framework/issues/271)
 - Fixed stubs generation for case with array declaration with square brackets in params
 - Fixed parameters positioning for `implode()` php function [#2120](https://github.com/phalcon/zephir/issues/2120)
+- Fixed path separators in generated `config.m4` file on Windows [#2153](https://github.com/phalcon/zephir/issues/2153)
+
 
 ## [0.12.19] - 2020-05-13
 ### Fixed

--- a/Library/Compiler.php
+++ b/Library/Compiler.php
@@ -1113,9 +1113,9 @@ final class Compiler
             '%PROJECT_LOWER%' => strtolower($project),
             '%PROJECT_UPPER%' => strtoupper($project),
             '%PROJECT_CAMELIZE%' => ucfirst($project),
-            '%FILES_COMPILED%' => implode("\n\t", $compiledFiles),
-            '%HEADERS_COMPILED%' => implode(' ', $compiledHeaders),
-            '%EXTRA_FILES_COMPILED%' => implode("\n\t", $this->extraFiles),
+            '%FILES_COMPILED%' => implode("\n\t", $this->toUnixPaths($compiledFiles)),
+            '%HEADERS_COMPILED%' => implode(' ', $this->toUnixPaths($compiledHeaders)),
+            '%EXTRA_FILES_COMPILED%' => implode("\n\t", $this->toUnixPaths($this->extraFiles)),
             '%PROJECT_EXTRA_LIBS%' => $extraLibs,
             '%PROJECT_EXTRA_CFLAGS%' => $extraCflags,
         ];
@@ -2328,5 +2328,16 @@ final class Compiler
         }
 
         return '0.0.0';
+    }
+
+    private function toUnixPaths(array $paths): array
+    {
+        return array_map(
+            static function(string $path): string
+            {
+                return str_replace(\DIRECTORY_SEPARATOR, '/', $path);
+            },
+            $paths
+        );
     }
 }

--- a/tests/Zephir/CompilerFile/CheckPathSeparatorTest.php
+++ b/tests/Zephir/CompilerFile/CheckPathSeparatorTest.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Zephir.
+ *
+ * (c) Phalcon Team <team@zephir-lang.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zephir\Test\CompilerFile;
+
+use PHPUnit\Framework\TestCase;
+
+class CheckPathSeparatorTest extends TestCase
+{
+    public function testExtendsClassThatDoesNotExist()
+    {
+        $configM4Path = realpath(__DIR__.'/../../../ext/config.m4');
+        $configM4Contents = file_get_contents($configM4Path);
+        $this->assertTrue(strpos($configM4Contents, 'stub/oo/abstractstatic.zep.c') !== false);
+    }
+}


### PR DESCRIPTION
When running `zephir generate` under Windows, paths are separated by `\` instead of `/` in the generated `config.m4` file. We should always have `/`.

Fixes #2153