### PR TITLE
Fix undefined array key error when detecting class name entry

### DIFF
--- a/Library/ClassMethod.php
+++ b/Library/ClassMethod.php
@@ -2702,7 +2702,7 @@ class ClassMethod
          */
         if (strpos($className, '\\') === 0) {
             $classNamespace = explode('\\', $className);
-            $classNamespace = array_filter($classNamespace);
+            $classNamespace = array_values(array_filter($classNamespace));
 
             /**
              * External class


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/zephir-lang/zephir/issues/2111

In raising this pull request, I confirm the following:

- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I updated the CHANGELOG

I am trying to compile custom Phalcon 3.4.x for PHP 8 ([diff](https://github.com/phalcon/cphalcon/compare/3.4.x...ufoproger:3.4.x-php8)) by latest Zephir from `zephir-php8` branch. Command `zephir generate` breaks with error below:
```
In ClassMethod.php line 2717:
                         
  [ErrorException]       
  Undefined array key 0  
                         

Exception trace:
  at /navikey/php8-phalcon/vendor/phalcon/zephir/Library/ClassMethod.php:2717
 Zephir\{closure}() at /navikey/php8-phalcon/vendor/phalcon/zephir/Library/ClassMethod.php:2717
 Zephir\ClassMethod->detectClassNameEntry() at /navikey/php8-phalcon/vendor/phalcon/zephir/Library/ClassMethod.php:2586
 Zephir\ClassMethod->detectParam() at /navikey/php8-phalcon/vendor/phalcon/zephir/Library/ClassMethod.php:2243
 Zephir\ClassMethod->compile() at /navikey/php8-phalcon/vendor/phalcon/zephir/Library/ClassDefinition.php:1262
 Zephir\ClassDefinition->compile() at /navikey/php8-phalcon/vendor/phalcon/zephir/Library/CompilerFile.php:259
 Zephir\CompilerFile->compileClass() at /navikey/php8-phalcon/vendor/phalcon/zephir/Library/CompilerFile.php:853
 Zephir\CompilerFile->compile() at /navikey/php8-phalcon/vendor/phalcon/zephir/Library/Compiler.php:707
 Zephir\Compiler->generate() at /navikey/php8-phalcon/vendor/phalcon/zephir/Library/Console/Command/GenerateCommand.php:72
 Zephir\Console\Command\GenerateCommand->execute() at /navikey/php8-phalcon/vendor/symfony/console/Command/Command.php:255
 Symfony\Component\Console\Command\Command->run() at /navikey/php8-phalcon/vendor/symfony/console/Application.php:1010
 Symfony\Component\Console\Application->doRunCommand() at /navikey/php8-phalcon/vendor/symfony/console/Application.php:255
 Symfony\Component\Console\Application->doRun() at /navikey/php8-phalcon/vendor/phalcon/zephir/Library/Console/Application.php:162
 Zephir\Console\Application->doRun() at /navikey/php8-phalcon/vendor/symfony/console/Application.php:148
 Symfony\Component\Console\Application->run() at /navikey/php8-phalcon/vendor/phalcon/zephir/zephir:22

generate [--backend BACKEND] [-h|--help] [--no-ansi] [-v|--verbose] [--] <command>
```

https://github.com/zephir-lang/zephir/blob/7cb884252f1800a3a958b686bb5c3a7dbc9cf21f/Library/ClassMethod.php#L2703-L2722

This code does not guarantee that the array contains an element with key `0`. The `array_filter` function removes empty elements, but retains the keys. Additionally, you need to reset the array keys using `array_values`. 