### PR TITLE
#2176 - Fix ZEND_FENTRY() for interface with static method without parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format based on [Keep a Changelog](http://keepachangelog.com)
 and this project adheres to [Semantic Versioning](http://semver.org).
 
 ## [Unreleased]
+### Fixed
+- Fixed not used arginfo for interface static method without parameters (PHP `>= 8.0` only) [#2178](https://github.com/zephir-lang/zephir/pull/2178)
 
 ## [0.13.0] - 2021-03-25
 ### Added

--- a/Library/ClassDefinition.php
+++ b/Library/ClassDefinition.php
@@ -1414,12 +1414,22 @@ final class ClassDefinition extends AbstractClassDefinition
                                 )
                             );
                         } else {
+                            $codePrinter->output('#if PHP_VERSION_ID >= 80000');
+                            $codePrinter->output(
+                                sprintf(
+                                    "\tZEND_FENTRY(%s, NULL, %s, ZEND_ACC_STATIC|ZEND_ACC_ABSTRACT|ZEND_ACC_PUBLIC)",
+                                    $method->getName(),
+                                    $method->getArgInfoName($this)
+                                )
+                            );
+                            $codePrinter->output('#else');
                             $codePrinter->output(
                                 sprintf(
                                     "\tZEND_FENTRY(%s, NULL, NULL, ZEND_ACC_STATIC|ZEND_ACC_ABSTRACT|ZEND_ACC_PUBLIC)",
                                     $method->getName()
                                 )
                             );
+                            $codePrinter->output('#endif');
                         }
                     } else {
                         $isInterface = $method->getClassDefinition()->isInterface();

--- a/stub/interfaces/interfacestaticmethod.zep
+++ b/stub/interfaces/interfacestaticmethod.zep
@@ -1,0 +1,6 @@
+namespace Stub\Interfaces;
+
+interface InterfaceStaticMethod
+{
+    public static function reset();
+}


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: fix #2176

In raising this pull request, I confirm the following:

- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I updated the CHANGELOG

Small description of change:
Use arginfo when calling macros ZEND_FENTRY() for interface static method without parameters. Needs for PHP 8.

Thanks

P.S.: pull request https://github.com/zephir-lang/zephir/pull/2177 can be deleted.
