### PR TITLE
#812 - Fix `uint` cast to abs in function params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 ## [Unreleased]
 ### Fixed
 - Fixed default value of nullable string parameter [#2180](https://github.com/zephir-lang/zephir/issues/2180)
+- Fix `uint` cast to `unsigned int` in function params [#812](https://github.com/zephir-lang/zephir/issues/812)
 
 ## [0.13.1] - 2021-03-31
 ### Added

--- a/Library/Backends/ZendEngine2/Backend.php
+++ b/Library/Backends/ZendEngine2/Backend.php
@@ -1009,9 +1009,11 @@ class Backend extends BaseBackend
         /* Assign param */
         switch ($type) {
             case 'int':
-            case 'uint':
             case 'long':
                 $codePrinter->output($var['name'].' = Z_LVAL_P('.$parameterCode.');');
+                break;
+            case 'uint':
+                $codePrinter->output($var['name'].' = ZEND_ABS(Z_LVAL_P('.$parameterCode.'));');
                 break;
             case 'bool':
                 $codePrinter->output($var['name'].' = '.$this->getBoolCode($parameterVariable, $context, false).';');

--- a/Library/ClassMethod.php
+++ b/Library/ClassMethod.php
@@ -2370,6 +2370,8 @@ class ClassMethod
                 break;
 
             case 'int':
+            case 'uint':
+            case 'long':
                 if ($hasDefaultNull) {
                     $param = sprintf('Z_PARAM_LONG_OR_NULL(%s, is_null_true)', $name);
                 } else {

--- a/kernels/ZendEngine3/object.c
+++ b/kernels/ZendEngine3/object.c
@@ -501,7 +501,8 @@ int zephir_read_property(
 	zval *result,
 	zval *object,
 	const char *property_name,
-	uint32_t property_length, int flags
+	uint32_t property_length,
+	int flags
 ) {
 	zval property, tmp;
 	zval *res;

--- a/stub/arithmetic.zep
+++ b/stub/arithmetic.zep
@@ -1468,7 +1468,17 @@ class Arithmetic
     /**
      * @issue https://github.com/zephir-lang/zephir/issues/812
      */
-	public function absParam(const uint! val)
+	public function absParam(const uint! val) -> uint
+	{
+	    return val;
+	}
+
+	public function negativeInt(const int val) -> int
+	{
+	    return val;
+	}
+
+	public function negativeLong(const long val) -> long
 	{
 	    return val;
 	}

--- a/stub/arithmetic.zep
+++ b/stub/arithmetic.zep
@@ -1464,4 +1464,12 @@ class Arithmetic
 	{
 		return (this->tmp1 - 1) / 4;
 	}
+
+    /**
+     * @issue https://github.com/zephir-lang/zephir/issues/812
+     */
+	public function absParam(const uint! val)
+	{
+	    return val;
+	}
 }

--- a/tests/Extension/ArithmeticTest.php
+++ b/tests/Extension/ArithmeticTest.php
@@ -265,4 +265,10 @@ final class ArithmeticTest extends TestCase
         $this->assertFalse($this->class->letStatementBoolMinus(false));
         $this->assertFalse($this->class->letStatementBoolMinus(0));
     }
+
+    public function testIssue812(): void
+    {
+        $this->assertSame(1, $this->class->absParam(1));
+        $this->assertSame(1, $this->class->absParam(-1));
+    }
 }

--- a/tests/Extension/ArithmeticTest.php
+++ b/tests/Extension/ArithmeticTest.php
@@ -270,5 +270,14 @@ final class ArithmeticTest extends TestCase
     {
         $this->assertSame(1, $this->class->absParam(1));
         $this->assertSame(1, $this->class->absParam(-1));
+        $this->assertSame(1234567, $this->class->absParam(-1234567));
+
+        $this->assertSame(-1, $this->class->negativeInt(-1));
+        $this->assertSame(-1234567, $this->class->negativeInt(-1234567));
+        $this->assertSame(1234567, $this->class->negativeInt(1234567));
+
+        $this->assertSame(-1, $this->class->negativeLong(-1));
+        $this->assertSame(-1234567, $this->class->negativeLong(-1234567));
+        $this->assertSame(1234567, $this->class->negativeLong(1234567));
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #812

In raising this pull request, I confirm the following:

- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I updated the CHANGELOG

Thanks
