### PR TITLE
#2186 - Change empty string check from `IS_UNDEF` to `ZEPHIR_IS_EMPTY`

### DIFF
--- a/Library/Backends/ZendEngine3/Backend.php
+++ b/Library/Backends/ZendEngine3/Backend.php
@@ -1160,7 +1160,7 @@ class Backend extends BackendZendEngine2
         if ($var->isDoublePointer()) {
             return parent::ifVariableValueUndefined($var, $context, $useBody, $useCodePrinter);
         }
-        $body = 'Z_TYPE_P('.$this->getVariableCode($var).') == IS_UNDEF';
+        $body = 'ZEPHIR_IS_EMPTY('.$this->getVariableCode($var).')';
         $output = 'if ('.$body.') {';
         if ($useCodePrinter) {
             $context->codePrinter->output($output);

--- a/Library/Optimizers/EvalExpression.php
+++ b/Library/Optimizers/EvalExpression.php
@@ -190,7 +190,7 @@ class EvalExpression
 
                 $this->usedVariables[] = $variableRight->getName();
 
-                /*
+                /**
                  * Evaluate the variable
                  */
                 switch ($variableRight->getType()) {
@@ -203,9 +203,7 @@ class EvalExpression
                         return $variableRight->getName();
 
                     case 'string':
-                        $variableRightCode = $compilationContext->backend->getVariableCode($variableRight);
-
-                        return '!('.$compilationContext->backend->ifVariableValueUndefined($variableRight, $compilationContext, true, false).') && Z_STRLEN_P('.$variableRightCode.')';
+                        return '!('.$compilationContext->backend->ifVariableValueUndefined($variableRight, $compilationContext, true, false).')';
 
                     case 'bool':
                         return $variableRight->getName();

--- a/stub/strings.zep
+++ b/stub/strings.zep
@@ -174,4 +174,34 @@ class Strings
 	{
 	    return val === null;
 	}
+
+	public function issue2186SegFault(string val = null) -> bool
+	{
+	    if val {
+	        return true;
+	    }
+
+	    return false;
+	}
+
+	public function issue2186SegFaultCall(string val = null) -> string
+	{
+	    return this->issue2186Child1(val);
+	}
+
+	protected function issue2186Child1(string val = null) -> string
+	{
+	    return this->issue2186Child2(val);
+	}
+
+    protected function issue2186Child2(string val = null) -> string
+    {
+        var output = "";
+
+        if val {
+            let output = val . " all ok";
+        }
+
+        return output;
+    }
 }

--- a/tests/Extension/StringTest.php
+++ b/tests/Extension/StringTest.php
@@ -291,6 +291,27 @@ final class StringTest extends TestCase
         $this->assertFalse($this->test->issue2186('string'));
         $this->assertFalse($this->test->issue2186('0'));
         $this->assertFalse($this->test->issue2186('1'));
+
+        $this->assertFalse($this->test->issue2186SegFault());
+        $this->assertFalse($this->test->issue2186SegFault(null));
+        $this->assertFalse($this->test->issue2186SegFault(''));
+
+        /**
+         * Assert PHP and Zephir behavior
+         */
+        $zeroString = false;
+        if ('0') {
+            $zeroString = true;
+        }
+
+        $this->assertFalse(!empty('0'));
+        $this->assertFalse($zeroString);
+        $this->assertFalse($this->test->issue2186SegFault('0'));
+
+        $this->assertTrue($this->test->issue2186SegFault('string'));
+
+        $this->assertSame('', $this->test->issue2186SegFaultCall());
+        $this->assertSame('ok all ok', $this->test->issue2186SegFaultCall('ok'));
     }
 
     public function providerHashEquals(): array


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #2186

In raising this pull request, I confirm the following:

- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I updated the CHANGELOG

In some cases, when used `IS_UNDEF` on `null` it was giving **seg fault**.

```php
<?php

declare(strict_types=1);


$var1 = null;
$var2 = 0;
$var3 = 1;
$var4 = '0';
$var5 = false;
$var6 = '';
$var7 = '1';
$var8 = [];

var_dump(empty($var1), !$var1); // true, true
echo PHP_EOL;
var_dump(empty($var2), !$var2); // true, true
echo PHP_EOL;
var_dump(empty($var3), !$var3); // false, false
echo PHP_EOL;
var_dump(empty($var4), !$var4); // true, true
echo PHP_EOL;
var_dump(empty($var5), !$var5); // true, true
echo PHP_EOL;
var_dump(empty($var6), !$var6); // true, true
echo PHP_EOL;
var_dump(empty($var7), !$var7); // false, false
echo PHP_EOL;
var_dump(empty($var8), !$var8); // true, true
```

Thanks
