### PR TITLE
#1245 - Add test case for `get_object_vars()`

### DIFF
--- a/ext/config.m4
+++ b/ext/config.m4
@@ -171,6 +171,7 @@ if test "$PHP_STUB" = "yes"; then
 	stub/pregmatch.zep.c
 	stub/properties/app.zep.c
 	stub/properties/extendspublicproperties.zep.c
+	stub/properties/getobjectvars.zep.c
 	stub/properties/privateproperties.zep.c
 	stub/properties/propertyarray.zep.c
 	stub/properties/propertyupdate.zep.c

--- a/ext/config.w32
+++ b/ext/config.w32
@@ -21,7 +21,7 @@ if (PHP_STUB != "no") {
 	ADD_SOURCES(configure_module_dirname + "/stub/oo/extend/db/query", "exception.zep.c", "stub");
 	ADD_SOURCES(configure_module_dirname + "/stub/oo/scopes", "hasprivatemethod.zep.c scopetesterinterface.zep.c abstractclass.zep.c abstractclassmagic.zep.c privatescopetester.zep.c", "stub");
 	ADD_SOURCES(configure_module_dirname + "/stub/ooimpl", "zbeginning.zep.c abeginning.zep.c", "stub");
-	ADD_SOURCES(configure_module_dirname + "/stub/properties", "publicproperties.zep.c app.zep.c extendspublicproperties.zep.c privateproperties.zep.c propertyarray.zep.c propertyupdate.zep.c protectedproperties.zep.c staticprivateproperties.zep.c staticpropertyarray.zep.c staticprotectedproperties.zep.c staticpublicproperties.zep.c", "stub");
+	ADD_SOURCES(configure_module_dirname + "/stub/properties", "publicproperties.zep.c app.zep.c extendspublicproperties.zep.c getobjectvars.zep.c privateproperties.zep.c propertyarray.zep.c propertyupdate.zep.c protectedproperties.zep.c staticprivateproperties.zep.c staticpropertyarray.zep.c staticprotectedproperties.zep.c staticpublicproperties.zep.c", "stub");
 	ADD_SOURCES(configure_module_dirname + "/stub/bench", "foo.zep.c", "stub");
 	ADD_SOURCES(configure_module_dirname + "/stub/builtin", "arraymethods.zep.c charmethods.zep.c intmethods.zep.c stringmethods.zep.c", "stub");
 	ADD_SOURCES(configure_module_dirname + "/stub/constructors", "issue1803.zep.c", "stub");

--- a/ext/stub.c
+++ b/ext/stub.c
@@ -199,6 +199,7 @@ zend_class_entry *stub_pdostatement_ce;
 zend_class_entry *stub_pregmatch_ce;
 zend_class_entry *stub_properties_app_ce;
 zend_class_entry *stub_properties_extendspublicproperties_ce;
+zend_class_entry *stub_properties_getobjectvars_ce;
 zend_class_entry *stub_properties_privateproperties_ce;
 zend_class_entry *stub_properties_propertyarray_ce;
 zend_class_entry *stub_properties_propertyupdate_ce;
@@ -420,6 +421,7 @@ static PHP_MINIT_FUNCTION(stub)
 	ZEPHIR_INIT(Stub_Pregmatch);
 	ZEPHIR_INIT(Stub_Properties_App);
 	ZEPHIR_INIT(Stub_Properties_ExtendsPublicProperties);
+	ZEPHIR_INIT(Stub_Properties_GetObjectVars);
 	ZEPHIR_INIT(Stub_Properties_PrivateProperties);
 	ZEPHIR_INIT(Stub_Properties_PropertyArray);
 	ZEPHIR_INIT(Stub_Properties_PropertyUpdate);

--- a/ext/stub.h
+++ b/ext/stub.h
@@ -166,6 +166,7 @@
 #include "stub/pregmatch.zep.h"
 #include "stub/properties/app.zep.h"
 #include "stub/properties/extendspublicproperties.zep.h"
+#include "stub/properties/getobjectvars.zep.h"
 #include "stub/properties/privateproperties.zep.h"
 #include "stub/properties/propertyarray.zep.h"
 #include "stub/properties/propertyupdate.zep.h"

--- a/ext/stub/properties/getobjectvars.zep.c
+++ b/ext/stub/properties/getobjectvars.zep.c
@@ -1,0 +1,47 @@
+
+#ifdef HAVE_CONFIG_H
+#include "../../ext_config.h"
+#endif
+
+#include <php.h>
+#include "../../php_ext.h"
+#include "../../ext.h"
+
+#include <Zend/zend_operators.h>
+#include <Zend/zend_exceptions.h>
+#include <Zend/zend_interfaces.h>
+
+#include "kernel/main.h"
+#include "kernel/fcall.h"
+#include "kernel/object.h"
+#include "kernel/memory.h"
+
+
+ZEPHIR_INIT_CLASS(Stub_Properties_GetObjectVars)
+{
+	ZEPHIR_REGISTER_CLASS(Stub\\Properties, GetObjectVars, stub, properties_getobjectvars, stub_properties_getobjectvars_method_entry, 0);
+
+	zend_declare_property_long(stub_properties_getobjectvars_ce, SL("a"), 1, ZEND_ACC_PUBLIC);
+	zend_declare_property_long(stub_properties_getobjectvars_ce, SL("b"), 2, ZEND_ACC_PROTECTED);
+	zend_declare_property_long(stub_properties_getobjectvars_ce, SL("c"), 3, ZEND_ACC_PRIVATE);
+	return SUCCESS;
+}
+
+/**
+ * @issue https://github.com/zephir-lang/zephir/issues/1245
+ */
+PHP_METHOD(Stub_Properties_GetObjectVars, issue1245)
+{
+	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
+	zend_long ZEPHIR_LAST_CALL_STATUS;
+	zval *this_ptr = getThis();
+
+
+
+	ZEPHIR_MM_GROW();
+
+	ZEPHIR_RETURN_CALL_FUNCTION("get_object_vars", NULL, 73, this_ptr);
+	zephir_check_call_status();
+	RETURN_MM();
+}
+

--- a/ext/stub/properties/getobjectvars.zep.h
+++ b/ext/stub/properties/getobjectvars.zep.h
@@ -1,0 +1,14 @@
+
+extern zend_class_entry *stub_properties_getobjectvars_ce;
+
+ZEPHIR_INIT_CLASS(Stub_Properties_GetObjectVars);
+
+PHP_METHOD(Stub_Properties_GetObjectVars, issue1245);
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_stub_properties_getobjectvars_issue1245, 0, 0, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEPHIR_INIT_FUNCS(stub_properties_getobjectvars_method_entry) {
+	PHP_ME(Stub_Properties_GetObjectVars, issue1245, arginfo_stub_properties_getobjectvars_issue1245, ZEND_ACC_PUBLIC)
+	PHP_FE_END
+};

--- a/ext/stub/properties/staticprotectedproperties.zep.c
+++ b/ext/stub/properties/staticprotectedproperties.zep.c
@@ -194,6 +194,9 @@ PHP_METHOD(Stub_Properties_StaticProtectedProperties, getSomeString)
 	RETURN_CTORW(&_0);
 }
 
+/**
+ * @issue https://github.com/zephir-lang/zephir/issues/1536
+ */
 PHP_METHOD(Stub_Properties_StaticProtectedProperties, compareStaticNull)
 {
 	zval someNull, _0;

--- a/stub/properties/getobjectvars.zep
+++ b/stub/properties/getobjectvars.zep
@@ -1,0 +1,17 @@
+
+namespace Stub\Properties;
+
+class GetObjectVars
+{
+    public    a = 1;
+    protected b = 2;
+    private   c = 3;
+
+    /**
+     * @issue https://github.com/zephir-lang/zephir/issues/1245
+     */
+    public function issue1245() -> array
+    {
+        return get_object_vars(this);
+    }
+}

--- a/tests/Extension/Properties/GetObjectVarsTest.php
+++ b/tests/Extension/Properties/GetObjectVarsTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * This file is part of the Zephir.
+ *
+ * (c) Phalcon Team <team@zephir-lang.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Extension\Properties;
+
+use PHPUnit\Framework\TestCase;
+use Stub\Properties\GetObjectVars;
+
+final class GetObjectVarsTest extends TestCase
+{
+    /**
+     * @issue https://github.com/zephir-lang/zephir/issues/1245
+     */
+    public function testIssue1245ShouldReturnAllVisibilityProperties(): void
+    {
+        $test = new GetObjectVars();
+
+        $this->assertSame(['a' => 1, 'b' => 2, 'c' => 3], $test->issue1245());
+    }
+}


### PR DESCRIPTION
Hello!

* Type: code quality

In raising this pull request, I confirm the following:

- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [ ] I updated the CHANGELOG

Small description of change:

Thanks
