### PR TITLE
#2226 - Update list of class entries for PHP extension 'date'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 ### Fixed
 - Fixed nullable array [#1094](https://github.com/zephir-lang/zephir/issues/1094)
 - Fixed default value detection with Reflection (only PHP 8.0) [#1134](https://github.com/zephir-lang/zephir/issues/1134)
+- Updated supported list of class entries for PHP date extension [#2226](https://github.com/zephir-lang/zephir/issues/2226)
 
 ### Added
 - Added support syntax assign-bitwise operators [#1103](https://github.com/zephir-lang/zephir/issues/1103)

--- a/Library/ClassDefinition.php
+++ b/Library/ClassDefinition.php
@@ -1912,14 +1912,37 @@ final class ClassDefinition extends AbstractClassDefinition
                 $classEntry = 'php_pdo_get_exception()';
                 break;
 
+            /**
+             * PHP Ext Date
+             */
+            case 'datetimeinterface':
+                $compilationContext->headersManager->add('ext/date/php_date');
+                $classEntry = 'php_date_get_interface_ce()';
+                break;
+
             case 'datetime':
                 $compilationContext->headersManager->add('ext/date/php_date');
                 $classEntry = 'php_date_get_date_ce()';
                 break;
 
+            case 'datetimeimmutable':
+                $compilationContext->headersManager->add('ext/date/php_date');
+                $classEntry = 'php_date_get_immutable_ce()';
+                break;
+
             case 'datetimezone':
                 $compilationContext->headersManager->add('ext/date/php_date');
                 $classEntry = 'php_date_get_timezone_ce()';
+                break;
+
+            case 'dateinterval':
+                $compilationContext->headersManager->add('ext/date/php_date');
+                $classEntry = 'php_date_get_interval_ce()';
+                break;
+
+            case 'dateperiod':
+                $compilationContext->headersManager->add('ext/date/php_date');
+                $classEntry = 'php_date_get_period_ce()';
                 break;
 
             /**


### PR DESCRIPTION
Hello!

* Type: bug fix

In raising this pull request, I confirm the following:

- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I updated the CHANGELOG

Blocks https://github.com/phalcon/cphalcon/pull/15412

Thanks
