### PR TITLE
Add release notes parser, store Phar after build [ci skip]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,10 +55,20 @@ jobs:
       - name: Build Zephir PHAR
         run: .ci/build-phar.sh
 
+      - name: Upload Zephir Phar
+        uses: actions/upload-artifact@v2
+        with:
+          name: zephir.phar
+          path: zephir.phar
+
       - name: Get the release version
         id: get-version
         run: |
           echo ::set-output name=version::${GITHUB_REF#refs/tags/}
+
+      - name: Prepare Release Notes
+        run: |
+          ./.ci/release-notes.sh ./CHANGELOG.md > ./release-notes.md
 
       - name: Create Release
         uses: ncipollo/release-action@v1

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,0 +1,13 @@
+### Fixed
+- Fixed multiple return types in stubs [#2283](https://github.com/zephir-lang/zephir/issues/2283)
+- Fixed `bool` return type in stubs [#2272](https://github.com/zephir-lang/zephir/issues/2272)
+
+### Changed
+- Removed `.zep` from stubs filenames [#2273](https://github.com/zephir-lang/zephir/issues/2273)
+
+## [0.14.0] - 2021-09-18
+### Added
+- Added support for `require_once` [#2253](https://github.com/zephir-lang/zephir/issues/2253)
+
+### Changed
+- Bumped minimal version of Zephir Parser to `1.4.1`. [#2284](https://github.com/zephir-lang/zephir/issues/2284)


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue:

Small description of change:

- added release notes parser
- added step to always store `zephir.phar` after build

Thanks
