### PR TITLE
#2339 - Remove call by reference from `return_value`

### DIFF
--- a/kernels/ZendEngine3/file.c
+++ b/kernels/ZendEngine3/file.c
@@ -296,7 +296,7 @@ void zephir_filemtime(zval *return_value, zval *path)
 	if (EXPECTED(Z_TYPE_P(path) == IS_STRING)) {
 #if PHP_VERSION_ID >= 80100
 		zend_string *file = zend_string_init(Z_STRVAL_P(path), Z_STRLEN_P(path), 0);
-		php_stat(file, FS_MTIME, &return_value);
+		php_stat(file, FS_MTIME, return_value);
 		zval_ptr_dtor(file);
 #else
 		php_stat(Z_STRVAL_P(path), (php_stat_len)(Z_STRLEN_P(path)), FS_MTIME, return_value);


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue:

In raising this pull request, I confirm the following:

- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I updated the CHANGELOG

Small description of change:

Thanks
