### PR TITLE
There is no need to continue if no namespaces exist

### DIFF
--- a/Library/Classes/Entry.php
+++ b/Library/Classes/Entry.php
@@ -121,7 +121,7 @@ class Entry
         /**
          * External class, we don't know its ClassEntry in C world.
          */
-        if (!$this->isInternalClass($classNamespace[0])) {
+        if ($classNamespace[0] == "" || !$this->isInternalClass($classNamespace[0])) {
             $className = str_replace(self::NAMESPACE_SEPARATOR, self::NAMESPACE_SEPARATOR.self::NAMESPACE_SEPARATOR, strtolower($className));
 
             return sprintf(

--- a/Library/Classes/Entry.php
+++ b/Library/Classes/Entry.php
@@ -121,7 +121,7 @@ class Entry
         /**
          * External class, we don't know its ClassEntry in C world.
          */
-        if ($classNamespace[0] == "" || !$this->isInternalClass($classNamespace[0])) {
+        if ($classNamespace[0] === '' || !$this->isInternalClass($classNamespace[0])) {
             $className = str_replace(self::NAMESPACE_SEPARATOR, self::NAMESPACE_SEPARATOR.self::NAMESPACE_SEPARATOR, strtolower($className));
 
             return sprintf(


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue:

In raising this pull request, I confirm the following:

- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I updated the CHANGELOG

When I build cphalcon-v5, there were always errors like:
```
cphalcon-5.0.0beta2/ext/phalcon/storage/adapter/libmemcached.zep.c: In function ‘zim_Phalcon_Storage_Adapter_Libmemcached_setOptions’:
cphalcon-5.0.0beta2/ext/phalcon/storage/adapter/libmemcached.zep.c:717:53: error: ‘__ce’ undeclared (first use in this function)
  717 |                 Z_PARAM_OBJECT_OF_CLASS(connection, __ce)
```
... and the related method definition in zephir is:

```zephir
private function setServers(<\Memcached> connection, array servers) -> <Libmemcached>
```

The 1st parameter `<\Memcached>` has no namespace or has root namespace, its variable `$classNamespace` is: 
```php
array(1) {
  [0]=> ""
}
```
 ... nothing but empty string,  so trying to resolve its `ClassDefinition` is impossible.  Like this:

 https://github.com/zephir-lang/zephir/blob/development/Library/Classes/Entry.php#L124-L134

Not just libmemcached, storage/image class like redis, imagik  etc. which defined in extension-level,  all have this problem.

Thanks
