### PR TITLE
Disable backtrace on alpine, fix #2397

### DIFF
--- a/kernels/ZendEngine3/backtrace.c
+++ b/kernels/ZendEngine3/backtrace.c
@@ -10,7 +10,7 @@
  */
 
 #ifndef ZEPHIR_RELEASE
-#if defined(linux) || defined(DARWIN) || defined(__APPLE__)
+#if defined(linux) && !defined(ALPINE_LINUX) || defined(DARWIN) || defined(__APPLE__)
 
 #include <execinfo.h>
 #include <Zend/zend.h>


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #2397

In raising this pull request, I confirm the following:

- [ ] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I updated the CHANGELOG

Small description of change:
Don't include execinfo.h if alpine linux is defined.
Thanks
