### PR TITLE
[PHP 8.4] Change `PHP_DEBUG` constant usage to `ZEND_DEBUG_BUILD`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ### Added
 - Added support of PHP `8.3` [#2407](https://github.com/zephir-lang/zephir/issues/2407)
 - Added support of multiple return types in stubs
+- Changed `PHP_DEBUG` const usage to `ZEND_DEBUG_BUILD`
 
 ### Changed
 - Changed minimal PHP version to `8.0` [#2407](https://github.com/zephir-lang/zephir/issues/2407)

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -98,7 +98,7 @@ use const DIRECTORY_SEPARATOR;
 use const INFO_GENERAL;
 use const PHP_EOL;
 use const PHP_INT_SIZE;
-use const PHP_ZTS;
+use const ZEND_THREAD_SAFE;
 use const SORT_STRING;
 use const STDERR;
 
@@ -2043,7 +2043,7 @@ final class Compiler
 
     private function isZts(): bool
     {
-        if (defined('PHP_ZTS') && PHP_ZTS === 1) {
+        if (defined('ZEND_THREAD_SAFE') && ZEND_THREAD_SAFE === true) {
             return true;
         }
 


### PR DESCRIPTION
In PHP 8.4, the type of `PHP_DEBUG` changes from `int` to `bool`. Please also see [PHP.Watch: PHP 8.4: `PHP_ZTS` and `PHP_DEBUG` constant value type changed from `int` to `bool`](https://php.watch/versions/8.4/PHP_ZTS-PHP_DEBUG-const-type-change).

This changes the constants to `ZEND_DEBUG_BUILD`, which contains the same value but as a `bool` across all PHP versions.

- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I updated the CHANGELOG