### PR TITLE
Get the class using its name, not just its namespace name

### DIFF
--- a/src/Class/Entry.php
+++ b/src/Class/Entry.php
@@ -108,7 +108,7 @@ class Entry
                 );
             }
 
-            $classNamespace = explode(self::NAMESPACE_SEPARATOR, $reflection->getNamespaceName());
+            $classNamespace = explode(self::NAMESPACE_SEPARATOR, $reflection->getName());
         } else {
             $className      = $this->classname;
             $classNamespace = explode(self::NAMESPACE_SEPARATOR, $className);


### PR DESCRIPTION
Hi!

* Type: bug fix
* Link to issue: #2277   (FYI @andrewdalpino)

In raising this pull request, I confirm the following:

- [X] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR (not yet, but I can do if this is a correct fix)
- [ ] I updated the CHANGELOG

Small description of change: I made this change while diagnosing why https://github.com/RubixML/Tensor could not be compiled against PHP 8.3, it was encountering the same issue as described in #2277.

The compile errors were, for example:
```/Users/chrisl/Code/Tensor/ext/tensor/vector.zep.c:3715:30: error: use of undeclared identifier '_tensor_ce'```

This was because for an example class `Tensor\Vector` the compiler was generating the identifier `_tensor_ce` instead of `tensor_vector_ce`.

I tracked this down to https://github.com/zephir-lang/zephir/blob/c68f9cde9734a5cef7586a27f788acf2e8a910b0/src/Class/Entry.php#L111 in the area where the code has different techniques for discovering the class name and namespace.

If I force the code to use the simpler technique by making the conditional at https://github.com/zephir-lang/zephir/blob/c68f9cde9734a5cef7586a27f788acf2e8a910b0/src/Class/Entry.php#L93 false, it gets `$classNamespace` and `$className` correctly for the code that follows the if statement. It appeared that `$classNamespace` should be the FQDN, not just the namespace.

I was not sure whether this was the correct fix for this issue, so I welcome any feedback.
