### PR TITLE
Refactor object constructor calls to use new PHP 8.4 API

### DIFF
--- a/kernel/object.c
+++ b/kernel/object.c
@@ -1227,6 +1227,77 @@ int zephir_create_closure_ex(zval *return_value, zval *this_ptr, zend_class_entr
 }
 
 /**
+ * Copied from php-src source tree for PHP 8.4
+ */
+#ifndef object_init_with_constructor
+static zend_result object_init_with_constructor(zval *arg, zend_class_entry *class_type, uint32_t param_count, zval *params, HashTable *named_params)
+{
+	zend_result status = object_and_properties_init(arg, class_type, NULL);
+	if (UNEXPECTED(status == FAILURE)) {
+		ZVAL_UNDEF(arg);
+		return FAILURE;
+	}
+	zend_object *obj = Z_OBJ_P(arg);
+	zend_function *constructor = obj->handlers->get_constructor(obj);
+	if (constructor == NULL) {
+		/* The constructor can be NULL for 2 different reasons:
+		 * - It is not defined
+		 * - We are not allowed to call the constructor (e.g. private, or internal opaque class)
+		 *   and an exception has been thrown
+		 * in the former case, we are (mostly) done and the object is initialized,
+		 * in the latter we need to destroy the object as initialization failed
+		 */
+		if (UNEXPECTED(EG(exception))) {
+			zval_ptr_dtor(arg);
+			ZVAL_UNDEF(arg);
+			return FAILURE;
+		}
+
+		/* Surprisingly, this is the only case where internal classes will allow to pass extra arguments
+		 * However, if there are named arguments (and it is not empty),
+		 * an Error must be thrown to be consistent with new ClassName() */
+		if (UNEXPECTED(named_params != NULL && zend_hash_num_elements(named_params) != 0)) {
+			/* Throw standard Error */
+			zend_string *arg_name = NULL;
+			zend_hash_get_current_key(named_params, &arg_name, /* num_index */ NULL);
+			ZEND_ASSERT(arg_name != NULL);
+			zend_throw_error(NULL, "Unknown named parameter $%s", ZSTR_VAL(arg_name));
+			/* Do not call destructor, free object, and set arg to IS_UNDEF */
+			zend_object_store_ctor_failed(obj);
+			zval_ptr_dtor(arg);
+			ZVAL_UNDEF(arg);
+			return FAILURE;
+		} else {
+			return SUCCESS;
+		}
+	}
+	/* A constructor should not return a value, however if an exception is thrown
+	 * zend_call_known_function() will set the retval to IS_UNDEF */
+	zval retval;
+	zend_call_known_function(
+		constructor,
+		obj,
+		class_type,
+		&retval,
+		param_count,
+		params,
+		named_params
+	);
+	if (Z_TYPE(retval) == IS_UNDEF) {
+		/* Do not call destructor, free object, and set arg to IS_UNDEF */
+		zend_object_store_ctor_failed(obj);
+		zval_ptr_dtor(arg);
+		ZVAL_UNDEF(arg);
+		return FAILURE;
+	} else {
+		/* Unlikely, but user constructors may return any value they want */
+		zval_ptr_dtor(&retval);
+		return SUCCESS;
+	}
+}
+#endif
+
+/**
  * Creates a new instance dynamically. Call constructor without parameters
  */
 int zephir_create_instance(zval *return_value, const zval *class_name)
@@ -1244,38 +1315,7 @@ int zephir_create_instance(zval *return_value, const zval *class_name)
 		return FAILURE;
 	}
 
-	if(UNEXPECTED(object_init_ex(return_value, ce) != SUCCESS)) {
-    	return FAILURE;
-    }
-
-	if (EXPECTED(Z_OBJ_HT_P(return_value)->get_constructor)) {
-		zend_object* obj    = Z_OBJ_P(return_value);
-		zend_function* ctor = Z_OBJ_HT_P(return_value)->get_constructor(obj);
-		if (ctor) {
-			zend_fcall_info fci;
-			zend_fcall_info_cache fcc;
-
-			zend_class_entry* ce = Z_OBJCE_P(return_value);
-
-			fci.size             = sizeof(fci);
-			fci.object           = obj;
-			fci.retval           = 0;
-			fci.param_count      = 0;
-			fci.params           = 0;
-			fci.named_params 	 = NULL;
-
-			ZVAL_NULL(&fci.function_name);
-
-			fcc.object           = obj;
-			fcc.called_scope     = ce;
-			fcc.calling_scope    = ce;
-			fcc.function_handler = ctor;
-
-			return zend_fcall_info_call(&fci, &fcc, NULL, NULL);
-		}
-	}
-
-	return SUCCESS;
+	return object_init_with_constructor(return_value, ce, 0, NULL, NULL);
 }
 
 /**
@@ -1301,40 +1341,5 @@ int zephir_create_instance_params(zval *return_value, const zval *class_name, zv
 		return FAILURE;
 	}
 
-	if(UNEXPECTED(object_init_ex(return_value, ce) != SUCCESS)) {
-    	return FAILURE;
-    }
-
-	if (EXPECTED(Z_OBJ_HT_P(return_value)->get_constructor)) {
-		zend_object* obj    = Z_OBJ_P(return_value);
-		zend_function* ctor = Z_OBJ_HT_P(return_value)->get_constructor(obj);
-		if (ctor) {
-			int status;
-			zend_fcall_info fci;
-			zend_fcall_info_cache fcc;
-
-			zend_class_entry* ce = Z_OBJCE_P(return_value);
-
-			fci.size             = sizeof(fci);
-			fci.object           = obj;
-			fci.retval           = 0;
-			fci.param_count      = 0;
-			fci.params           = 0;
-			fci.named_params 	 = NULL;
-
-			ZVAL_NULL(&fci.function_name);
-
-			fcc.object           = obj;
-			fcc.called_scope     = ce;
-			fcc.calling_scope    = ce;
-			fcc.function_handler = ctor;
-
-			zend_fcall_info_args_ex(&fci, fcc.function_handler, params);
-			status = zend_fcall_info_call(&fci, &fcc, NULL, NULL);
-			zend_fcall_info_args_clear(&fci, 1);
-			return status;
-		}
-	}
-
-	return SUCCESS;
+	return object_init_with_constructor(return_value, ce, 0, NULL, Z_ARRVAL_P(params));
 }


### PR DESCRIPTION
Hello!

* Type: code quality 
* Link to issue: N/A

In raising this pull request, I confirm the following:

- [x] I have checked that another pull request for this purpose does not exist
- [x] ~I wrote some tests for this PR~ N/A as this is a refactoring
- [ ] I updated the CHANGELOG

Small description of change:

Zephir is one of the few users of the `zend_fcall_info_args_ex()` Zend API which does some non-obvious stuff with regard to by-ref arguments, while at the same time not supporting named arguments.

Refactor this usage by introducing the new PHP 8.4 `object_init_with_constructor()` API, as it turns out calling constructors is not so obvious.