### PR TITLE
Refactor CUFA implementation

### DIFF
--- a/kernel/fcall.c
+++ b/kernel/fcall.c
@@ -610,15 +610,18 @@ int zephir_call_user_func_array_noex(zval *return_value, zval *handler, zval *pa
 
 	fci.size = sizeof(fci);
 	fci.object = fci_cache.object;
-	ZVAL_COPY_VALUE(&fci.function_name, handler);
+	/* We have an FCC so no need to copy the callable */
+	ZVAL_UNDEF(&fci.function_name);
 	fci.param_count = 0;
 	fci.params = NULL;
 	fci.retval = return_value;
-	fci.named_params = NULL;
+	if (params) {
+		fci.named_params = Z_ARRVAL_P(params);
+	} else {
+		fci.named_params = NULL;
+	}
 
-	zend_fcall_info_args(&fci, params);
 	status = zend_call_function(&fci, &fci_cache);
-	zend_fcall_info_args_clear(&fci, 1);
 
 	return status;
 }


### PR DESCRIPTION
Hello!

* Type:  code quality
* Link to issue:

In raising this pull request, I confirm the following:

- [x] I have checked that another pull request for this purpose does not exist
- [x] ~I wrote some tests for this PR~ N/A
- [ ] I updated the CHANGELOG

Small description of change:

Use the named_params field to handle positional and named arguments for CUFA.

This saves on an unnecessary copy of the HashTable.

Long term project is to get rid of the `zend_fcall_info_args*()` APIs in Zend as they are not really intuitive, moreover there is no need to perform a copy of the arguments.

One question I have is if I need to do something to regenerate `ext/kernel` or will this be done at another time?
