### PR TITLE
Converting To Use Local Variable Instead of Static Variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format based on [Keep a Changelog](https://keepachangelog.com)
 and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
-
+- Fixed bug with Closures using the `use` Statement in a loop always returning the last loop.
 ## [0.19.0] - 2025-05-13
 ### Added
 - Added support of PHP `8.4` [#2440](https://github.com/zephir-lang/zephir/issues/2440), [#2443](https://github.com/zephir-lang/zephir/pull/2443)

--- a/stub/closures.zep
+++ b/stub/closures.zep
@@ -52,9 +52,8 @@ class Closures
 		return x => (x + 100) + (x * 150);
 	}
 
-	public function testUseCommand()
+	public function testUseCommand(var abc = 1)
 	{
-		var abc = 1;
 		return function() use (abc) {
 			return abc + 1;
 		};

--- a/tests/Extension/ClosureTest.php
+++ b/tests/Extension/ClosureTest.php
@@ -22,8 +22,19 @@ final class ClosureTest extends TestCase
     {
         $test = new Closures();
 
-        $this->assertSame(2, $test->testUseCommand()());
+        $this->assertSame(2, $test->testUseCommand(1)());
         $this->assertInstanceOf(\stdClass::class, $test->issue642());
+    }
+
+    public function testUseCommandMultiple(): void
+    {
+        $test = new Closures();
+
+        $callbackA = $test->testUseCommand(1);
+        $callbackB = $test->testUseCommand(2);
+
+        $this->assertSame(2, $callbackA());
+        $this->assertSame(3, $callbackB());
     }
 
     /**


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: N/A

In raising this pull request, I confirm the following:

- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I updated the CHANGELOG

Small description of change:

Taking a Stab at fixing the issue where calling a closure with a `use` statement within a loop always uses the last value:

IE: (Psudo Code)
```php
class Something extends Injectable {
    function doSomething(string! name, int value) {
        this->getDi() ->set(name, function() use (value) {
            return value;
        });
    }
}

var something = new Something();
something->doSomething("a", 1);
something->doSomething("b", 2);

// Current
di->get("a"); // Returns 2
di->get("b"); // Returns 2

// Should Be
di->get("a"); // Returns 1
di->get("b"); // Returns 2
```

I'm posting this here as I have no clue what I'm doing, and someone smarter than I may be able to make quick changes to this to finish it up. My latest change was to Method and stubs stopped building as a result and I don't have the time to keep digging ATM. Otherwise, I will keep working on it as time permits.