### PR TITLE
Adding Block Manager To Allow Modifications of Headers In Expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format based on [Keep a Changelog](https://keepachangelog.com)
 and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
+- Added Block Manager to Allow Modification of C-Headers Via Advanced Components of Zephir
+
 
 ## [0.19.0] - 2025-05-13
 ### Added

--- a/src/BlockManager.php
+++ b/src/BlockManager.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * This file is part of the Zephir.
+ *
+ * (c) Phalcon Team <team@zephir-lang.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Zephir;
+
+use InvalidArgumentException;
+
+use function array_merge;
+
+/**
+ * Manages the c-headers that must be added to a file
+ */
+class BlockManager
+{
+    /**
+     * List of headers.
+     */
+    protected array $blocks = [];
+
+    /**
+     * Adds a header path to the manager.
+     *
+     * @throws InvalidArgumentException
+     */
+    #[SuppressWarnings("php:S4790")]
+    public function add(string $block): BlockManager
+    {
+        $this->blocks[md5($block)] = $block;
+
+        return $this;
+    }
+
+    /**
+     * Returns a set of headers merged.
+     */
+    public function get(): array
+    {
+        return $this->blocks;
+    }
+
+    public function isEmpty(): bool
+    {
+        return empty($this->blocks);
+    }
+}

--- a/src/CompilationContext.php
+++ b/src/CompilationContext.php
@@ -75,6 +75,10 @@ class CompilationContext
      */
     public int $currentTryCatch = 0;
     /**
+     * Represents the c-blocks added to the file.
+     */
+    public ?BlockManager $blockManager = null;
+    /**
      * Current cycle/loop block.
      */
     public array $cycleBlocks = [];

--- a/src/CompilerFile.php
+++ b/src/CompilerFile.php
@@ -79,8 +79,7 @@ final class CompilerFile implements FileInterface
 
     private array $functionDefinitions = [];
 
-    private array $headerCBlocks = [];
-
+    private BlockManager $headerCBlocks;
     /**
      * Original internal representation (IR) of the file.
      */
@@ -101,6 +100,8 @@ final class CompilerFile implements FileInterface
         $this->logger       = new NullLogger();
         $this->aliasManager = $aliasManager;
         $this->filesystem   = $filesystem;
+
+        $this->headerCBlocks = new BlockManager();
     }
 
     /**
@@ -274,6 +275,11 @@ final class CompilerFile implements FileInterface
          * Headers manager.
          */
         $compilationContext->headersManager = new HeadersManager();
+
+        /**
+         * C-Block manager.
+         */
+        $compilationContext->blockManager   = $this->headerCBlocks;
 
         /**
          * Main code-printer for the file.
@@ -522,7 +528,7 @@ final class CompilerFile implements FileInterface
                     break;
 
                 case 'cblock':
-                    $this->headerCBlocks[] = $topStatement['value'];
+                    $this->headerCBlocks->add($topStatement['value']);
                     break;
 
                 case 'function':

--- a/src/CompilerFileAnonymous.php
+++ b/src/CompilerFileAnonymous.php
@@ -39,7 +39,7 @@ final class CompilerFileAnonymous implements FileInterface
 
     protected ?string             $compiledFile  = null;
     protected bool                $external      = false;
-    protected array               $headerCBlocks = [];
+    protected BlockManager        $headerCBlocks;
     protected ?string             $namespace     = null;
 
     /**
@@ -55,6 +55,8 @@ final class CompilerFileAnonymous implements FileInterface
         protected ?CompilationContext $context = null
     ) {
         $this->logger = new NullLogger();
+
+        $this->headerCBlocks = new BlockManager();
     }
 
     /**
@@ -80,6 +82,11 @@ final class CompilerFileAnonymous implements FileInterface
         $compilationContext->stringsManager = $stringsManager;
         $compilationContext->backend        = $compiler->backend;
         $compilationContext->headersManager = new HeadersManager();
+
+        /**
+         * C-Block manager.
+         */
+        $compilationContext->blockManager   = $this->headerCBlocks;
 
         /**
          * Main code-printer for the file.

--- a/src/Traits/CompilerTrait.php
+++ b/src/Traits/CompilerTrait.php
@@ -62,8 +62,11 @@ trait CompilerTrait
             }
         }
 
-        if (count($this->headerCBlocks) > 0) {
-            $code .= implode(PHP_EOL, $this->headerCBlocks) . PHP_EOL;
+        $code .= PHP_EOL;
+
+        if (!$this->headerCBlocks->isEmpty()) {
+            $code .= implode(PHP_EOL, $this->headerCBlocks->get()) . PHP_EOL;
+            $code .= PHP_EOL;
         }
 
         /**

--- a/tests/Zephir/BlockManagerTest.php
+++ b/tests/Zephir/BlockManagerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the Zephir.
+ *
+ * (c) Phalcon Team <team@zephir-lang.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Zephir\Test;
+
+use PHPUnit\Framework\TestCase;
+use Zephir\BlockManager;
+
+final class BlockManagerTest extends TestCase
+{
+    public function testBasics(): void
+    {
+        $testSubject = new BlockManager();
+
+        $testSubject->add('test1');
+        $testSubject->add('test2');
+        $testSubject->add('test1');
+
+        $this->assertFalse($testSubject->isEmpty());
+
+        $this->assertEquals(
+            [
+                '5a105e8b9d40e1329780d62ea2265d8a' => 'test1',
+                'ad0234829205b9033196ba818f7a872b' => 'test2',
+            ],
+            $testSubject->get(),
+        );
+    }
+}


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: N/A

In raising this pull request, I confirm the following:

- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I updated the CHANGELOG

Small description of change:

As part of the changes I was "attempting" with #2450, at one point, I added these changes. This was originally done so I could have something like the below inside Closures.php. Eventually, my changes went another path, and these additions were no longer required. However, I still see them as having some value, so I wanted to go ahead and create a separate PR for these changes.

```php
$compilationContext->blockManager->add(
                <<<EOF
typedef struct _zend_closure {
	zend_object       std;
	zend_function     func;
	zval              this_ptr;
	zend_class_entry *called_scope;
	zif_handler       orig_internal_handler;
} zend_closure;
EOF
            );
```