### PR TITLE
Adding support for typed constants (stubs) for php 8.3+

### DIFF
--- a/src/Stubs/Generator.php
+++ b/src/Stubs/Generator.php
@@ -31,6 +31,7 @@ use function in_array;
 use function is_dir;
 use function key;
 use function mkdir;
+use function preg_match;
 use function realpath;
 use function sprintf;
 use function str_ireplace;
@@ -40,6 +41,7 @@ use function ucfirst;
 
 use const DIRECTORY_SEPARATOR;
 use const PHP_EOL;
+use const PHP_VERSION_ID;
 
 class Generator
 {
@@ -218,7 +220,8 @@ class Generator
 
     protected function buildConstant(Constant $constant, string $indent): string
     {
-        $source = 'const ' . $constant->getName();
+        $type   = PHP_VERSION_ID >= 80300 ? $this->extractVarTypeFromDocBlock($constant->getDocBlock()) : '';
+        $source = 'const ' . ($type !== '' ? $type . ' ' : '') . $constant->getName();
 
         $value = $this->wrapPHPValue([
             'default' => $constant->getValue(),
@@ -425,6 +428,19 @@ class Generator
         }
 
         return (string)$returnValue;
+    }
+
+    private function extractVarTypeFromDocBlock(?string $docBlock): string
+    {
+        if ($docBlock === null) {
+            return '';
+        }
+
+        if (preg_match('/@var\s+([\w\\\\|]+)/', $docBlock, $matches)) {
+            return $matches[1];
+        }
+
+        return '';
     }
 
     private function fetchDocBlock(?string $docBlock, string $indent): string

--- a/tests/Zephir/Stubs/GeneratorTest.php
+++ b/tests/Zephir/Stubs/GeneratorTest.php
@@ -328,20 +328,24 @@ class GeneratorTest extends TestCase
 
     public function typedConstantProvider(): array
     {
-        $typed = PHP_VERSION_ID >= 80300;
+        $typed   = PHP_VERSION_ID >= 80300;
+        $docPart = "/**\n * @var %s\n */\n";
 
         return [
             [
-                'int', 1, '/** @var int */', $typed ? 'const int TEST = 1;' : 'const TEST = 1;',
+                'int', 1, '@var int',
+                sprintf($docPart, 'int') . ($typed ? 'const int TEST = 1;' : 'const TEST = 1;'),
             ],
             [
-                'string', 'Foo', '/** @var string */', $typed ? "const string TEST = 'Foo';" : "const TEST = 'Foo';",
+                'string', 'Foo', '@var string',
+                sprintf($docPart, 'string') . ($typed ? "const string TEST = 'Foo';" : "const TEST = 'Foo';"),
             ],
             [
-                'bool', 1, '/** @var bool */', $typed ? 'const bool TEST = 1;' : 'const TEST = 1;',
+                'bool', 1, '@var bool',
+                sprintf($docPart, 'bool') . ($typed ? 'const bool TEST = 1;' : 'const TEST = 1;'),
             ],
             [
-                'string', 'bar', null, 'const TEST = \'bar\';',
+                'string', 'bar', null, "const TEST = 'bar';",
             ],
         ];
     }

--- a/tests/Zephir/Stubs/GeneratorTest.php
+++ b/tests/Zephir/Stubs/GeneratorTest.php
@@ -326,6 +326,59 @@ class GeneratorTest extends TestCase
         ];
     }
 
+    public function typedConstantProvider(): array
+    {
+        $typed = PHP_VERSION_ID >= 80300;
+
+        return [
+            [
+                'int', 1, '/** @var int */', $typed ? 'const int TEST = 1;' : 'const TEST = 1;',
+            ],
+            [
+                'string', 'Foo', '/** @var string */', $typed ? "const string TEST = 'Foo';" : "const TEST = 'Foo';",
+            ],
+            [
+                'bool', 1, '/** @var bool */', $typed ? 'const bool TEST = 1;' : 'const TEST = 1;',
+            ],
+            [
+                'string', 'bar', null, 'const TEST = \'bar\';',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider typedConstantProvider
+     *
+     * @throws \ReflectionException
+     */
+    public function testShouldBuildTypedConstant(string $type, mixed $value, ?string $docBlock, string $expected): void
+    {
+        if (Os::isWindows()) {
+            $this->markTestSkipped('Warning: Strings contain different line endings!');
+        }
+
+        $buildClass = $this->getMethod('buildConstant');
+
+        $classConstant = new Constant(
+            'TEST',
+            [
+                'type'  => $type,
+                'value' => $value,
+            ],
+            $docBlock
+        );
+
+        $actual = $buildClass->invokeArgs(
+            $this->testClass,
+            [
+                $classConstant,
+                '',
+            ]
+        );
+
+        $this->assertSame($expected, $actual);
+    }
+
     /**
      * @dataProvider constantProvider
      *


### PR DESCRIPTION
Hello!

In raising this pull request, I confirm the following:

- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [ ] I updated the CHANGELOG

Adding support for typed constants (stubs) for php 8.3+