### PR TITLE
Fix zend_long formatting in zephir_fclose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+- Fixed a `-Wformat` warning in `zephir_fclose()` by formatting the `zend_long` resource handle with the portable `ZEND_LONG_FMT` macro instead of `%d`.
+
 ## [1.3.0] - 2026-08-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ## [Unreleased]
 
 ### Fixed
-- Fixed a `-Wformat` warning in `zephir_fclose()` by formatting the `zend_long` resource handle with the portable `ZEND_LONG_FMT` macro instead of `%d`.
+- Fixed a `-Wformat` warning in `zephir_fclose()` by casting the resource handle to `zend_long` and formatting it with the portable `ZEND_LONG_FMT` macro instead of `%d`, preserving compatibility with PHP 8.0's `int` handle.
 
 ## [1.3.0] - 2026-08-25
 

--- a/ext/kernel/file.c
+++ b/ext/kernel/file.c
@@ -178,7 +178,7 @@ int zephir_fclose(zval *stream_zval)
 	}
 
 	if ((stream->flags & PHP_STREAM_FLAG_NO_FCLOSE) != 0) {
-		php_error_docref(NULL, E_WARNING, "%d is not a valid stream resource", stream->res->handle);
+		php_error_docref(NULL, E_WARNING, ZEND_LONG_FMT " is not a valid stream resource", stream->res->handle);
 		return 0;
 	}
 

--- a/ext/kernel/file.c
+++ b/ext/kernel/file.c
@@ -178,7 +178,7 @@ int zephir_fclose(zval *stream_zval)
 	}
 
 	if ((stream->flags & PHP_STREAM_FLAG_NO_FCLOSE) != 0) {
-		php_error_docref(NULL, E_WARNING, ZEND_LONG_FMT " is not a valid stream resource", stream->res->handle);
+		php_error_docref(NULL, E_WARNING, ZEND_LONG_FMT " is not a valid stream resource", (zend_long) stream->res->handle);
 		return 0;
 	}
 

--- a/kernel/file.c
+++ b/kernel/file.c
@@ -178,7 +178,7 @@ int zephir_fclose(zval *stream_zval)
 	}
 
 	if ((stream->flags & PHP_STREAM_FLAG_NO_FCLOSE) != 0) {
-		php_error_docref(NULL, E_WARNING, "%d is not a valid stream resource", stream->res->handle);
+		php_error_docref(NULL, E_WARNING, ZEND_LONG_FMT " is not a valid stream resource", stream->res->handle);
 		return 0;
 	}
 

--- a/kernel/file.c
+++ b/kernel/file.c
@@ -178,7 +178,7 @@ int zephir_fclose(zval *stream_zval)
 	}
 
 	if ((stream->flags & PHP_STREAM_FLAG_NO_FCLOSE) != 0) {
-		php_error_docref(NULL, E_WARNING, ZEND_LONG_FMT " is not a valid stream resource", stream->res->handle);
+		php_error_docref(NULL, E_WARNING, ZEND_LONG_FMT " is not a valid stream resource", (zend_long) stream->res->handle);
 		return 0;
 	}
 


### PR DESCRIPTION
Hello!

In raising this pull request, I confirm the following:

- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I updated the CHANGELOG

## Summary

Use PHP's portable `ZEND_LONG_FMT` macro when `zephir_fclose()` includes a resource handle in its warning message, and cast the handle to `zend_long` so the variadic argument matches the format on every supported PHP version.

The existing `%d` conversion is correct for PHP 8.0, where `zend_resource::handle` is an `int`, but PHP 8.1 and newer declare it as a `zend_long`. This causes a compiler diagnostic when a generated extension is built with `-Wformat` on newer PHP versions:

```text
warning: format '%d' expects argument of type 'int', but argument 4 has type 'zend_long' {aka 'long int'} [-Wformat=]
```

The warning was reproduced while building cphalcon 5.20.1 on Arch Linux. cphalcon concatenates Zephir's `kernel/file.c` into its generated `phalcon.zep.c`, which is why the diagnostic points at that generated file.

## Change

Replace the int-only conversion:

```c
"%d is not a valid stream resource"
```

with the portable Zend format and a matching argument:

```c
ZEND_LONG_FMT " is not a valid stream resource", (zend_long) stream->res->handle
```

The cast safely widens PHP 8.0's `int` handle and is a no-op for the `zend_long` handle used by PHP 8.1 and newer. Both `kernel/file.c` and the tracked `ext/kernel/file.c` copy are updated.

## Environment

- Arch Linux x86_64
- PHP 8.5.9 NTS
- GCC 16.2.1
- cphalcon 5.20.1
- Zephir development at `a573e565a913db0cd57c20dc9e4805eeddbe9712`

## Validation

- `composer cs`: 374/374 checks passed
- `composer test`: 1,282 tests and 1,771 assertions passed; 21 environment-dependent tests skipped
- Regenerated the cphalcon 5.20.1 amalgamated source after applying this change
- Compiled the regenerated extension successfully with `-Werror=format`
- Loaded the resulting extension under PHP 8.5.9 and confirmed it reports Phalcon 5.20.1

No runtime regression test was added because this is a compile-time format-type diagnostic. Promoting `-Wformat` to an error during the cphalcon build directly verifies the correction.
