### PR TITLE
Fix undefined integer self-concat helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ## [Unreleased]
 
 ### Fixed
+- Fixed appending an integer variable to a string emitting a call to the undefined `zephir_concat_self_long()` helper, which caused the compiled extension to fail at load time [#2660](https://github.com/zephir-lang/zephir/issues/2660)
 - Fixed a `-Wformat` warning in `zephir_fclose()` by casting the resource handle to `zend_long` and formatting it with the portable `ZEND_LONG_FMT` macro instead of `%d`, preserving compatibility with PHP 8.0's `int` handle.
 - A variable whose only consumer is a closure's `use (...)` clause now counts as used: it is no longer reported as `unused-variable`, and it is declared in the generated C. A declared-but-unassigned capture was skipped by both, so the generated code referenced an undeclared identifier and the extension failed to build. Capturing a variable that was never declared now fails with `Cannot capture variable 'x' because it wasn't declared` instead of a PHP fatal error [#2029](https://github.com/zephir-lang/zephir/issues/2029)
 - Fixed array defaults on a class (typed `array` property defaults, trait array property defaults and array class constants), which were one shared table that every instance mutated in place instead of being copy-on-write [#2651](https://github.com/zephir-lang/zephir/issues/2651)

--- a/kernel/operators.c
+++ b/kernel/operators.c
@@ -80,6 +80,17 @@ void zephir_concat_self(zval *left, zval *right)
 }
 
 /**
+ * Appends the string representation of the right integer to the left operand
+ */
+void zephir_concat_self_long(zval *left, const long right)
+{
+	zend_string *right_str = zend_long_to_str(right);
+
+	zephir_concat_self_str(left, ZSTR_VAL(right_str), ZSTR_LEN(right_str));
+	zend_string_release(right_str);
+}
+
+/**
  * Appends the content of the right operator to the left operator
  */
 void zephir_concat_self_char(zval *left, unsigned char right)

--- a/tests/zept/issue_2660.zept
+++ b/tests/zept/issue_2660.zept
@@ -1,0 +1,24 @@
+--TEST--
+Appending an integer variable to a string
+--FILE--
+namespace Issue2660;
+
+class Example
+{
+    public function append() -> string
+    {
+        string value;
+        int suffix;
+
+        let value = "x";
+        let suffix = 5;
+        let value .= suffix;
+
+        return value;
+    }
+}
+--USAGE--
+$example = new \Issue2660\Example();
+echo $example->append(), "\n";
+--EXPECT--
+x5


### PR DESCRIPTION
Fixes #2660

## Summary

- define the integer self-concatenation helper already declared and emitted by the compiler
- convert the integer with Zend's native long-to-string helper and reuse the existing string append path
- add an executable `.zept` regression case and changelog entry

## Root cause

The compiler emits `zephir_concat_self_long()` for a string appended with an integer variable, and the function is declared in `kernel/operators.h`, but no implementation existed. The generated extension therefore built with an unresolved symbol and failed when PHP loaded it.

## Validation

- baseline generated extension: deterministic `undefined symbol: zephir_concat_self_long` load failure
- `zephir test tests/zept/issue_2660.zept`: 1 passed, 0 failed
- patched extension load and invocation: returned `x5`
- focused PHPUnit (`Concat|Variable`): 20 tests, 133 assertions passed
- changed-source PHPCS: passed
- `git diff --check`: passed

## Checklist

- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I updated the CHANGELOG

## AI disclosure

This change was prepared with OpenAI Codex assistance and reviewed and validated locally by the contributor.
